### PR TITLE
Order Ansible Playbook from a Custom Button using a Method

### DIFF
--- a/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
@@ -41,7 +41,6 @@ module ManageIQ
           def vmdb_object_ip
             vmdb_object.try(:ipaddresses).try(:first).tap do |ip|
               if ip.nil?
-                @handle.log(:error, "IP address not specified for vmdb_object")
                 raise "IP address not specified for vmdb_object"
               end
             end
@@ -49,14 +48,12 @@ module ManageIQ
 
           def vmdb_object
             if @handle.root['vmdb_object_type'].nil?
-              @handle.log(:error, "vmdb_object_type missing in root object")
               raise "vmdb_object_type missing in root object"
             end
 
             vmdb_object_type = @handle.root['vmdb_object_type']
 
             if @handle.root[vmdb_object_type].nil?
-              @handle.log(:error, "vmdb_object #{vmdb_object_type} missing in root object")
               raise "vmdb_object #{vmdb_object_type} missing in root object"
             end
             @handle.root[vmdb_object_type]
@@ -65,7 +62,6 @@ module ManageIQ
           def service_template
             @service_template ||= @handle.vmdb('ServiceTemplate').where(:name => service_template_name).first.tap do |st|
               if st.nil?
-                @handle.log(:error, "Service Template #{@handle.root['service_template_name']} not found")
                 raise "Service Template #{@handle.root['service_template_name']} not found"
               end
             end
@@ -73,7 +69,6 @@ module ManageIQ
 
           def service_template_name
             if @handle.root['service_template_name'].nil?
-              @handle.log(:error, "service_template_name is a required parameter")
               raise "service_template_name is a required parameter"
             end
             @handle.root['service_template_name']

--- a/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
@@ -3,7 +3,7 @@
 #   service_template_name
 # Optional Parameters in the root object
 # hosts   localhost|vm|ip1,ip2,ip3
-#   vm    If the hosts is vm, at runtime will use the ip address of the vm in the hosts field
+#   vmdb_object    If the hosts is vmdb_object, at runtime will use the ip address of the vmdb_object in the hosts field
 
 module ManageIQ
   module Automate
@@ -31,22 +31,35 @@ module ManageIQ
           end
 
           def hosts
-            if @handle.root['hosts'] == 'vm'
-              vm_ip
+            if @handle.root['hosts'] == 'vmdb_object'
+              vmdb_object_ip
             else
               @handle.root['hosts'] || @handle.root['dialog_hosts']
             end
           end
 
-          def vm_ip
-            raise "VM object not passed in" unless @handle.root['vm']
-
-            @handle.root['vm'].ipaddresses.try(:first).tap do |ip|
+          def vmdb_object_ip
+            vmdb_object.try(:ipaddresses).try(:first).tap do |ip|
               if ip.nil?
-                @handle.log(:error, "IP address not specified for vm: #{@handle.root['vm'].name}")
-                raise "IP address not specified for vm: #{@handle.root['vm'].name}"
+                @handle.log(:error, "IP address not specified for vmdb_object")
+                raise "IP address not specified for vmdb_object"
               end
             end
+          end
+
+          def vmdb_object
+            if @handle.root['vmdb_object_type'].nil?
+              @handle.log(:error, "vmdb_object_type missing in root object")
+              raise "vmdb_object_type missing in root object"
+            end
+
+            vmdb_object_type = @handle.root['vmdb_object_type']
+
+            if @handle.root[vmdb_object_type].nil?
+              @handle.log(:error, "vmdb_object #{vmdb_object_type} missing in root object")
+              raise "vmdb_object #{vmdb_object_type} missing in root object"
+            end
+            @handle.root[vmdb_object_type]
           end
 
           def service_template

