### PR TITLE
Add spec and helper rake tasks for clean YAML files.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,8 @@ begin
 rescue LoadError
 end
 
+ManageIQ::Content::Engine.load_tasks
+
 if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
   namespace :spec do
     desc "Setup environment for specs"

--- a/lib/tasks/clean_yaml_files.rake
+++ b/lib/tasks/clean_yaml_files.rake
@@ -1,0 +1,12 @@
+desc "Clean YAML files for consistent whitespace and formatting"
+task :clean_yaml_files do
+  yaml_files = ManageIQ::Content::Engine.root.join("content/**/*.yaml")
+  Dir.glob(yaml_files).sort.each do |f|
+    content = File.read(f)
+    yaml_content = YAML.load(content).to_yaml
+    if content != yaml_content
+      puts "Fixing #{Pathname.new(f).relative_path_from(ManageIQ::Content::Engine.root)}"
+      File.write(f, yaml_content)
+    end
+  end
+end

--- a/spec/content/automate/clean_yaml_spec.rb
+++ b/spec/content/automate/clean_yaml_spec.rb
@@ -1,0 +1,31 @@
+describe "YAML files" do
+  it "should be programatically generated" do
+    yaml_files = ManageIQ::Content::Engine.root.join("content/**/*.yaml")
+    invalid_files = Dir.glob(yaml_files).sort.select do |f|
+      content = File.read(f)
+      yaml_content = YAML.load(content).to_yaml
+      content != yaml_content
+    end
+    expect(invalid_files).to(be_empty, invalid_files_message(invalid_files))
+  end
+
+  def invalid_files_message(invalid_files)
+    file_list = invalid_files.collect do |f|
+      "./#{Pathname.new(f).relative_path_from(ManageIQ::Content::Engine.root)}"
+    end.join("\n    ")
+
+    <<-EOS
+The following files appear to have been hand edited, and should be
+programatically edited instead.
+
+    #{file_list}
+
+This allows for future exports of the domain to remain consistent without
+introducing unnecessary differences in whitespace and formatting.
+
+To fix the files, you can edit them, export them, or run the following command:
+
+    bundle exec rake clean_yaml_files
+EOS
+  end
+end


### PR DESCRIPTION
@mkanoor Please review.

This PR introduces a spec that will fail if someone creates a PR with unclean YAML files.  That is, PRs like #4 will no longer be necessary because the PRs introducing those problems won't get merged in the first place.  In addition I've added a helper rake task for developers who need to "fix" files they've modified manually.  This will make it easier on developers to get the test green when they make it go red.

In the future, we can probably create other rake tasks that verify the content of the various files and assert they are correct, have the correct keys, etc.

To test, I modified a bunch of YAML files manually, ran it, and got the output below.  After that I ran the rake task as instructed, and the test passed.

```
$ bundle exec rspec spec/clean_yaml_spec.rb

Randomized with seed 29330
** Resetting ManageIQ domain(s)

YAML files
  should be programatically generated (FAILED - 1)

Failures:

  1) YAML files should be programatically generated
     Failure/Error: expect(invalid_files).to(be_empty, invalid_files_message(invalid_files))

       The following files appear to have been hand edited, and should be
       programatically edited instead.

           ./content/automate/ManageIQ/Cloud/Orchestration/__namespace__.yaml
           ./content/automate/ManageIQ/__domain__.yaml

       This allows for future exports of the domain to remain consistent without
       introducing unnecessary differences in whitespace and formatting.

       To fix the files, you can edit them, export them, or run the following command:

           bundle exec rake clean_yaml_files
     # ./spec/clean_yaml_spec.rb:28:in `block (2 levels) in <top (required)>'

Finished in 16.47 seconds (files took 7.72 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/clean_yaml_spec.rb:22 # YAML files should be programatically generated

Randomized with seed 29330

Coverage report generated for RSpec to /Users/jfrey/dev/manageiq-content/coverage. 2324 / 7618 LOC (30.51%) covered.
```