### PR TITLE
Automate method to list ansible credentials

### DIFF
--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__class__.yaml
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__class__.yaml
@@ -1,0 +1,53 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Methods
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: credential_type
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: execute
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
@@ -34,10 +34,8 @@ module ManageIQ
 
             def fetch_list_data
               credential_list = Hash[*credentials.pluck(:id, :name).flatten]
-              @handle.log(:info, "Number of credentials found #{credential_list.count}")
-              return nil => "<none>" if credential_list.blank?
-              credential_list[nil] = "<select>" if credential_list.length > 1
-              credential_list
+              @handle.log(:debug, "Number of credentials found #{credential_list.count}")
+              {nil => '<Default>'}.merge(credential_list)
             end
 
             def fill_dialog_field(list)

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
@@ -8,6 +8,7 @@ module ManageIQ
       module AnsibleTower
         module Operations
           class AvailableCredentials
+            AUTH_CLASS = "ManageIQ_Providers_AutomationManager_Authentication".freeze
             def initialize(handle = $evm)
               @handle = handle
             end
@@ -26,8 +27,9 @@ module ManageIQ
             end
 
             def credentials
-              result = provider.try(:credentials) || []
-              result.select { |c| c.type == @handle.inputs['credential_type'] }
+              @handle.vmdb(AUTH_CLASS).where("resource_id = ? AND type = ?",
+                                             provider.try(:id),
+                                             @handle.inputs['credential_type'])
             end
 
             def fetch_list_data
@@ -42,10 +44,10 @@ module ManageIQ
               dialog_hash = {
                 'sort_by'       => "value",
                 'data_type'     => "string",
-                'required'      => true,
+                'required'      => false,
                 'sort_order'    => "ascending",
                 'values'        => list,
-                'default_value' => list.length == 1 ? list.keys.first : nil
+                'default_value' => nil
               }
 
               dialog_hash.each { |key, value| @handle.object[key] = value }

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
@@ -1,0 +1,62 @@
+#
+# Description: provide the dynamic list content from available credentials
+# for Ansible Provider
+#
+module ManageIQ
+  module Automate
+    module AutomationManagement
+      module AnsibleTower
+        module Operations
+          class AvailableCredentials
+            def initialize(handle = $evm)
+              @handle = handle
+            end 
+
+            def main
+              fill_dialog_field(fetch_list_data)
+            end 
+
+            private
+    
+            def get_provider
+              # for provisioning we use     service_template
+              # for reconfig and retire use service
+              service = @handle.root['service_template'] || @handle.root['service']
+              service.try(:job_template, 'Provision').try(:manager)
+            end 
+
+            def get_credentials
+              credentials = get_provider.try(:credentials) || []
+              credentials.select { |c| c.type == @handle.inputs['credential_type'] }
+            end
+            
+            def fetch_list_data
+              credential_list = Hash[*get_credentials.pluck(:id, :name).flatten]
+              @handle.log(:info, "Number of credentials found #{credential_list.keys.count}")
+              return nil => "<none>" if credential_list.blank?
+              credential_list[nil] = "<select>" if credential_list.length > 1
+              credential_list
+            end
+
+            def fill_dialog_field(list)
+              dialog_hash = {
+                'sort_by'       => "value",
+                'data_type'     => "string",
+                'required'      => true,
+                'sort_order'    => "ascending",
+                'values'        => list,
+                'default_value' => list.length == 1 ? list.keys.first : nil
+              }
+
+              dialog_hash.each { |key, value| @handle.object[key] = value }
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::AvailableCredentials.new.main
+end

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
@@ -34,7 +34,7 @@ module ManageIQ
 
             def fetch_list_data
               credential_list = Hash[*credentials.pluck(:id, :name).flatten]
-              @handle.log(:info, "Number of credentials found #{credential_list.keys.count}")
+              @handle.log(:info, "Number of credentials found #{credential_list.count}")
               return nil => "<none>" if credential_list.blank?
               credential_list[nil] = "<select>" if credential_list.length > 1
               credential_list
