### PR TITLE
Automate - RFE - Added Retirement functionality for Services.

### DIFF
--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
@@ -38,12 +38,30 @@ def override_service_attribute(dialogs_options_hash, attr_name)
 
   log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...", true)
   attr_value = dialogs_options_hash.fetch(service_attr_name, nil)
-  attr_value = "#{@service.name}-#{Time.now.strftime('%Y%m%d-%H%M%S')}" if attr_name == 'name' && attr_value.nil?
+  attr_value = "#{@service.name}-#{Time.zone.now.strftime('%Y%m%d-%H%M%S')}" if attr_name == 'name' && attr_value.nil?
 
   log_and_update_message(:info, "Setting service attribute: #{attr_name} to: #{attr_value}")
   @service.send("#{attr_name}=", attr_value)
 
   log_and_update_message(:info, "Processing override_attribute for #{service_attr_name}...Complete", true)
+end
+
+def override_service_retirement_days(dialog_options_hash, _attr_name)
+  new_service_retirement_days = dialog_options_hash.fetch(:service_retirement_days, nil)
+  return if new_service_retirement_days.blank?
+
+  log_and_update_message(:info, "Processing override_service_retirement_days: #{new_service_retirement_days}", true)
+  @service.extend_retires_on(new_service_retirement_days.to_i)
+  log_and_update_message(:info, "Processing override_service_retirement_days...Complete", true)
+end
+
+def override_service_retirement_warn_days(dialog_options_hash, _attr_name)
+  new_service_retirement_warn_days = dialog_options_hash.fetch(:service_retirement_warn_days, nil)
+  return if new_service_retirement_warn_days.blank?
+
+  log_and_update_message(:info, "Processing service_retirement_warn_days: #{new_service_retirement_warn_days}", true)
+  @service.retirement_warn = new_service_retirement_warn_days.to_i
+  log_and_update_message(:info, "Processing override_service_retirement_warn_days...Complete", true)
 end
 
 def process_tag(tag_category, tag_value)
@@ -98,6 +116,8 @@ begin
   unless dialog_options_hash.blank?
     override_service_attribute(dialog_options_hash.fetch(0, {}), "name")
     override_service_attribute(dialog_options_hash.fetch(0, {}), "description")
+    override_service_retirement_days(dialog_options_hash.fetch(0, {}), "service_retirement_days")
+    override_service_retirement_warn_days(dialog_options_hash.fetch(0, {}), "service_retirement_warn_days")
   end
 
   tag_service(dialog_tags_hash) unless dialog_tags_hash.blank?

--- a/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
@@ -32,18 +32,25 @@ describe "CatalogBundleInitialization Automate Method" do
   context "override" do
     before do
       @service_name = "Fred"
+
       @service_description = "My Favorite Service"
-      @dialog_hash = {'dialog_option_1_service_name'        => 'one',
-                      'dialog_option_2_service_name'        => 'two',
-                      'dialog_option_0_service_name'        => @service_name,
-                      'dialog_option_0_service_description' => @service_description,
-                      'dialog_tag_0_tracker'                => 'gps',
-                      'dialog_tag_1_location'               => 'BOM',
-                      'dialog_tag_2_location'               => 'EWR'}
+      @service_retirement_days = "10"
+      @service_retirement_warn_days = 9
+      @dialog_hash = {'dialog_option_1_service_name'                 => 'one',
+                      'dialog_option_2_service_name'                 => 'two',
+                      'dialog_option_0_service_name'                 => @service_name,
+                      'dialog_option_0_service_description'          => @service_description,
+                      'dialog_option_0_service_retirement_days'      => @service_retirement_days,
+                      'dialog_option_0_service_retirement_warn_days' => @service_retirement_warn_days,
+                      'dialog_tag_0_tracker'                         => 'gps',
+                      'dialog_tag_1_location'                        => 'BOM',
+                      'dialog_tag_2_location'                        => 'EWR'}
       @parsed_dialog_options_hash = {1 => {:service_name => "one"},
                                      2 => {:service_name => "two"},
-                                     0 => {:service_name        => @service_name,
-                                           :service_description => @service_description}}
+                                     0 => {:service_name                 => @service_name,
+                                           :service_retirement_days      => @service_retirement_days,
+                                           :service_retirement_warn_days => @service_retirement_warn_days,
+                                           :service_description          => @service_description}}
       @parsed_dialog_tags_hash = {1 => {:location => "BOM"},
                                   2 => {:location => "EWR"},
                                   0 => {:tracker => "gps"}}
@@ -51,10 +58,13 @@ describe "CatalogBundleInitialization Automate Method" do
 
     def check_svc_attrs
       @stp.reload
-      service = @stp.destination
-      expect(service.description).to eql(@service_description)
-      expect(service.name).to eql(@service_name)
-      expect(service.tags[0].name).to eql('/managed/tracker/gps')
+      expect(@stp.destination).to have_attributes(
+        :description     => @service_description,
+        :name            => @service_name,
+        :retires_on      => Time.zone.today + @service_retirement_days.to_i,
+        :retirement_warn => @service_retirement_warn_days,
+      )
+      expect(@stp.destination.tags.first.name).to eq('/managed/tracker/gps')
     end
 
     def process_stp(options)


### PR DESCRIPTION
Modified methods to allow a dialog to pass retirement days and days to warn
for a service bundle and service item.
Modified catalog bundle spec to include retirement days.

see PR:https://github.com/ManageIQ/manageiq/pull/9653