### PR TITLE
Remove VM reconfiguration email.

### DIFF
--- a/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/vm_reconfigure.yaml
+++ b/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/vm_reconfigure.yaml
@@ -8,7 +8,5 @@ object:
     inherits: 
     description: 
   fields:
-  - rel4:
-      value: "/Infrastructure/VM/Reconfigure/Email/VmReconfigureTaskComplete"
   - rel5:
       value: "/System/event_handlers/event_enforce_policy"


### PR DESCRIPTION
Removed vm_reconfigure email from System/Event/MiqEvent/Policy instance.
This event is being called sometimes when provisioning.

https://bugzilla.redhat.com/show_bug.cgi?id=1422208

@miq-bot add_label bug, fine/yes

Reverts one of the changes make in PR https://github.com/ManageIQ/manageiq/pull/7399