--- a/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
@@ -1,0 +1,76 @@
+# Description: Launch an ansible playbook service
+# Required Parameters in the root object
+#   service_template_name
+# Optional Parameters in the root object
+# hosts   localhost|vm|ip1,ip2,ip3
+#   vm    If the hosts is vm, at runtime will use the ip address of the vm in the hosts field
+
+module ManageIQ
+  module Automate
+    module System
+      module Request
+        class OrderAnsiblePlaybook
+          ANSIBLE_DIALOG_VAR_REGEX = Regexp.new(/dialog_param_(.*)/)
+          def initialize(handle = $evm)
+            @handle = handle
+          end 
+
+          def main
+            request = @handle.create_service_provision_request(service_template, extra_vars.merge(:hosts => hosts)) 
+            @handle.log(:info, "Submitted provision request #{request.id} for service template #{service_template_name}")
+          end 
+
+          private
+
+          def extra_vars
+            key_list = @handle.root.attributes.keys.select { |k| k.start_with?('dialog_param') }
+            key_list.each_with_object({}) do |key, hash|
+              match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
+              hash["param_#{match_data[1]}"] = @handle.root[key] if match_data
+            end 
+          end 
+    
+          def hosts
+            if @handle.root['hosts'] == 'vm'
+              vm_ip
+            else
+              @handle.root['hosts'] || @handle.root['dialog_hosts']
+            end 
+          end 
+    
+          def vm_ip
+            raise "VM object not passed in" unless @handle.root['vm']
+
+            @handle.root['vm'].ipaddresses.try(:first).tap do |ip|
+              if ip.nil?
+                @handle.log(:error, "IP address not specified for vm: #{@handle.root['vm'].name}")
+                raise "IP address not specified for vm: #{@handle.root['vm'].name}"
+              end 
+            end 
+          end
+          
+          def service_template
+            @service_template ||= @handle.vmdb('ServiceTemplate').where(:name => service_template_name).first.tap do |st| 
+              if st.nil?
+                @handle.log(:error, "Service Template #{@handle.root['service_template_name']} not found")
+                raise "Service Template #{@handle.root['service_template_name']} not found"
+              end
+            end
+          end
+
+          def service_template_name
+            if @handle.root['service_template_name'].nil?
+              @handle.log(:error, "service_template_name is a required parameter")
+              raise "service_template_name is a required parameter"
+            end
+            @handle.root['service_template_name']
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::System::Request::OrderAnsiblePlaybook.new.main
+end

--- a/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
@@ -13,12 +13,12 @@ module ManageIQ
           ANSIBLE_DIALOG_VAR_REGEX = Regexp.new(/dialog_param_(.*)/)
           def initialize(handle = $evm)
             @handle = handle
-          end 
+          end
 
           def main
-            request = @handle.create_service_provision_request(service_template, extra_vars.merge(:hosts => hosts)) 
+            request = @handle.create_service_provision_request(service_template, extra_vars.merge(:hosts => hosts))
             @handle.log(:info, "Submitted provision request #{request.id} for service template #{service_template_name}")
-          end 
+          end
 
           private
 
@@ -27,17 +27,17 @@ module ManageIQ
             key_list.each_with_object({}) do |key, hash|
               match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
               hash["param_#{match_data[1]}"] = @handle.root[key] if match_data
-            end 
-          end 
-    
+            end
+          end
+
           def hosts
             if @handle.root['hosts'] == 'vm'
               vm_ip
             else
               @handle.root['hosts'] || @handle.root['dialog_hosts']
-            end 
-          end 
-    
+            end
+          end
+
           def vm_ip
             raise "VM object not passed in" unless @handle.root['vm']
 
@@ -45,12 +45,12 @@ module ManageIQ
               if ip.nil?
                 @handle.log(:error, "IP address not specified for vm: #{@handle.root['vm'].name}")
                 raise "IP address not specified for vm: #{@handle.root['vm'].name}"
-              end 
-            end 
+              end
+            end
           end
-          
+
           def service_template
-            @service_template ||= @handle.vmdb('ServiceTemplate').where(:name => service_template_name).first.tap do |st| 
+            @service_template ||= @handle.vmdb('ServiceTemplate').where(:name => service_template_name).first.tap do |st|
               if st.nil?
                 @handle.log(:error, "Service Template #{@handle.root['service_template_name']} not found")
                 raise "Service Template #{@handle.root['service_template_name']} not found"

