### PR TITLE
Exclude orphaned VMs from quota count

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
@@ -6,7 +6,7 @@ def consumption(source)
   {
     :cpu                 => source.allocated_vcpu,
     :memory              => source.allocated_memory,
-    :vms                 => source.vms.count { |vm| vm.id unless vm.archived || vm.orphaned },
+    :vms                 => source.vms.count { |vm| vm.id if vm.ems_id },
     :storage             => source.allocated_storage,
     :provisioned_storage => source.provisioned_storage
   }

--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
@@ -6,7 +6,7 @@ def consumption(source)
   {
     :cpu                 => source.allocated_vcpu,
     :memory              => source.allocated_memory,
-    :vms                 => source.vms.count { |vm| vm.id unless vm.archived },
+    :vms                 => source.vms.count { |vm| vm.id unless vm.archived || vm.orphaned },
     :storage             => source.allocated_storage,
     :provisioned_storage => source.provisioned_storage
   }


### PR DESCRIPTION
When calculating the number of VMs during quota check archived VMs are excluded from the return count. This PR adds excluding orphaned VMs as well.