### PR TITLE
Don't wait for refresh if stack no longer exists

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -62,7 +62,14 @@ module ManageIQ
                 stack = service.orchestration_stack
                 refreshed_stack = @handle.vmdb(:orchestration_stack).find_by(:name    => stack.name,
                                                                              :ems_ref => stack.ems_ref)
-                refreshed_stack && refreshed_stack.status != 'CREATE_IN_PROGRESS'
+                if refreshed_stack
+                  refreshed_stack.status != 'CREATE_IN_PROGRESS'
+                elsif @handle.get_state_var('deploy_result') == 'error' && service.orchestration_stack_status[0] == 'check_status_failed'
+                  # stack failed and has been removed from the provider, no need to wait for refresh complete
+                  true
+                else
+                  false
+                end
               end
 
               def check_deployed(service)

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned_spec.rb
@@ -110,6 +110,16 @@ describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::
       expect(ae_service.root['ae_result']).to eq("retry")
     end
 
+    it "does not need to wait for refresh completes if the stack has been removed from provider" do
+      ae_service.set_state_var('provider_last_refresh', true)
+      ae_service.set_state_var('deploy_result', 'error')
+      allow(svc_model_service)
+        .to receive(:orchestration_stack_status) { ['check_status_failed', 'stack does not exist'] }
+      amazon_stack.update_attributes(:ems_ref => nil)
+      described_class.new(ae_service).main
+      expect(ae_service.root['ae_result']).to eq('error')
+    end
+
     it "completes check_provisioned step when refresh is done" do
       ae_service.set_state_var('provider_last_refresh', true)
       ae_service.set_state_var('deploy_result', deploy_result)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1414989

We don't have a good way to determine whether a refresh completes. Currently we are relying on whether a target stack appears in VMDB. The reported problem occurs when a stack is failed (rolled back as reported in the BZ), it no longer exists in the provider and nor can it exist in VMDB. In this case we should not retry and wait for refresh to complete. 

@mkanoor @gmcculloug please review