--- a/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.yaml
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: order_ansible_playbook
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/System/Request.class/order_ansible_playbook.yaml
+++ b/content/automate/ManageIQ/System/Request.class/order_ansible_playbook.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Order_Ansible_Playbook
+    inherits: 
+    description: 
+  fields:
+  - meth1:
+      value: order_ansible_playbook

--- a/spec/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook_spec.rb
+++ b/spec/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook_spec.rb
@@ -51,8 +51,7 @@ describe ManageIQ::Automate::System::Request::OrderAnsiblePlaybook do
       { 'service_template_name' => svc_service_template.name,
         'dialog_param_var1'     => 'A',
         'dialog_param_var2'     => 'B',
-        'vm'                    => svc_vm
-      }
+        'vm'                    => svc_vm }
     end
 
     it_behaves_like "order playbook"

--- a/spec/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook_spec.rb
+++ b/spec/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook_spec.rb
@@ -51,6 +51,7 @@ describe ManageIQ::Automate::System::Request::OrderAnsiblePlaybook do
       { 'service_template_name' => svc_service_template.name,
         'dialog_param_var1'     => 'A',
         'dialog_param_var2'     => 'B',
+        'vmdb_object_type'      => 'vm',
         'vm'                    => svc_vm }
     end
 
@@ -76,7 +77,8 @@ describe ManageIQ::Automate::System::Request::OrderAnsiblePlaybook do
       { 'service_template_name' => svc_service_template.name,
         'dialog_param_var1'     => 'A',
         'dialog_param_var2'     => 'B',
-        'hosts'                 => 'vm',
+        'hosts'                 => 'vmdb_object',
+        'vmdb_object_type'      => 'vm',
         'vm'                    => svc_vm }
     end
 
@@ -94,14 +96,14 @@ describe ManageIQ::Automate::System::Request::OrderAnsiblePlaybook do
       { 'service_template_name' => svc_service_template.name,
         'dialog_param_var1'     => 'A',
         'dialog_param_var2'     => 'B',
-        'hosts'                 => 'vm' }
+        'hosts'                 => 'vmdb_object' }
     end
 
     it "raises an error" do
       allow(ae_service).to receive(:vmdb).with('ServiceTemplate').and_return(svc_vmdb_handle)
       allow(svc_vmdb_handle).to receive(:where).with(:name => svc_template.name).and_return([svc_service_template])
 
-      expect { described_class.new(ae_service).main }.to raise_error(/VM object not passed/)
+      expect { described_class.new(ae_service).main }.to raise_error(/vmdb_object_type missing in root object/)
     end
   end
 
@@ -111,7 +113,8 @@ describe ManageIQ::Automate::System::Request::OrderAnsiblePlaybook do
         'dialog_param_var1'     => 'A',
         'dialog_param_var2'     => 'B',
         'vm'                    => svc_vm,
-        'hosts'                 => 'vm' }
+        'vmdb_object_type'      => 'vm',
+        'hosts'                 => 'vmdb_object' }
     end
 
     it "raises an error" do

