### PR TITLE
Associate VM created from ansible playbook to original service

### DIFF
--- a/content/automate/ManageIQ/System/Request.class/__methods__/add_vm_to_service.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/add_vm_to_service.rb
@@ -1,52 +1,73 @@
 #
-# Description: add_VM_to_Service
+# Description: Add a VM to a Service
+# Input: job_id        The ID of the Job
+#        vm_name       The VM Name
 #
+#
+module ManageIQ
+  module Automate
+    module System
+      module Request
+        class AddVmToService
 
-begin 
-  $evm.log("info", "Called add_VM_to_Service")
-  job_id = $evm.object['job_id']
-  vm_name = $evm.object['vm_name']
-  $evm.log("info", "Called add_VM_to_Service with job_id: #{job_id} and vm_name: #{vm_name}")
-  
-  # Lookup for Service associated with ansible tower job_id
-  job = $evm.vmdb('orchestration_stack').find_by_ems_ref(job_id)
-  if job.nil?
-    $evm.log("error", "Can't find Ansible Job with ems_ref: #{job_id}")
-    exit MIQ_ERROR
-  end
-  $evm.log("info", "Found Ansible Job with id: #{job.id} and name: #{job.name}")
-  
-  # Lookup for Service from Ansible Job (Orchestration Stack)
-  resource = $evm.vmdb('service_resource').find_by_resource_id(job.id)
-  if resource.nil?
-    $evm.log("error", "Can't find Service with resource_id: #{job.id}")
-    exit MIQ_ERROR
-  end
-  $evm.log("info", "Found Resource with id: #{resource.id}")
-  
-  # Lookup for service from Resource
-  service = $evm.vmdb('service').find_by_id(resource.service_id)
-  if service.nil?
-    $evm.log("error", "Can't find Service with id: #{resource.service_id}")
-    exit MIQ_ERROR
-  end
-  $evm.log("info", "Found Service with id: #{resource.service_id} and name: #{service.name}")
-  
-  # Lookup for VM with vm_name
-  vm = $evm.vmdb('vm').find_by_name(vm_name)
-  # or try VmOrTemplate.find_by_name(vm_name)
-  if vm.nil?
-    $evm.log("error", "Can't find VM with name: #{vm_name}")
-    exit MIQ_ERROR
-  end
-  $evm.log("info", "Found VM with id: #{vm.id} and name: #{vm.name}")
+          def initialize(handle = $evm)
+              @handle = handle
+          end
 
-  # Associate VM to Service
-  $evm.log("info", "Adding VM: #{vm.name} to service: #{service.name}")
-  vm.add_to_service(service)
+          def main
+            vm.add_to_service(service)
+          end
 
-  exit MIQ_OK
-rescue => err
-  $evm.log("error", "[#{err}]\n#{err.backtrace.join("\n")}")
-  exit MIQ_ERROR
+          private 
+
+          def job
+            # Lookup for Service associated with ansible tower job_id
+            job_id = @handle.object['job_id']
+            job = @handle.vmdb('orchestration_stack').find_by_ems_ref(job_id)
+            if job.nil?
+              @handle.log("error", "Can't find Ansible Job with ems_ref: #{job_id}")
+              raise "Can't find Ansible Job with ems_ref; #{job_id}"
+            end
+            @handle.log("info", "Found Ansible Job with id: #{job.id} and name: #{job.name}")
+            return job
+          end
+
+          def service
+            # Lookup for Service from Ansible Job (Orchestration Stack)
+            resource = @handle.vmdb('service_resource').find_by_resource_id(job.id)
+            if resource.nil?
+              @handle.log("error", "Can't find Service resource with resource_id: #{job.id}")
+              raise "Can't find Service resource with resource_id: #{job.id}"
+            end
+            @handle.log("info", "Found Service Resource with id: #{resource.id}")
+
+            # Lookup for service from Resource
+            service = @handle.vmdb('service').find_by_id(resource.service_id)
+            if service.nil?
+              @handle.log("error", "Can't find Service with id: #{resource.service_id}")
+              raise "Can't find Service with id: #{resource.service_id}"
+            end
+            @handle.log("info", "Found Service with id: #{resource.service_id} and name: #{service.name}")
+            return service
+          end
+
+          def vm
+            # Lookup for VM with vm_name
+            vm_name = @handle.object['vm_name']
+            vm = @handle.vmdb('vm').find_by_name(vm_name)
+            if vm.nil?
+              @handle.log("error", "Can't find VM with name: #{vm_name}")
+              raise "Can't find VM with name: #{vm_name}"
+            end
+            @handle.log("info", "Found VM with id: #{vm.id} and name: #{vm.name}")
+            return vm
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::System::Request::AddVmToService.new.main
 end

