### PR TITLE
Add automate methods for VM import between providers

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__class__.yaml
@@ -1,0 +1,53 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Import
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: vm_id
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: execute
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: create_vm_import_request
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
@@ -1,0 +1,57 @@
+#
+# Description: This method initiates VM import to given infra provider
+#
+
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class CreateVmImportRequest
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                validate_root_args %w(vm dialog_name dialog_provider dialog_cluster dialog_storage dialog_sparse)
+
+                options = {
+                  :namespace     => 'Infrastructure/VM/Transform/StateMachines',
+                  :class_name    => 'VmImport',
+                  :instance_name => 'default',
+                  :message       => 'create',
+                  :attrs         => {
+                    'Vm::vm'      => @handle.root['vm'].id,
+                    'name'        => @handle.root['dialog_name'],
+                    'provider_id' => @handle.root['dialog_provider'],
+                    'cluster_id'  => @handle.root['dialog_cluster'],
+                    'storage_id'  => @handle.root['dialog_storage'],
+                    'sparse'      => @handle.root['dialog_sparse'],
+                  },
+                  :user_id       => @handle.root['user'].id
+                }
+
+                auto_approve = true
+                @handle.execute('create_automation_request', options, @handle.root['user'].userid, auto_approve)
+              end
+
+              def validate_root_args(arg_names)
+                arg_names.each do |name|
+                  next if @handle.root[name].present?
+                  msg = "Error, required root attribute: #{name} not found"
+                  @handle.log(:error, msg)
+                  raise msg
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::CreateVmImportRequest.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: create_vm_import_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters.rb
@@ -1,0 +1,45 @@
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class ListClusters
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                values_hash = {}
+                values_hash[nil] = '-- select cluster from list --'
+
+                provider_id = @handle.root['dialog_provider']
+                if provider_id.present? && provider_id != '!'
+                  provider = @handle.vmdb(:ext_management_system, provider_id)
+                  if provider.nil?
+                    values_hash[nil] = 'None'
+                  else
+                    provider.ems_clusters.each do |cluster|
+                      values_hash[cluster.id] = cluster.name
+                    end
+                  end
+                end
+                list_values = {
+                  'sort_by'   => :description,
+                  'data_type' => :string,
+                  'required'  => true,
+                  'values'    => values_hash
+                }
+                list_values.each { |key, value| @handle.object[key] = value }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListClusters.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: list_clusters
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers.rb
@@ -1,0 +1,38 @@
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class ListInfraProviders
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                values_hash = {}
+                values_hash[nil] = '-- select target infrastructure provider from list --'
+
+                managers = @handle.vmdb('ManageIQ_Providers_Redhat_InfraManager').all.select(&:validate_import_vm)
+                managers.each do |manager|
+                  values_hash[manager.id] = manager.name
+                end
+                list_values = {
+                  'sort_by'   => :description,
+                  'data_type' => :string,
+                  'required'  => true,
+                  'values'    => values_hash
+                }
+                list_values.each { |key, value| @handle.object[key] = value }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListInfraProviders.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: list_infra_providers
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
@@ -1,0 +1,46 @@
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class ListStorages
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                values_hash = {}
+                values_hash[nil] = '-- select storage from list --'
+
+                provider_id = @handle.root['dialog_provider']
+                @handle.log(:info, "Selected provider: #{provider_id}")
+                if provider_id.present? && provider_id != '!'
+                  provider = @handle.vmdb(:ext_management_system, provider_id)
+                  if provider.nil?
+                    values_hash[nil] = 'None'
+                  else
+                    provider.storages.each do |storage|
+                      values_hash[storage.id] = storage.name
+                    end
+                  end
+                end
+                list_values = {
+                  'sort_by'   => :description,
+                  'data_type' => :string,
+                  'required'  => true,
+                  'values'    => values_hash
+                }
+                list_values.each { |key, value| @handle.object[key] = value }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListStorages.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: list_storages
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/import_vm.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/import_vm.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ImportVm
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_clusters.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_clusters.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: list_clusters
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: list_clusters

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_infra_providers.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_infra_providers.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: list_infra_providers
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: list_infra_providers

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_storages.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_storages.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: list_storages
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: list_storages

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__class__.yaml
@@ -1,0 +1,234 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: VmImport
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: start
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: pre1
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: pre2
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: pre3
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: Launch
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: METHOD::submit_vm_import
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_vm_import_status(status => 'Submitting VM Import to RHV')
+      on_exit: update_vm_import_status(status => 'Submitted VM Import to RHV')
+      on_error: update_vm_import_status(status => 'Error submitting VM Import to RHV')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: WaitForImport
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: METHOD::wait_for_vm_import
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_vm_import_status(status => 'Checking for VM Import completion')
+      on_exit: update_vm_import_status(status => 'VM Import completed')
+      on_error: update_vm_import_status(status => 'Error in checking for VM Import
+        completion')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: post1
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: post2
+      display_name: 
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: post3
+      display_name: 
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: email
+      display_name: 
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: finish
+      display_name: 
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import.rb
@@ -1,0 +1,51 @@
+#
+# Description: This method initiates VM import to given infra provider
+#
+
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module StateMachines
+            class SubmitVmImport
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                validate_root_args %w(vm name cluster_id storage_id sparse)
+
+                provider = @handle.vmdb(:ext_management_system, @handle.root['provider_id'])
+                @handle.log(:info, 'Submitting Import')
+                new_ems_ref = provider.submit_import_vm(
+                  @handle.root['user'].userid,
+                  @handle.root['vm'].id,
+                  :name       => @handle.root['name'],
+                  :cluster_id => @handle.root['cluster_id'],
+                  :storage_id => @handle.root['storage_id'],
+                  :sparse     => @handle.root['sparse']
+                )
+                @handle.log(:info, "New Ems Ref is #{new_ems_ref}")
+                @handle.set_state_var('new_ems_ref', new_ems_ref)
+              end
+
+              def validate_root_args(arg_names)
+                arg_names.each do |name|
+                  next if @handle.root[name].present?
+                  msg = "Error, required root attribute: #{name} not found"
+                  @handle.log(:error, msg)
+                  raise msg
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::SubmitVmImport.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: submit_vm_import
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/update_vm_import_status.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/update_vm_import_status.rb
@@ -1,0 +1,32 @@
+#
+# Description: This method updates the vm import status.
+# Required inputs: status
+#
+
+prov = $evm.root['automation_task']
+unless prov
+  $evm.log(:error, "automation_task object not provided")
+  exit(MIQ_STOP)
+end
+status = $evm.inputs['status']
+
+vm = $evm.root['vm']
+unless vm
+  $evm.log(:error, 'vm object not provided')
+  exit(MIQ_STOP)
+end
+
+# Update Status Message
+updated_message  = "[#{$evm.root['miq_server'].name}] "
+updated_message += "VM [#{vm.name}] "
+updated_message += "Step [#{$evm.root['ae_state']}] "
+updated_message += "Status [#{status}] "
+updated_message += "Message [#{prov.message}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+prov.miq_request.user_message = updated_message
+prov.message = status
+
+if $evm.root['ae_result'] == "error"
+  $evm.create_notification(:level => "error", :message => "VM Import Error: #{updated_message}")
+  $evm.log(:error, "VM Import Error: #{updated_message}")
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/update_vm_import_status.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/update_vm_import_status.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: update_vm_import_status
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs:
+  - field:
+      aetype: 
+      name: status
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.rb
@@ -1,0 +1,52 @@
+#
+# Description: This method checks if the VM has been successfully imported
+#
+
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module StateMachines
+            class WaitForVmImport
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                vm = imported_vm
+                if vm
+                  status = vm.custom_get(:import_status)
+                  case status
+                  when 'success'
+                    @handle.root['ae_result'] = 'ok'
+                  when 'failure'
+                    @handle.root['ae_result'] = 'error'
+                  else
+                    set_retry
+                  end
+                else
+                  set_retry
+                end
+              end
+
+              def set_retry
+                @handle.root['ae_result'] = 'retry'
+                @handle.root['ae_retry_interval'] = @handle.inputs['retry_interval'] || 30.minutes
+              end
+
+              def imported_vm
+                ems_ref = @handle.get_state_var('new_ems_ref')
+                @handle.vmdb(:Vm).find_by(:ems_ref => ems_ref)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::WaitForVmImport.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: wait_for_vm_import
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/default.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/default.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: default
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/__namespace__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: StateMachines
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/__namespace__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Transform
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status.rb
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status.rb
@@ -1,0 +1,55 @@
+module ManageIQ
+  module Automate
+    module System
+      module Event
+        module EmsEvent
+          module RHEVM
+            class UpdateVmImportStatus
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                update_import_status(vm)
+              end
+
+              private
+
+              def vm_id
+                event_stream = @handle.root['event_stream']
+                if event_stream.nil?
+                  @handle.log(:error, 'event_stream not found')
+                  raise 'event_stream not found'
+                end
+                event_stream.vm_or_template_id
+              end
+
+              def vm
+                @handle.vmdb('Vm', vm_id).tap do |vm|
+                  if vm.nil?
+                    @handle.log(:error, 'VM object not found')
+                    raise 'VM object not found'
+                  end
+                end
+              end
+
+              def import_status
+                @handle.root['event_type'] == 'IMPORTEXPORT_IMPORT_VM_FAILED' ? 'failure' : 'success'
+              end
+
+              def update_import_status(vm)
+                @handle.log(:info, "Updating VM [#{vm.name}] import status to [#{import_status}]")
+                vm.custom_set(:import_status, import_status)
+                exit MIQ_OK
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::System::Event::EmsEvent::RHEVM::UpdateVmImportStatus.new.main
+end

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: update_vm_import_status
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/importexport_import_vm_failed.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/importexport_import_vm_failed.yaml
@@ -4,11 +4,9 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: IMPORTEXPORT_IMPORT_VM
+    name: IMPORTEXPORT_IMPORT_VM_FAILED
     inherits: 
     description: 
   fields:
-  - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=ems"
   - meth4:
       value: update_vm_import_status

--- a/content/automate/ManageIQ/System/Request.class/import_vm.yaml
+++ b/content/automate/ManageIQ/System/Request.class/import_vm.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: import_vm
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/Infrastructure/VM/Transform/Import/ImportVm"

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request_spec.rb
@@ -1,0 +1,45 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::CreateVmImportRequest do
+  let(:user)        { FactoryGirl.create(:user_admin) }
+  let(:vm)          { FactoryGirl.create(:vm_vmware) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_vm)   { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(vm.id) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(
+      :vm              => svc_model_vm,
+      :user            => svc_model_user,
+      :dialog_name     => 'my_vm',
+      :dialog_provider => 1,
+      :dialog_cluster  => 2,
+      :dialog_storage  => 3,
+      :dialog_sparse   => true
+    )
+  end
+
+  let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
+
+  it 'Executes create_automation_request with correct params' do
+    exp_options = {
+      :namespace     => 'Infrastructure/VM/Transform/StateMachines',
+      :class_name    => 'VmImport',
+      :instance_name => 'default',
+      :message       => 'create',
+      :attrs         => {
+        'Vm::vm'      => vm.id,
+        'name'        => 'my_vm',
+        'provider_id' => 1,
+        'cluster_id'  => 2,
+        'storage_id'  => 3,
+        'sparse'      => true,
+      },
+      :user_id       => user.id
+    }
+    exp_auto_approve = true
+    expect(ae_service).to receive(:execute).with('create_automation_request', exp_options, user.userid, exp_auto_approve)
+
+    described_class.new(ae_service).main
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters_spec.rb
@@ -1,0 +1,32 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListClusters do
+  let(:provider) { FactoryGirl.create(:ems_redhat, :with_clusters) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(
+      'dialog_provider' => provider.id.to_s
+    )
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it 'should list clusters of selected infra provider' do
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['sort_by']).to eq(:description)
+    expect(ae_service.object['data_type']).to eq(:string)
+    expect(ae_service.object['required']).to eq(true)
+
+    clusters = { nil => '-- select cluster from list --' }
+    provider.ems_clusters.each { |cluster| clusters[cluster.id] = cluster.name }
+
+    expect(ae_service.object['values']).to eq(clusters)
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers_spec.rb
@@ -1,0 +1,36 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListInfraProviders do
+  let!(:vmware)     { FactoryGirl.create(:ems_vmware) }
+  let!(:old_redhat) { FactoryGirl.create(:ems_redhat_v3) }
+  let!(:new_redhat) { FactoryGirl.create(:ems_redhat_v4) }
+
+  let(:root_object) { Spec::Support::MiqAeMockObject.new }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
+    # mock to use DB stored data instead of dynamic runtime values from Cacher
+    def supported_api_versions
+      [api_version]
+    end
+  end
+
+  it 'should list infra providers supporting VM import' do
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['sort_by']).to eq(:description)
+    expect(ae_service.object['data_type']).to eq(:string)
+    expect(ae_service.object['required']).to eq(true)
+    expect(ae_service.object['values']).to eq(
+      nil           => '-- select target infrastructure provider from list --',
+      new_redhat.id => new_redhat.name
+    )
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages_spec.rb
@@ -1,0 +1,32 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListStorages do
+  let(:provider) { FactoryGirl.create(:ems_redhat, :with_storages) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(
+      'dialog_provider' => provider.id.to_s
+    )
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it 'should list infra providers supporting VM import' do
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['sort_by']).to eq(:description)
+    expect(ae_service.object['data_type']).to eq(:string)
+    expect(ae_service.object['required']).to eq(true)
+
+    storages = { nil => '-- select storage from list --' }
+    provider.storages.each { |storage| storages[storage.id] = storage.name }
+
+    expect(ae_service.object['values']).to eq(storages)
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import_spec.rb
@@ -1,0 +1,44 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::SubmitVmImport do
+  let(:user)        { FactoryGirl.create(:user_admin) }
+  let(:vm)          { FactoryGirl.create(:vm_vmware) }
+  let(:provider)    { FactoryGirl.create(:ems_redhat) }
+
+  let(:svc_model_user)     { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_vm)       { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(vm.id) }
+  let(:svc_model_provider) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager.find(provider.id) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(
+      :user        => svc_model_user,
+      :vm          => svc_model_vm,
+      :name        => 'my_vm',
+      :provider_id => provider.id,
+      :cluster_id  => 1,
+      :storage_id  => 2,
+      :sparse      => true
+    )
+  end
+
+  let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
+
+  let(:new_ems_ref) { '/api/vms/6820ad2a-a8c0-4b4e-baf2-3482357ba352' }
+
+  it 'Calls :submit_import_vm on the provider object with correct params' do
+    allow(ae_service).to receive(:vmdb).with(:ext_management_system, provider.id).and_return(svc_model_provider)
+
+    expect(svc_model_provider).to receive(:submit_import_vm).with(
+      user.userid,
+      vm.id,
+      :name       => 'my_vm',
+      :cluster_id => 1,
+      :storage_id => 2,
+      :sparse     => true
+    ).and_return(new_ems_ref)
+
+    described_class.new(ae_service).main
+
+    expect(ae_service.get_state_var('new_ems_ref')).to eq(new_ems_ref)
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import_spec.rb
@@ -1,0 +1,41 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::WaitForVmImport do
+  let(:new_ems_ref) { '/api/vms/6820ad2a-a8c0-4b4e-baf2-3482357ba352' }
+
+  let(:root_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service)  { Spec::Support::MiqAeMockService.new(root_object, 'new_ems_ref' => new_ems_ref) }
+
+  context 'On missing import status' do
+    let!(:vm) { FactoryGirl.create(:vm_redhat, :ems_ref => new_ems_ref) }
+
+    it 'Exits with retry' do
+      described_class.new(ae_service).main
+
+      expect(ae_service.root['ae_result']).to eq('retry')
+      expect(ae_service.root['ae_retry_interval']).to eq(30.minutes)
+    end
+  end
+
+  context 'On successful import status' do
+    let!(:custom_attribute) { FactoryGirl.create(:miq_custom_attribute, :name => 'import_status', :value => 'success') }
+    let!(:vm)               { FactoryGirl.create(:vm_redhat, :ems_ref => new_ems_ref, :custom_attributes => [custom_attribute]) }
+
+    it 'Exits with success' do
+      described_class.new(ae_service).main
+
+      expect(ae_service.root['ae_result']).to eq('ok')
+    end
+  end
+
+  context 'On failed import status' do
+    let!(:custom_attribute) { FactoryGirl.create(:miq_custom_attribute, :name => 'import_status', :value => 'failure') }
+    let!(:vm)               { FactoryGirl.create(:vm_redhat, :ems_ref => new_ems_ref, :custom_attributes => [custom_attribute]) }
+
+    it 'Exits with failure' do
+      described_class.new(ae_service).main
+
+      expect(ae_service.root['ae_result']).to eq('error')
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status_spec.rb
+++ b/spec/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status_spec.rb
@@ -1,0 +1,53 @@
+require_domain_file
+
+describe ManageIQ::Automate::System::Event::EmsEvent::RHEVM::UpdateVmImportStatus do
+  let(:user)       { FactoryGirl.create(:user_with_group) }
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
+  let(:ems)        { FactoryGirl.create(:ems_redhat) }
+  let(:vm)         { FactoryGirl.create(:vm_redhat) }
+
+  let(:ems_event) do
+    FactoryGirl.create(:ems_event, :vm_or_template => vm, :ext_management_system => ems)
+  end
+  let(:svc_model_miq_server) { MiqAeMethodService::MiqAeServiceMiqServer.find(miq_server.id) }
+  let(:svc_model_user)       { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+
+  let(:root_hash) do
+    {
+      'user'         => svc_model_user,
+      'miq_server'   => svc_model_miq_server,
+      'event_stream' => MiqAeMethodService::MiqAeServiceEmsEvent.find(ems_event.id),
+      'event_type'   => event_type
+    }
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+
+  context 'on IMPORTEXPORT_IMPORT_VM_FAILED received' do
+    let(:event_type) { 'IMPORTEXPORT_IMPORT_VM_FAILED' }
+
+    it 'updates VM import status to failure' do
+      described_class.new(ae_service).main
+
+      expect(vm.miq_custom_get('import_status')).to eq('failure')
+    end
+  end
+
+  context 'on IMPORTEXPORT_IMPORT_VM received' do
+    let(:event_type) { 'IMPORTEXPORT_IMPORT_VM' }
+
+    it 'updates VM import status to success' do
+      described_class.new(ae_service).main
+
+      expect(vm.miq_custom_get('import_status')).to eq('success')
+    end
+  end
+end


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1404920

Added automate methods required to back the transform vm service dialog (https://github.com/ManageIQ/manageiq/pull/13794 https://github.com/ManageIQ/manageiq-ui-classic/pull/383) facilitating v2v conversion of VMs between two infra providers.

The dialog consists of 3 select boxes (target infra provider, cluster, storage domain) and a single checkbox that controls whether thin provisioning is enabled. To supply those select boxes we provided the `list_infra_providers`, `list_clusters` and `list_storages` methods respectively.