### PR TITLE
In the F release ConfigurationManagement has been deprecated

### DIFF
--- a/content/automate/ManageIQ/ConfigurationManagement/__namespace__.yaml
+++ b/content/automate/ManageIQ/ConfigurationManagement/__namespace__.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     name: ConfigurationManagement
-    description: 
-    display_name: 
+    description: Deprecated please use AutomationManagement
+    display_name: ConfigurationManagement (Deprecated)
     priority: 
     enabled: 


### PR DESCRIPTION
<img width="483" alt="screen shot 2017-04-07 at 10 18 00 am" src="https://cloud.githubusercontent.com/assets/6452699/24809564/e292284e-1b8d-11e7-9500-7ce171cee91f.png">
Depends on
https://github.com/ManageIQ/manageiq/pull/14689

This would let customers know that  the ConfigurationManagement namespace is being deprecated and should not be used.