### PR TITLE
Added missing instance preprovision_clone_to_vm

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_vm.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_vm.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: PreProvision_Clone_to_VM
+    inherits: 
+    description: 
+  fields:
+  - amazon_meth1:
+      value: amazon_PreProvision_clone_to_vm
+  - openstack_meth1:
+      value: openstack_PreProvision_clone_to_vm


### PR DESCRIPTION
A missing instance was being referenced in
https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/clone_to_vm.yaml

which has a relationship
"/Cloud/VM/Provisioning/StateMachines/Methods/PreProvision_Clone_to_VM#${/#miq_provision.source.vendor}"

But there was no PreProvision_Clone_to_VM in the Automate model

PR https://github.com/ManageIQ/manageiq/pull/9630 added the instance
This PR just cleans up the YAML file

Links

https://github.com/ManageIQ/manageiq/pull/9630