--- a/spec/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook_spec.rb
+++ b/spec/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook_spec.rb
@@ -1,0 +1,126 @@
+require_domain_file
+
+describe ManageIQ::Automate::System::Request::OrderAnsiblePlaybook do
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(attributes)
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  let(:ip1) { "1.1.1.94" }
+
+  let(:vm) { FactoryGirl.create(:vm_vmware, :name => 'fred') }
+  let(:svc_vm) { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+
+  let(:svc_template) { FactoryGirl.create(:service_template_ansible_playbook, :name => 'fred') }
+  let(:svc_service_template) do
+    MiqAeMethodService::MiqAeServiceServiceTemplate.find(svc_template.id)
+  end
+
+  let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
+  let(:svc_miq_request) do
+    MiqAeMethodService::MiqAeServiceMiqRequest.find(miq_request.id)
+  end
+
+  let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceServiceTemplate }
+
+  shared_examples_for "order playbook" do
+    it "creates request" do
+      allow(ae_service).to receive(:vmdb).with('ServiceTemplate').and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:name => svc_template.name).and_return([svc_service_template])
+      allow(svc_vm).to receive(:ipaddresses).and_return([ip1])
+      expect(ae_service).to receive(:create_service_provision_request).with(svc_service_template, extra_vars).and_return(svc_miq_request)
+
+      described_class.new(ae_service).main
+    end
+  end
+
+  context "with no host" do
+    let(:extra_vars) do
+      { :hosts       => nil,
+        'param_var1' => 'A',
+        'param_var2' => 'B' }
+    end
+    let(:attributes) do
+      { 'service_template_name' => svc_service_template.name,
+        'dialog_param_var1'     => 'A',
+        'dialog_param_var2'     => 'B',
+        'vm'                    => svc_vm
+      }
+    end
+
+    it_behaves_like "order playbook"
+
+    it "order playbook with incorrect service_template_name should raise error" do
+      allow(ae_service).to receive(:vmdb).with('ServiceTemplate').and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:name => svc_template.name).and_return([nil])
+
+      expect { described_class.new(ae_service).main }.to raise_error(/not found/)
+    end
+  end
+
+  context "with no service_template_name" do
+    let(:attributes) { {} }
+    it "should raise error" do
+      expect { described_class.new(ae_service).main }.to raise_error(/service_template_name/)
+    end
+  end
+
+  context "with vm host" do
+    let(:attributes) do
+      { 'service_template_name' => svc_service_template.name,
+        'dialog_param_var1'     => 'A',
+        'dialog_param_var2'     => 'B',
+        'hosts'                 => 'vm',
+        'vm'                    => svc_vm }
+    end
+
+    let(:extra_vars) do
+      { :hosts       => ip1,
+        'param_var1' => 'A',
+        'param_var2' => 'B' }
+    end
+
+    it_behaves_like "order playbook"
+  end
+
+  context "with vm host but no vm" do
+    let(:attributes) do
+      { 'service_template_name' => svc_service_template.name,
+        'dialog_param_var1'     => 'A',
+        'dialog_param_var2'     => 'B',
+        'hosts'                 => 'vm' }
+    end
+
+    it "raises an error" do
+      allow(ae_service).to receive(:vmdb).with('ServiceTemplate').and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:name => svc_template.name).and_return([svc_service_template])
+
+      expect { described_class.new(ae_service).main }.to raise_error(/VM object not passed/)
+    end
+  end
+
+  context "with vm host but no ip address" do
+    let(:attributes) do
+      { 'service_template_name' => svc_service_template.name,
+        'dialog_param_var1'     => 'A',
+        'dialog_param_var2'     => 'B',
+        'vm'                    => svc_vm,
+        'hosts'                 => 'vm' }
+    end
+
+    it "raises an error" do
+      allow(ae_service).to receive(:vmdb).with('ServiceTemplate').and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:name => svc_template.name).and_return([svc_service_template])
+      allow(svc_vm).to receive(:ipaddresses).and_return([nil])
+
+      expect { described_class.new(ae_service).main }.to raise_error(/IP address not specified for vm/)
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1449361

Allows for using a single dialog that is shared between the Custom Button and the Service Template Ordering.

The button needs 2 parameters along with the tie up to the Service Dialog
![screen shot 2017-05-09 at 3 14 07 pm](https://cloud.githubusercontent.com/assets/6452699/25909431/256069cc-357b-11e7-8ae5-2b0d1d998d1b.png)

- service_template_name
- hosts                              localhost|vmdb_object|ip1,ip2,ip3

vmdb_object refers to the context of the current object being selected from the button it could be a host or vm. The method would figure out the object to use at runtime.
![screen shot 2017-05-11 at 12 03 44 pm](https://cloud.githubusercontent.com/assets/6452699/25960352/b619d416-3644-11e7-85cd-70317dbb3b59.png)
