### PR TITLE
[WIP] Refresh the dest host on VmDeployedEvent

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/VC.class/vmdeployedevent.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/VC.class/vmdeployedevent.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: VmDeployedEvent
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=dest_host"


### PR DESCRIPTION
We have seen where cloning a VM will emit a `VmDeployedEvent` but not a `CloneVM_Task_Complete` event which leads to a targeted refresh of the dest_host not being queued and the provision request timing out.

https://bugzilla.redhat.com/show_bug.cgi?id=1429032