### PR TITLE
Automate - Notification for Ansible and Cloud provisioning errors.

### DIFF
--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -1,7 +1,7 @@
 #
 # Description: This method updates the service provision status.
 # Required inputs: status
-#
+
 module ManageIQ
   module Automate
     module AutomationManagement
@@ -22,7 +22,13 @@ module ManageIQ
                     raise "Service Template Provision Task not provided"
                   end
 
-                  update_status_message(prov, @handle.inputs['status'])
+                  updated_message = update_status_message(prov, @handle.inputs['status'])
+
+                  if @handle.root['ae_result'] == "error"
+                    @handle.create_notification(:level   => "error",
+                                                :subject => prov.miq_request,
+                                                :message => "Instance Provision Error: #{updated_message}")
+                  end
                 end
 
                 private

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -21,7 +21,7 @@ module ManageIQ
                   raise "Service Template Provision Task not provided"
                 end
 
-                update_status_message(prov, @handle.inputs['status'])
+                updated_message = update_status_message(prov, @handle.inputs['status'])
 
                 if @handle.root['ae_result'] == "error"
                   @handle.create_notification(:level   => "error",

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -22,6 +22,12 @@ module ManageIQ
                 end
 
                 update_status_message(prov, @handle.inputs['status'])
+
+                if @handle.root['ae_result'] == "error"
+                  @handle.create_notification(:level   => "error",
+                                              :subject => prov.miq_request,
+                                              :message => "Instance Provision Error: #{updated_message}")
+                end
               end
 
               private

--- a/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -22,7 +22,7 @@ module ManageIQ
                     raise "Service Template Provision Task not provided"
                   end
 
-                  update_status_message(prov, @handle.inputs['status'])
+                  updated_message = update_status_message(prov, @handle.inputs['status'])
 
                   if @handle.root['ae_result'] == 'error'
                     @handle.create_notification(:level   => 'error',

--- a/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -23,6 +23,12 @@ module ManageIQ
                   end
 
                   update_status_message(prov, @handle.inputs['status'])
+
+                  if @handle.root['ae_result'] == 'error'
+                    @handle.create_notification(:level   => 'error',
+                                                :subject => prov.miq_request,
+                                                :message => "Ansible Tower Provision Error: #{updated_message}")
+                  end
                 end
 
                 private

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status_spec.rb
@@ -58,6 +58,12 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::
       msg = "Server [#{miq_server.name}] Service [#{service_orchestration.name}] Step [] Status [fred] Message [] "
       expect(svc_model_request.reload.message).to eq(msg)
     end
+
+    it "creates notification due to ae_result is 'error'" do
+      ae_service.root['ae_result'] = "error"
+      expect(ae_service).to receive(:create_notification)
+      described_class.new(ae_service).main
+    end
   end
 
   context "without a stp request object" do

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status_spec.rb
@@ -57,6 +57,12 @@ describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::
       msg = "Server [#{miq_server.name}] Service [#{service_orchestration.name}] Step [] Status [fred] Message [] "
       expect(svc_model_request.reload.message).to eq(msg)
     end
+
+    it "creates notification due to ae_result is 'error'" do
+      ae_service.root['ae_result'] = "error"
+      expect(ae_service).to receive(:create_notification)
+      described_class.new(ae_service).main
+    end
   end
 
   context "without a stp request object" do

--- a/spec/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status_spec.rb
+++ b/spec/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status_spec.rb
@@ -58,6 +58,12 @@ describe ManageIQ::Automate::ConfigurationManagement::AnsibleTower::Service::
       msg = "Server [#{miq_server.name}] Service [#{service_orchestration.name}] Step [] Status [fred] Message [] "
       expect(svc_model_request.reload.message).to eq(msg)
     end
+
+    it "creates notification due to ae_result is 'error'" do
+      ae_service.root['ae_result'] = "error"
+      expect(ae_service).to receive(:create_notification)
+      described_class.new(ae_service).main
+    end
   end
 
   context "without a stp request object" do


### PR DESCRIPTION
This sends a notification with an error occurs.

Modified update_serviceprovision_status methods in
Cloud/Orchestration/Provisioning/StateMachines/Provision/ and
ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision
Methods class.

Updated existing spec to test for notification in case of error.