### PR TITLE
Automate - Notification for Service and VM Retirement warning/errors.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/__methods__/update_retirement_status.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/__methods__/update_retirement_status.rb
@@ -1,5 +1,5 @@
 #
-# Description: This method updates retirement status
+# Description: This method updates the stack retirement status.
 #
 
 # Get variables from Server object
@@ -10,7 +10,7 @@ state  = $evm.current_object.class_name
 status = $evm.inputs['status']
 
 # Get current step
-step = $evm.current_object.current_field_name
+step = $evm.root['ae_state']
 
 # Get status_state ['on_entry', 'on_exit', 'on_error']
 status_state = $evm.root['ae_status_state']
@@ -20,12 +20,24 @@ $evm.log("info", "Step:<#{step}> Status_State:<#{status_state}> Status:<#{status
 
 stack = $evm.root['orchestration_stack']
 
+# Update Status Message
+updated_message  = "Server [#{server.name}] "
+updated_message += "Stack [#{stack.name}] " if stack
+updated_message += "Step [#{step}] "
+updated_message += "Status [#{status}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+
 # Update Status for on_error for all states other than the first state which is startretirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'
   if step.downcase == 'startretirement'
-    $evm.log("info", "Cannot continue because stack is already retired or is being retired.")
+    msg = 'Cannot continue because Stack is '
+    msg += stack ? "#{stack.retirement_state}." : 'nil.'
+    $evm.log('info', msg)
+    updated_message += msg
+    $evm.create_notification(:level => 'warning', :message => "Stack Retirement Warning: #{updated_message}")
   else
+    $evm.create_notification(:level => 'error', :message => "Stack Retirement Error: #{updated_message}")
     stack.retirement_state = 'error' if stack
   end
 end

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
@@ -1,31 +1,46 @@
 #
-# Description: This method updates retirement status
+# Description: This method updates the vm retirement status.
+# Required inputs: status
 #
 
 # Get variables from Server object
 server = $evm.root['miq_server']
 
 # Get State Machine
-state  = $evm.current_object.class_name
-status = $evm.inputs['status']
+state = $evm.current_object.class_name
 
 # Get current step
-step = $evm.current_object.current_field_name
+step = $evm.root['ae_state']
+
+# Get status from input field status
+status = $evm.inputs['status']
 
 # Get status_state ['on_entry', 'on_exit', 'on_error']
 status_state = $evm.root['ae_status_state']
 
-$evm.log("info", "Server:<#{server.name}> Ae_Result:<#{$evm.root['ae_result']}> State:<#{state}>")
-$evm.log("info", "Step:<#{step}> Status_State:<#{status_state}> Status:<#{status}>")
-
 vm = $evm.root['vm']
+
+$evm.log("info", "Server:<#{server.name}> Ae_Result:<#{$evm.root['ae_result']}> State:<#{state}> Step:<#{step}>")
+$evm.log("info", "Status_State:<#{status_state}> Status:<#{status}>")
+
+# Update Status Message
+updated_message  = "Server [#{server.name}] "
+updated_message += "VM [#{vm.name}] " if vm
+updated_message += "Step [#{step}] "
+updated_message += "Status [#{status}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
 
 # Update Status for on_error for all states other than the first state which is startretirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'
   if step.downcase == 'startretirement'
-    $evm.log("info", "Cannot continue because VM is already retired or is being retired.")
+    msg = 'Cannot continue because Instance is '
+    msg += vm ? "#{vm.retirement_state}." : 'nil.'
+    $evm.log('info', msg)
+    updated_message += msg
+    $evm.create_notification(:level => 'warning', :message => "Instance Retirement Warning: #{updated_message}")
   else
+    $evm.create_notification(:level => 'error', :message => "Instance Retirement Error: #{updated_message}")
     vm.retirement_state = 'error' if vm
   end
 end

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
@@ -1,5 +1,5 @@
 #
-# Description: This method is a placeholder for updating the retirement status
+# Description: This method updates the vm retirement status.
 # Required inputs: status
 #
 
@@ -10,7 +10,7 @@ server = $evm.root['miq_server']
 state = $evm.current_object.class_name
 
 # Get current step
-step = $evm.current_object.current_field_name
+step = $evm.root['ae_state']
 
 # Get status from input field status
 status = $evm.inputs['status']
@@ -23,12 +23,24 @@ vm = $evm.root['vm']
 $evm.log("info", "Server:<#{server.name}> Ae_Result:<#{$evm.root['ae_result']}> State:<#{state}> Step:<#{step}>")
 $evm.log("info", "Status_State:<#{status_state}> Status:<#{status}>")
 
+# Update Status Message
+updated_message  = "Server [#{server.name}] "
+updated_message += "VM [#{vm.name}] " if vm
+updated_message += "Step [#{step}] "
+updated_message += "Status [#{status}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+
 # Update Status for on_error for all states other than the first state which is startretirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'
   if step.downcase == 'startretirement'
-    $evm.log("info", "Cannot continue because VM is already retired or is being retired.")
+    msg = 'Cannot continue because VM is '
+    msg += vm ? "#{vm.retirement_state}." : 'nil.'
+    $evm.log('info', msg)
+    updated_message += msg
+    $evm.create_notification(:level => 'warning', :message => "VM Retirement Warning: #{updated_message}")
   else
+    $evm.create_notification(:level => 'error', :message => "VM Retirement Error: #{updated_message}")
     vm.retirement_state = 'error' if vm
   end
 end

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
@@ -1,5 +1,5 @@
 #
-# Description: This method is a placeholder for retirement status update
+# Description: This method updates the retirement status.
 #
 
 # Get variables from Server object
@@ -11,7 +11,7 @@ service = $evm.root['service']
 state = $evm.current_object.class_name
 
 # Get current step
-step = $evm.current_object.current_field_name
+step = $evm.root['ae_state']
 
 # Get status from input field status
 status = $evm.inputs['status']
@@ -22,12 +22,24 @@ status_state = $evm.root['ae_status_state']
 $evm.log("info", "Server:<#{server.name}> Ae_Result:<#{$evm.root['ae_result']}> State:<#{state}> Step:<#{step}>")
 $evm.log("info", "Status_State:<#{status_state}> Status:<#{status}>")
 
+# Update Status Message
+updated_message  = "Server [#{server.name}] "
+updated_message += "Service [#{service.name}] " if service
+updated_message += "Step [#{step}] "
+updated_message += "Status [#{status}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+
 # Update Status for on_error for all states other than the first state which is start retirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'
   if step.downcase == 'start retirement'
-    $evm.log("info", "Cannot continue because Service is already retired or is being retired.")
+    msg = 'Cannot continue because Service is '
+    msg += service ? "#{service.retirement_state}." : 'nil.'
+    $evm.log('info', msg)
+    updated_message += msg
+    $evm.create_notification(:level => 'warning', :message => "Service Retirement Warning: #{updated_message}")
   else
+    $evm.create_notification(:level => 'error', :message => "Service Retirement Error: #{updated_message}")
     service.retirement_state = 'error' if service
   end
 end


### PR DESCRIPTION
Modified 3 instances of update_retirement_status and modified update_service_retirement
methods to send Notification when warnings or errors occur in Service Retirement requests.

See PR:  https://github.com/ManageIQ/manageiq/pull/12404