### PR TITLE
v2v: Add automate methods for post-import network configuration

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__class__.yaml
@@ -134,27 +134,28 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: post1
+      name: ConfigureNetworks
       display_name: 
       datatype: string
       priority: 7
       owner: 
-      default_value: 
-      substitute: true
+      default_value: METHOD::configure_vm_networks
+      substitute: false
       message: create
       visibility: 
       collect: 
       scope: 
       description: 
       condition: 
-      on_entry: 
-      on_exit: 
-      on_error: 
-      max_retries: 
+      on_entry: update_vm_import_status(status => 'Updating imported VM's networks')
+      on_exit: update_vm_import_status(status => 'Configuration of VM networks completed')
+      on_error: update_vm_import_status(status => 'Error configuring imported VM's
+        networks')
+      max_retries: '100'
       max_time: 
   - field:
       aetype: state
-      name: post2
+      name: post1
       display_name: 
       datatype: string
       priority: 8
@@ -174,7 +175,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: post3
+      name: post2
       display_name: 
       datatype: string
       priority: 9
@@ -194,7 +195,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: email
+      name: post3
       display_name: 
       datatype: string
       priority: 10
@@ -214,10 +215,30 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: finish
+      name: email
       display_name: 
       datatype: string
       priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: finish
+      display_name: 
+      datatype: string
+      priority: 12
       owner: 
       default_value: 
       substitute: true

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks.rb
@@ -1,0 +1,43 @@
+#
+# Description: This method initiates post-import configuration of VM network interfaces.
+#
+
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module StateMachines
+            class ConfigureVmNetworks
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                validate_root_args %w(provider_id)
+
+                provider = @handle.vmdb(:ext_management_system, @handle.root['provider_id'])
+                vm_id = @handle.get_state_var('imported_vm_id')
+                @handle.log(:info, "Configuring VM ID: #{vm_id} Networks")
+                provider.submit_configure_imported_vm_networks(@handle.root['user'].userid, vm_id)
+              end
+
+              def validate_root_args(arg_names)
+                arg_names.each do |name|
+                  next if @handle.root[name].present?
+                  msg = "Error, required root attribute: #{name} not found"
+                  @handle.log(:error, msg)
+                  raise msg
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::ConfigureVmNetworks.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: configure_vm_networks
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.rb
@@ -19,6 +19,7 @@ module ManageIQ
                   status = vm.custom_get(:import_status)
                   case status
                   when 'success'
+                    @handle.set_state_var('imported_vm_id', vm.id)
                     @handle.root['ae_result'] = 'ok'
                   when 'failure'
                     @handle.root['ae_result'] = 'error'

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks_spec.rb
@@ -1,0 +1,29 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::ConfigureVmNetworks do
+  let(:user)        { FactoryGirl.create(:user_admin) }
+  let(:provider)    { FactoryGirl.create(:ems_redhat) }
+
+  let(:svc_model_user)     { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_provider) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager.find(provider.id) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(
+      :user        => svc_model_user,
+      :name        => 'my_vm',
+      :provider_id => provider.id
+    )
+  end
+
+  let(:vm_id) { 42 }
+
+  let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object, 'imported_vm_id' => vm_id) }
+
+  it 'Calls :submit_import_vm on the provider object with correct params' do
+    allow(ae_service).to receive(:vmdb).with(:ext_management_system, provider.id).and_return(svc_model_provider)
+
+    expect(svc_model_provider).to receive(:submit_configure_imported_vm_networks).with(user.userid, vm_id)
+
+    described_class.new(ae_service).main
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import_spec.rb
@@ -25,6 +25,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::WaitF
       described_class.new(ae_service).main
 
       expect(ae_service.root['ae_result']).to eq('ok')
+      expect(ae_service.get_state_var('imported_vm_id')).to eq(vm.id)
     end
   end
 


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1404920

Depends on ManageIQ/manageiq-automation_engine#35