### PR TITLE
Refactoring cloud orchestration retirement delete_from_vmdb method

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
@@ -1,11 +1,37 @@
 #
 # Description: This method removes the stack from the VMDB database
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Retirement
+          module StateMachines
+            module Methods
+              class DeleteFromVmdb
 
-stack = $evm.root['orchestration_stack']
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-if stack && !$evm.get_state_var('stack_exists_in_provider')
-  $evm.log('info', "Removing stack <#{stack.name}> from VMDB")
-  stack.remove_from_vmdb
-  $evm.root['orchestration_stack'] = nil
+                def main
+                  stack = @handle.root['orchestration_stack']
+
+                  if stack && !@handle.get_state_var('stack_exists_in_provider')
+                    @handle.log('info', "Removing stack <#{stack.name}> from VMDB")
+                    stack.remove_from_vmdb
+                    @handle.root['orchestration_stack'] = nil
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::DeleteFromVmdb.new.main
 end

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb_spec.rb
@@ -1,0 +1,33 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::DeleteFromVmdb do
+  let(:stack)                 { FactoryGirl.create(:orchestration_stack_amazon) }
+  let(:service_orchestration) { FactoryGirl.create(:service_orchestration) }
+  let(:svc_model_service)     { MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  let(:svc_model_stack)       { MiqAeMethodService::MiqAeServiceOrchestrationStack.find(stack.id) }
+
+  let(:root_hash) do
+    { 'service_template' => MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  end
+
+  let(:root_object) do
+    obj = Spec::Support::MiqAeMockObject.new(root_hash)
+    obj["orchestration_stack"] = svc_model_stack
+    obj
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "removes stack from vmdb" do
+    ae_service.set_state_var('stack_exists_in_provider', false)
+    described_class.new(ae_service).main
+
+    expect(ae_service.root['orchestration_stack']).to eq(nil)
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring Cloud/Orchestration/Retirement/StateMachines/delete_from_vmdb.rb method and adding a new spec. This PR is based on the issue bellow.

Links
-------------------
#8

@miq-bot add_label refactoring