### PR TITLE
Require just rails/engine

### DIFF
--- a/lib/manageiq/content/engine.rb
+++ b/lib/manageiq/content/engine.rb
@@ -1,4 +1,4 @@
-require 'rails/all'
+require 'rails/engine'
 
 module ManageIQ
   module Content


### PR DESCRIPTION
A blank rails engine generated by rails doesn't require anything...[1]

Other engines do the sensible thing: require what they need [2]

We shouldn't make assumptions about the rails features the application
using the engine will want to use.

[1]
https://github.com/rails/rails/blob/0e453e9150f0ac9fa2bdff4511c3c806a3e45f49/railties/lib/rails/generators/rails/plugin/templates/lib/%25namespaced_name%25/engine.rb

[2] https://github.com/rails/coffee-rails/blob/db0659924c82f24e2665d799b1ab342078f2501d/lib/coffee/rails/engine.rb#L1