### PR TITLE
Automate - Refactoring infra vm check_pre_retirement method.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
@@ -1,28 +1,59 @@
+# / Infra / VM / Retirement / StateMachines / CheckPreRetirement
+
 #
 # Description: This method checks to see if the VM has been powered off or suspended
 #
 
-# Get vm from root object
-vm = $evm.root['vm']
-ems = vm.ext_management_system if vm
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Retirement
+          module StateMachines
+            class CheckPreRetirement
+              def initialize(handle = $evm)
+                @handle = handle
+              end
 
-if vm.nil? || ems.nil?
-  $evm.log('info', "Skipping check pre retirement for VM:<#{vm.try(:name)}> on EMS:<#{ems.try(:name)}>")
-  exit MIQ_OK
+              def main
+                # Get vm from root object
+                vm = @handle.root['vm']
+
+                check_power_state(vm)
+              end
+
+              def check_power_state(vm)
+                ems = vm.ext_management_system if vm
+                if vm.nil? || ems.nil?
+                  @handle.log('info', "Skipping check pre retirement for VM:<#{vm.try(:name)}> "\
+                                      "on EMS:<#{ems.try(:name)}>")
+                  return
+                end
+
+                power_state = vm.power_state
+                @handle.log('info', "VM:<#{vm.name}> on Provider:<#{ems.name}> has Power State:<#{power_state}>")
+
+                # If VM is powered off or suspended exit
+
+                if %w(off suspended unknown).include?(power_state)
+                  # Bump State
+                  @handle.root['ae_result'] = 'ok'
+                elsif power_state == "never"
+                  # If never then this VM is a template so exit the retirement state machine
+                  @handle.root['ae_result'] = 'error'
+                else
+                  @handle.root['ae_result'] = 'retry'
+                  @handle.root['ae_retry_interval'] = '60.seconds'
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end
 
-power_state = vm.power_state
-$evm.log('info', "VM:<#{vm.name}> on Provider:<#{ems.name}> has Power State:<#{power_state}>")
-
-# If VM is powered off or suspended exit
-
-if %w(off suspended unknown).include?(power_state)
-  # Bump State
-  $evm.root['ae_result'] = 'ok'
-elsif power_state == "never"
-  # If never then this VM is a template so exit the retirement state machine
-  $evm.root['ae_result'] = 'error'
-else
-  $evm.root['ae_result'] = 'retry'
-  $evm.root['ae_retry_interval'] = '60.seconds'
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckPreRetirement.new.main
 end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement_spec.rb
@@ -1,0 +1,85 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckPreRetirement do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:zone) { FactoryGirl.create(:zone) }
+  let(:ems) { FactoryGirl.create(:ems_microsoft, :zone => zone) }
+  let(:vm) do
+    FactoryGirl.create(:vm_microsoft,
+                       :raw_power_state => "PowerOff",
+                       :ems_id          => ems.id)
+  end
+
+  let(:svc_model_vm) do
+    MiqAeMethodService::MiqAeServiceVm.find(vm.id)
+  end
+
+  let(:root_hash) do
+    { 'vm' => MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+  end
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(root_hash)
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "returns 'ok' for a vm in powered_off state" do
+    described_class.new(ae_service).main
+    expect(ae_service.root['vm'].power_state).to eq("off")
+    expect(ae_service.root['ae_result']).to eq('ok')
+  end
+
+  shared_examples_for "#vm power state" do
+    it "check" do
+      vm.update_attributes(:raw_power_state => raw_power_state)
+      svc_model_vm
+      described_class.new(ae_service).main
+      expect(ae_service.root['vm'].power_state).to eq(power_state)
+      expect(ae_service.root['ae_result']).to eq(ae_result)
+    end
+  end
+
+  context "powered_on " do
+    let(:raw_power_state) { "Running" }
+    let(:power_state) { "on" }
+    let(:ae_result) { "retry" }
+    it_behaves_like "#vm power state"
+  end
+
+  context "unknown" do
+    let(:raw_power_state) { "unknown" }
+    let(:power_state) { "unknown" }
+    let(:ae_result) { "ok" }
+    it_behaves_like "#vm power state"
+  end
+
+  context "exceptions" do
+    let(:root_hash) { {} }
+    let(:svc_model_service) { nil }
+    shared_examples_for "#ae_result nil" do
+      it "values" do
+        described_class.new(ae_service).main
+        expect(ae_service.root['ae_result']).to be_nil
+      end
+    end
+
+    context "no vm" do
+      let(:vm) { nil }
+      it_behaves_like "#ae_result nil"
+    end
+
+    context "no ems" do
+      let(:vm) do
+        FactoryGirl.create(:vm_microsoft, :raw_power_state => "PowerOff")
+      end
+      it_behaves_like "#ae_result nil"
+    end
+  end
+end


### PR DESCRIPTION
Refactoring the check_pre_retirement method for the infrastructure Vm. This PR is based on the issue bellow.

Links [Optional]

https://github.com/ManageIQ/manageiq/issues/12038