--- a/content/automate/ManageIQ/System/Request.class/__methods__/add_vm_to_service.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/add_vm_to_service.rb
@@ -1,0 +1,52 @@
+#
+# Description: add_VM_to_Service
+#
+
+begin 
+  $evm.log("info", "Called add_VM_to_Service")
+  job_id = $evm.object['job_id']
+  vm_name = $evm.object['vm_name']
+  $evm.log("info", "Called add_VM_to_Service with job_id: #{job_id} and vm_name: #{vm_name}")
+  
+  # Lookup for Service associated with ansible tower job_id
+  job = $evm.vmdb('orchestration_stack').find_by_ems_ref(job_id)
+  if job.nil?
+    $evm.log("error", "Can't find Ansible Job with ems_ref: #{job_id}")
+    exit MIQ_ERROR
+  end
+  $evm.log("info", "Found Ansible Job with id: #{job.id} and name: #{job.name}")
+  
+  # Lookup for Service from Ansible Job (Orchestration Stack)
+  resource = $evm.vmdb('service_resource').find_by_resource_id(job.id)
+  if resource.nil?
+    $evm.log("error", "Can't find Service with resource_id: #{job.id}")
+    exit MIQ_ERROR
+  end
+  $evm.log("info", "Found Resource with id: #{resource.id}")
+  
+  # Lookup for service from Resource
+  service = $evm.vmdb('service').find_by_id(resource.service_id)
+  if service.nil?
+    $evm.log("error", "Can't find Service with id: #{resource.service_id}")
+    exit MIQ_ERROR
+  end
+  $evm.log("info", "Found Service with id: #{resource.service_id} and name: #{service.name}")
+  
+  # Lookup for VM with vm_name
+  vm = $evm.vmdb('vm').find_by_name(vm_name)
+  # or try VmOrTemplate.find_by_name(vm_name)
+  if vm.nil?
+    $evm.log("error", "Can't find VM with name: #{vm_name}")
+    exit MIQ_ERROR
+  end
+  $evm.log("info", "Found VM with id: #{vm.id} and name: #{vm.name}")
+
+  # Associate VM to Service
+  $evm.log("info", "Adding VM: #{vm.name} to service: #{service.name}")
+  vm.add_to_service(service)
+
+  exit MIQ_OK
+rescue => err
+  $evm.log("error", "[#{err}]\n#{err.backtrace.join("\n")}")
+  exit MIQ_ERROR
+end

--- a/content/automate/ManageIQ/System/Request.class/__methods__/add_vm_to_service.yaml
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/add_vm_to_service.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: add_VM_to_Service
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/System/Request.class/add_vm_to_service.yaml
+++ b/content/automate/ManageIQ/System/Request.class/add_vm_to_service.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Add_VM_to_Service
+    inherits: 
+    description: 
+  fields:
+  - meth5:
+      value: add_VM_to_Service


### PR DESCRIPTION
When provisioning a new VM or instance using an Ansible playbook as part of a CloudForms service, the new VM is not associated to the original service. This method provides a way to lookup the original service based on the ansible job id and associates the new VM to the original service. This is called as the last step in the Ansible playbook using the /api/automation_requests CloudForms REST API call.