### PR TITLE
instance_of check doesn't work with Drb Reference object

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -22,11 +22,6 @@ module ManageIQ
                   raise 'Service is nil'
                 end
 
-                unless service.instance_of?(MiqAeMethodService::MiqAeServiceServiceOrchestration)
-                  @handle.log(:error, 'Service has a different type from MiqAeServiceServiceOrchestration')
-                  raise 'Service has a different type from MiqAeServiceServiceOrchestration'
-                end
-
                 if @handle.state_var_exist?('provider_last_refresh')
                   check_refreshed(service)
                 else

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned_spec.rb
@@ -140,14 +140,5 @@ describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::
         expect { described_class.new(ae_service).main }.to raise_error('Service is nil')
       end
     end
-
-    context 'with other than orchestration service' do
-      let(:service_orchestration) { FactoryGirl.create(:service_ansible_tower) }
-
-      it "raises the service has a different type exception" do
-        expect { described_class.new(ae_service).main }.to raise_error(
-          'Service has a different type from MiqAeServiceServiceOrchestration')
-      end
-    end
   end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/13844

When we test Automate methods we went a little too far to compare the passed in service using instance_of, it only works in tests but not in real use when we have DRb running the methods.
The DRb reference object fails the instance_of check.

Removed a test and code that validates service using instance_of

@pkomanek @Ladas @bzwei 