### PR TITLE
Change default behavior of Service Retirement to not remove the Service

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__class__.yaml
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__class__.yaml
@@ -183,7 +183,7 @@ object:
       datatype: string
       priority: 9
       owner: 
-      default_value: "/Service/Retirement/StateMachines/Methods/DeleteServiceFromVMDB"
+      default_value: "#/Service/Retirement/StateMachines/Methods/DeleteServiceFromVMDB"
       substitute: true
       message: create
       visibility: 


### PR DESCRIPTION
 Do not remove the Service from the VMDB during retirement.

https://www.pivotaltracker.com/story/show/142413205
