### PR TITLE
Refactoring cloud orchestration retirement finish_retirement method

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
@@ -1,6 +1,31 @@
 #
 # Description: This method marks the stack as retired
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Retirement
+          module StateMachines
+            module Methods
+              class FinishRetirement
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-stack = $evm.root['orchestration_stack']
-stack.finish_retirement if stack
+                def main
+                  stack = @handle.root['orchestration_stack']
+                  stack.finish_retirement if stack
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::FinishRetirement.new.main
+end

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement_spec.rb
@@ -1,0 +1,34 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::FinishRetirement do
+  let(:stack)                 { FactoryGirl.create(:orchestration_stack_amazon) }
+  let(:service_orchestration) { FactoryGirl.create(:service_orchestration) }
+  let(:svc_model_service)     { MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  let(:svc_model_stack)       { MiqAeMethodService::MiqAeServiceOrchestrationStack.find(stack.id) }
+
+  let(:root_hash) do
+    { 'service_template' => MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  end
+
+  let(:root_object) do
+    obj = Spec::Support::MiqAeMockObject.new(root_hash)
+    obj["orchestration_stack"] = svc_model_stack
+    obj
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "retires orchestration stack" do
+    described_class.new(ae_service).main
+
+    expect(svc_model_stack.retired).to eq(true)
+    expect(svc_model_stack.retires_on).to be_between(Time.zone.now - 10.seconds, Time.zone.now + 1.second)
+    expect(svc_model_stack.retirement_state).to eq("retired")
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring Cloud/Orchestration/Retirement/StateMachines/finish_retirement.rb method and adding a new spec. This PR is based on the issue bellow.

Links
-------------------
#8

@miq-bot add_label refactoring