### PR TITLE
Refactoring cloud orchestration postreconfigure method

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/postreconfigure.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/postreconfigure.rb
@@ -1,19 +1,59 @@
 #
 # Description: This method examines the orchestration stack reconfigured
 #
-def dump_stack_outputs(stack)
-  $evm.log("info", "Outputs from updated stack #{stack.name}")
-  stack.outputs.each do |output|
-    $evm.log("info", "Key #{output.key}, value #{output.value}")
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Reconfiguration
+          module StateMachines
+            class PostReconfigure
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                @handle.log("info", "Starting Orchestration Post-Reconfiguration")
+
+                if @handle.inputs.fetch('debug', false)
+                  dump_stack_outputs(stack)
+                end
+              end
+
+              private
+
+              def log_and_raise(obj_name)
+                @handle.log(:error, "#{obj_name} is nil")
+                raise "#{obj_name} not found"
+              end
+
+              def stack
+                task = @handle.root['service_reconfigure_task']
+                log_and_raise('Service Reconfigure Task') if task.nil?
+
+                source = task.source
+                log_and_raise('Service') if source.nil?
+
+                orchestration_stack = source.orchestration_stack
+                log_and_raise('Orchestration Stack') if orchestration_stack.nil?
+
+                orchestration_stack
+              end
+
+              def dump_stack_outputs(stack)
+                @handle.log("info", "Outputs from updated stack #{stack.name}")
+                stack.outputs.each do |output|
+                  @handle.log("info", "Key #{output.key}, value #{output.value}")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end
 
-$evm.log("info", "Starting Orchestration Post-Reconfiguration")
-
-service = $evm.root["service_reconfigure_task"].source
-stack = service.orchestration_stack
-
-# You can add logic to process the stack object in VMDB
-# For example, dump all outputs from the stack
-#
-# dump_stack_outputs(stack)
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachines::PostReconfigure.new.main
+end

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/postreconfigure_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/postreconfigure_spec.rb
@@ -1,0 +1,64 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachines::PostReconfigure do
+  let(:request)               { FactoryGirl.create(:service_template_provision_request, :requester => user) }
+  let(:service_orchestration) { FactoryGirl.create(:service_orchestration) }
+  let(:user)                  { FactoryGirl.create(:user_with_group) }
+  let(:output)                { FactoryGirl.create(:orchestration_stack_output, :key => 'key', :value => 'value') }
+  let(:orchestration_stack)   { FactoryGirl.create(:orchestration_stack_amazon, :name => "name", :outputs => [output]) }
+  let(:miq_request_task)      { FactoryGirl.create(:service_reconfigure_task, :request_type => 'service_reconfigure') }
+
+  let(:root_hash) do
+    { 'service_template' => MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  end
+
+  let(:root_object) do
+    obj = Spec::Support::MiqAeMockObject.new(root_hash)
+    obj["service_reconfigure_task"] = svc_model_miq_request_task
+    obj
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  let(:svc_model_service)          { MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  let(:svc_model_amazon_stack)     { MiqAeMethodService::MiqAeServiceOrchestrationStack.find(orchestration_stack.id) }
+  let(:svc_model_output)           { MiqAeMethodService::MiqAeServiceOrchestrationStackOutput.find(output.id) }
+  let(:svc_model_miq_request_task) { MiqAeMethodService::MiqAeServiceMiqRequestTask.find(miq_request_task.id) }
+
+  before do
+    allow(ae_service).to receive(:inputs) { {'debug' => true} }
+  end
+
+  it "calling the dump_stack_outputs method" do
+    allow(svc_model_miq_request_task).to receive(:source)     { svc_model_service }
+    allow(svc_model_service).to receive(:orchestration_stack) { svc_model_amazon_stack }
+    allow(svc_model_amazon_stack).to receive(:outputs)        { [svc_model_output] }
+
+    instance = described_class.new(ae_service)
+    expect(instance).to receive(:dump_stack_outputs).with(svc_model_amazon_stack)
+    instance.main
+  end
+
+  it "service_reconfigure_task is nil" do
+    service = ae_service
+    service.root['service_reconfigure_task'] = nil
+    expect { described_class.new(service).main }.to raise_error('Service Reconfigure Task not found')
+  end
+
+  it "service is nil" do
+    allow(svc_model_miq_request_task).to receive(:source) { nil }
+    expect { described_class.new(ae_service).main }.to raise_error('Service not found')
+  end
+
+  it "orchestration_stack is nil" do
+    allow(svc_model_miq_request_task).to receive(:source)     { svc_model_service }
+    allow(svc_model_service).to receive(:orchestration_stack) { nil }
+    expect { described_class.new(ae_service).main }.to raise_error('Orchestration Stack not found')
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/methods/postreconfigure.rb method and adding a new spec. This PR is based on the issue bellow.

Links [Optional]
-------------------
#8