### PR TITLE
Automate - Refactoring infra vm pre_retirement method.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.rb
@@ -1,10 +1,41 @@
+# / Infra / VM / Retirement / StateMachines / PreRetirement
+
 #
 # Description: This method powers-off the VM on the provider
 #
 
-vm = $evm.root['vm']
-unless vm.nil? || vm.attributes['power_state'] == 'off'
-  ems = vm.ext_management_system
-  $evm.log('info', "Powering Off VM <#{vm.name}> in provider <#{ems.try(:name)}>")
-  vm.stop
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Retirement
+          module StateMachines
+            class PreRetirement
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                # Get vm from root object
+                vm = @handle.root['vm']
+                check_power_state(vm)
+              end
+
+              def check_power_state(vm)
+                unless vm.nil? || vm.attributes['power_state'] == 'off'
+                  ems = vm.ext_management_system
+                  @handle.log('info', "Powering Off VM <#{vm.name}> in provider <#{ems.try(:name)}>")
+                  vm.stop
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::PreRetirement.new.main
 end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement_spec.rb
@@ -1,0 +1,94 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::PreRetirement do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:zone) { FactoryGirl.create(:zone) }
+  let(:ems) { FactoryGirl.create(:ems_microsoft, :zone => zone) }
+  let(:vm) do
+    FactoryGirl.create(:vm_microsoft,
+                       :raw_power_state => "PowerOff",
+                       :ems_id          => ems.id)
+  end
+
+  let(:svc_model_vm) do
+    MiqAeMethodService::MiqAeServiceVm.find(vm.id)
+  end
+
+  let(:root_hash) do
+    { 'vm' => MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+  end
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(root_hash)
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "returns 'ok' for a vm in powered_off state" do
+    described_class.new(ae_service).main
+    expect(ae_service.root['vm'].power_state).to eq("off")
+    expect(ae_service.root['ae_result']).to be_nil
+  end
+
+  shared_examples_for "#vm power state" do
+    it "check" do
+      vm.update_attribute(:raw_power_state, raw_power_state)
+      svc_model_vm
+      described_class.new(ae_service).main
+      expect(ae_service.root['vm'].power_state).to eq(power_state)
+    end
+  end
+
+  context "powered_on " do
+    let(:raw_power_state) { "Running" }
+    let(:power_state) { "on" }
+    let(:ae_result) { "retry" }
+    it_behaves_like "#vm power state"
+  end
+  context "unknown" do
+    let(:raw_power_state) { "unknown" }
+    let(:power_state) { "unknown" }
+    let(:ae_result) { "retry" }
+    it_behaves_like "#vm power state"
+  end
+  context "suspended" do
+    let(:raw_power_state) { "suspended" }
+    let(:power_state) { "unknown" }
+    let(:ae_result) { "unknown" }
+    it_behaves_like "#vm power state"
+  end
+  context "never" do
+    let(:raw_power_state) { "never" }
+    let(:power_state) { "never" }
+    let(:ae_result) { "error" }
+    it_behaves_like "#vm power state"
+  end
+  context "exceptions" do
+    let(:root_hash) { {} }
+    let(:svc_model_service) { nil }
+    shared_examples_for "#ae_result nil" do
+      it "values" do
+        described_class.new(ae_service).main
+        expect(ae_service.root['ae_result']).to be_nil
+      end
+    end
+
+    context "no vm" do
+      let(:vm) { nil }
+      it_behaves_like "#ae_result nil"
+    end
+
+    context "no ems" do
+      let(:vm) do
+        FactoryGirl.create(:vm_microsoft, :raw_power_state => "PowerOff")
+      end
+      it_behaves_like "#ae_result nil"
+    end
+  end
+end


### PR DESCRIPTION
Refactoring the pre_retirement method for the infrastructure Vm. This PR is based on the issue bellow.

Links [Optional]

ManageIQ/manageiq#12038