### PR TITLE
Add Available_Projects method for dynamic dropdown in container template service dialog

### DIFF
--- a/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__class__.yaml
+++ b/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__class__.yaml
@@ -1,0 +1,33 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Methods
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: method
+      name: execute
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects.rb
+++ b/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects.rb
@@ -1,0 +1,54 @@
+#
+# Description: provide the dynamic list content from available flavors
+#
+module ManageIQ
+  module Automate
+    module Container
+      module Openshift
+        module Operations
+          class AvailableProjects
+            def initialize(handle = $evm)
+              @handle = handle
+            end
+
+            def main
+              fill_dialog_field(fetch_list_data)
+            end
+
+            private
+
+            def fetch_list_data
+              service = @handle.root.attributes["service_template"] || @handle.root.attributes["service"]
+              projects = service.try(:container_manager).try(:container_projects)
+
+              project_list = {}
+              projects.each { |p| project_list[p.name] = p.name } if projects
+
+              return nil => "<none>" if project_list.blank?
+
+              project_list[nil] = "<select>" if project_list.length > 1
+              project_list
+            end
+
+            def fill_dialog_field(list)
+              dialog_hash = {
+                'sort_by'       => "description",
+                'data_type'     => "string",
+                'required'      => false,
+                'sort_order'    => "ascending",
+                'values'        => list,
+                'default_value' => list.length == 1 ? list.keys.first : nil
+              }
+
+              dialog_hash.each { |key, value| @handle.object[key] = value }
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Container::Openshift::Operations::AvailableProjects.new.main
+end

--- a/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects.yaml
+++ b/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Available_Projects
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/available_projects.yaml
+++ b/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/available_projects.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Available_Projects
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: Available_Projects

--- a/content/automate/ManageIQ/Container/Openshift/Operations/__namespace__.yaml
+++ b/content/automate/ManageIQ/Container/Openshift/Operations/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Operations
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/content/automate/ManageIQ/Container/Openshift/__namespace__.yaml
+++ b/content/automate/ManageIQ/Container/Openshift/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Openshift
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/content/automate/ManageIQ/Container/__namespace__.yaml
+++ b/content/automate/ManageIQ/Container/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Container
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/spec/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects_spec.rb
+++ b/spec/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects_spec.rb
@@ -1,0 +1,88 @@
+require_domain_file
+
+describe ManageIQ::Automate::Container::Openshift::Operations::AvailableProjects do
+  let(:root_hash) do
+    { 'service_template' => MiqAeMethodService::MiqAeServiceServiceTemplate.find(service_template.id) }
+  end
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+  let(:container_template) { FactoryGirl.create(:container_template, :name => 'my-template', :ems_id => ems.id) }
+  let(:ems) { FactoryGirl.create(:ems_openshift) }
+
+  shared_examples_for "#having only default value" do
+    let(:default_desc_blank) { "<none>" }
+
+    it "provides only default value to the project list" do
+      described_class.new(ae_service).main
+
+      expect(ae_service["values"]).to eq(nil => default_desc_blank)
+      expect(ae_service["default_value"]).to be_nil
+    end
+  end
+
+  shared_examples_for "#having the only project" do
+    let(:project) { FactoryGirl.create(:container_project, :name => 'my-project', :ems_id => ems.id) }
+
+    it "finds the only project and set it as the only item in the list" do
+      project
+      described_class.new(ae_service).main
+
+      expect(ae_service["values"]).to include(project.name => project.name)
+      expect(ae_service["default_value"]).to eq(project.name)
+    end
+  end
+
+  shared_examples_for "#having all projects" do
+    let(:default_desc) { "<select>" }
+    let(:project1) { FactoryGirl.create(:container_project, :name => 'my-project1', :ems_id => ems.id) }
+    let(:project2) { FactoryGirl.create(:container_project, :name => 'my-project2', :ems_id => ems.id) }
+
+    it "finds all of the projects and populates the list" do
+      project1
+      project2
+      described_class.new(ae_service).main
+
+      expect(ae_service["values"]).to include(
+        nil           => default_desc,
+        project1.name => project1.name,
+        project2.name => project2.name
+      )
+      expect(ae_service["default_value"]).to be_nil
+    end
+  end
+
+  context "workspace has no service template" do
+    let(:root_hash) { {} }
+
+    it_behaves_like "#having only default value"
+  end
+
+  context "workspace has service template other than container" do
+    let(:service_template) { FactoryGirl.create(:service_template) }
+
+    it_behaves_like "#having only default value"
+  end
+
+  context "workspace has container template service template" do
+    let(:service_template) do
+      FactoryGirl.create(:service_template_container_template).tap do |service_template|
+        allow(ServiceTemplate).to receive(:find).with(service_template.id).and_return(service_template)
+        allow(service_template).to receive(:container_template).and_return(container_template)
+      end
+    end
+
+    context "with all projects" do
+      it_behaves_like "#having all projects"
+    end
+
+    context "with one project" do
+      it_behaves_like "#having the only project"
+    end
+  end
+end


### PR DESCRIPTION
The method would collect the available projects for the dynamic dropdown list of projects during service ordering.

Depends on [manageiq #15356](https://github.com/ManageIQ/manageiq/pull/15356).
Depends on [engine #41](https://github.com/ManageIQ/manageiq-automation_engine/pull/41).
Related PR https://github.com/ManageIQ/manageiq/pull/15340

https://www.pivotaltracker.com/story/show/146528931
@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement, services