### PR TITLE
Ensure spec/support from ManageIQ::AutomationEngine is loaded

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ def require_domain_file
   require file_name
 end
 
+Dir[ManageIQ::AutomationEngine::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
+
 RSpec.configure do |config|
   config.include Spec::Support::AutomationHelper
 


### PR DESCRIPTION
Fixes:
```
     Failure/Error: let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
     
     NameError:
       uninitialized constant Spec::Support::MiqAeMockService
```