### PR TITLE
Add policy checking for the retirement request.

### DIFF
--- a/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/request_orchestration_stack_retire.yaml
+++ b/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/request_orchestration_stack_retire.yaml
@@ -10,6 +10,10 @@ object:
   fields:
   - logical_event:
       value: request_orchestration_stack_retire
+  - rel1:
+      value: "/System/event_handlers/event_enforce_policy"
+  - rel2:
+      value: "/System/event_handlers/check_policy_prevent"
   - rel4:
       value: "/System/Process/parse_provider_category"
   - rel5:

--- a/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/request_service_retire.yaml
+++ b/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/request_service_retire.yaml
@@ -11,8 +11,10 @@ object:
   - logical_event:
       value: request_service_retire
   - rel1:
+      value: "/System/event_handlers/event_enforce_policy"
+  - rel2:
+      value: "/System/event_handlers/check_policy_prevent"
+  - rel3:
       value: "/Service/Retirement/StateMachines/Methods/GetRetirementEntryPoint"
   - rel4:
       value: "${/#retirement_entry_point}?service_id=${process#service_id}"
-  - rel5:
-      value: "/System/event_handlers/event_enforce_policy"

--- a/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/request_vm_retire.yaml
+++ b/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/request_vm_retire.yaml
@@ -10,9 +10,11 @@ object:
   fields:
   - logical_event:
       value: request_vm_retire
+  - rel2:
+      value: "/System/event_handlers/event_enforce_policy"
+  - rel3:
+      value: "/System/event_handlers/check_policy_prevent"
   - rel4:
       value: "/System/Process/parse_provider_category"
   - rel5:
       value: "/${/#ae_provider_category}/VM/Lifecycle/Retirement?vm_id=${process#vm_id}"
-  - rel6:
-      value: "/System/event_handlers/event_enforce_policy"

--- a/content/automate/ManageIQ/System/event_handlers.class/__methods__/check_policy_prevent.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/__methods__/check_policy_prevent.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: check_policy_prevent
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: builtin
+  inputs: []

--- a/content/automate/ManageIQ/System/event_handlers.class/check_policy_prevent.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/check_policy_prevent.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: check_policy_prevent
+    inherits: 
+    description: 
+  fields:
+  - meth1:
+      value: check_policy_prevent


### PR DESCRIPTION
All events are sent to automate for processing since [Event Switchboard PR](https://github.com/ManageIQ/manageiq/pull/4328).
Since then the policy checking for prevent action has changed from a sync process to an async process.

Part of [#14641](https://github.com/ManageIQ/manageiq/pull/14641).

https://bugzilla.redhat.com/show_bug.cgi?id=1439331

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, darga/yes, euwe/yes