### PR TITLE
Fixed yaml line terminators in a hand edited file

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/catalogiteminitialization.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/catalogiteminitialization.yaml
@@ -6,7 +6,7 @@ object:
     display_name: 
     name: CatalogItemInitialization
     inherits: 
-    description:
+    description: 
   fields:
   - sequencer:
       value: "/Service/Provisioning/StateMachines/Methods/GroupSequenceCheck"


### PR DESCRIPTION
The YAML line terminators are different in hand edited and programmatically generated YAML files.
Changed to use the programmatically generated YAML file