### PR TITLE
Fixes VM extend retirement

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -30,7 +30,7 @@ unless vm.retires_on.nil?
   $evm.log("info", "Extending retirement <#{vm_retire_extend_days}> days for VM: <#{vm_name}>")
 
   # Set new retirement date here
-  vm.retires_on += vm_retire_extend_days.to_i
+  vm.extend_retires_on(vm_retire_extend_days, vm.retires_on)
 
   $evm.log("info", "VM: <#{vm_name}> new retirement date is #{vm.retires_on}")
 

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -32,7 +32,7 @@ unless vm.retires_on.nil?
   $evm.log("info", "Extending retirement <#{vm_retire_extend_days}> days for VM: <#{vm_name}>")
 
   # Set new retirement date here
-  vm.retires_on += vm_retire_extend_days.to_i
+  vm.extend_retires_on(vm_retire_extend_days, vm.retires_on)
 
   $evm.log("info", "VM: <#{vm_name}> new retirement date is #{vm.retires_on}")
 


### PR DESCRIPTION
The `retires_on` field was changed from a `:date` column to a `:datetime` which now requires the days (in seconds) be added to the time.

https://bugzilla.redhat.com/show_bug.cgi?id=1427503

This issue was introduced in PR https://github.com/ManageIQ/manageiq/pull/11156