@@ -42,7 +42,7 @@ module ManageIQ
 
             def fill_dialog_field(list)
               dialog_hash = {
-                'sort_by'       => "value",
+                'sort_by'       => "description",
                 'data_type'     => "string",
                 'required'      => false,
                 'sort_order'    => "ascending",

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
@@ -10,28 +10,28 @@ module ManageIQ
           class AvailableCredentials
             def initialize(handle = $evm)
               @handle = handle
-            end 
+            end
 
             def main
               fill_dialog_field(fetch_list_data)
-            end 
+            end
 
             private
-    
-            def get_provider
+
+            def provider
               # for provisioning we use     service_template
               # for reconfig and retire use service
               service = @handle.root['service_template'] || @handle.root['service']
               service.try(:job_template, 'Provision').try(:manager)
-            end 
-
-            def get_credentials
-              credentials = get_provider.try(:credentials) || []
-              credentials.select { |c| c.type == @handle.inputs['credential_type'] }
             end
-            
+
+            def credentials
+              result = provider.try(:credentials) || []
+              result.select { |c| c.type == @handle.inputs['credential_type'] }
+            end
+
             def fetch_list_data
-              credential_list = Hash[*get_credentials.pluck(:id, :name).flatten]
+              credential_list = Hash[*credentials.pluck(:id, :name).flatten]
               @handle.log(:info, "Number of credentials found #{credential_list.keys.count}")
               return nil => "<none>" if credential_list.blank?
               credential_list[nil] = "<select>" if credential_list.length > 1

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.yaml
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Available_Credentials
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs:
+  - field:
+      aetype: 
+      name: credential_type
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/available_machine_credentials.yaml
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/available_machine_credentials.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Available_Machine_Credentials
+    name: Available_Machine_Credentials
+    inherits: 
+    description: 
+  fields:
+  - credential_type:
+      value: ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential
+  - execute:
+      value: Available_Credentials

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/available_network_credentials.yaml
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/available_network_credentials.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Available_Network_Credentials
+    name: Available_Network_Credentials
+    inherits: 
+    description: 
+  fields:
+  - credential_type:
+      value: ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential
+  - execute:
+      value: Available_Credentials

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
@@ -56,6 +56,9 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::Ava
       expect(ae_service["values"].keys).to match_array(valid_ids)
       expect(ae_service["default_value"]).to be_nil
       expect(ae_service["required"]).to be_falsey
+      expect(ae_service["sort_by"]).to eq('description')
+      expect(ae_service["sort_order"]).to eq('ascending')
+      expect(ae_service["data_type"]).to eq('string')
     end
   end
 

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
@@ -1,0 +1,96 @@
+require_domain_file
+
+describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::AvailableCredentials do
+  let(:ansible_tower_manager) { FactoryGirl.create(:automation_manager_ansible_tower) }
+  let(:job_template) do
+    FactoryGirl.create(:ansible_configuration_script, :manager => ansible_tower_manager)
+  end
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new('service_template' => svc_service_template)
+  end
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+      service.inputs = {'credential_type' => credential_type }
+    end
+  end
+  let(:ra) { {:action => 'Provision', :configuration_template => job_template} }
+  let(:svc_template) do
+    FactoryGirl.create(:service_template_ansible_playbook).tap do |st|
+      st.resource_actions.build(ra)
+      st.save
+    end
+  end
+  let(:svc_service_template) do
+    MiqAeMethodService::MiqAeServiceServiceTemplate.find(svc_template.id)
+  end
+  let(:mach_cred1) do
+    FactoryGirl.create(:ansible_machine_credential, :resource => ansible_tower_manager)
+  end
+  let(:mach_cred2) do
+    FactoryGirl.create(:ansible_machine_credential, :resource => ansible_tower_manager)
+  end
+  let(:net_cred1) do
+    FactoryGirl.create(:ansible_network_credential, :resource => ansible_tower_manager)
+  end
+  let(:net_cred2) do
+    FactoryGirl.create(:ansible_network_credential, :resource => ansible_tower_manager)
+  end
+
+  shared_examples_for "#having only default value" do
+    let(:default_desc_blank) { "<none>" }
+    it "provides only default value if no credentials" do
+
+      described_class.new(ae_service).main
+
+      expect(ae_service["values"]).to eq(nil => default_desc_blank)
+      expect(ae_service["default_value"]).to be_nil
+    end
+  end
+
+
+  shared_examples_for "#having specific values based on credential type" do
+    it "provides only default value if no credentials" do
+      described_class.new(ae_service).main
+
+      expect(ae_service["values"].keys).to match_array(valid_ids)
+    end
+  end
+
+  context "credentials" do
+    before do
+      mach_cred1
+      mach_cred2
+      net_cred1
+      net_cred2
+    end
+
+    context "machine" do
+      let(:credential_type) do
+        "ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential"
+      end
+      let(:valid_ids) { [mach_cred1.id, mach_cred2.id, nil] }
+
+      it_behaves_like "#having specific values based on credential type"
+    end
+
+    context "network" do
+      let(:credential_type) do
+        "ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential"
+      end
+      let(:valid_ids) { [net_cred1.id, net_cred2.id, nil] }
+
+      it_behaves_like "#having specific values based on credential type"
+    end
+  end
+
+  context "no credentials" do
+    context "machine" do
+      let(:credential_type) { nil }
+
+      it_behaves_like "#having only default value"
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
@@ -42,14 +42,12 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::Ava
   shared_examples_for "#having only default value" do
     let(:default_desc_blank) { "<none>" }
     it "provides only default value if no credentials" do
-
       described_class.new(ae_service).main
 
       expect(ae_service["values"]).to eq(nil => default_desc_blank)
       expect(ae_service["default_value"]).to be_nil
     end
   end
-
 
   shared_examples_for "#having specific values based on credential type" do
     it "provides only default value if no credentials" do

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
@@ -40,7 +40,7 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::Ava
   end
 
   shared_examples_for "#having only default value" do
-    let(:default_desc_blank) { "<none>" }
+    let(:default_desc_blank) { "<Default>" }
     it "provides only default value if no credentials" do
       described_class.new(ae_service).main
 

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
@@ -54,6 +54,8 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::Ava
       described_class.new(ae_service).main
 
       expect(ae_service["values"].keys).to match_array(valid_ids)
+      expect(ae_service["default_value"]).to be_nil
+      expect(ae_service["required"]).to be_falsey
     end
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/137304515

Automate method to list machine, network and other ansible credentials.
The method accepts a type and yields a
{id => name} hash
e.g.
{id1 => "test1", id2 => "test2"} 

Depends on PR https://github.com/ManageIQ/manageiq/pull/13912
