### PR TITLE
Refresh based on all saved Amazon EmsEvents

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/_missing.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/_missing.yaml
@@ -7,4 +7,6 @@ object:
     name: ".missing"
     inherits: 
     description: 
-  fields: []
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
Refresh based on all saved Amazon EmsEvents in a way that
we can override the behaviour for single EventTypes
from automate.

https://github.com/ManageIQ/manageiq-providers-amazon/pull/93
needs to be reverted, since it changed all unknown event_types
to one. And The list of recognized events was in the code.

THis PR has the same behaviour, but all is configurable from
Automate.

fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1371222
https://github.com/ManageIQ/manageiq/issues/10591