### PR TITLE
Spec test for excluding orphaned vms from quota.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
@@ -6,7 +6,7 @@ def consumption(source)
   {
     :cpu                 => source.allocated_vcpu,
     :memory              => source.allocated_memory,
-    :vms                 => source.vms.count { |vm| vm.id unless vm.archived },
+    :vms                 => source.vms.count { |vm| vm.id if vm.ems_id },
     :storage             => source.allocated_storage,
     :provisioned_storage => source.provisioned_storage
   }

--- a/spec/automation/unit/method_validation/calculate_used_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_used_spec.rb
@@ -19,7 +19,7 @@ describe "Quota Validation" do
     expect(root['quota_source']).to be_kind_of(MiqAeMethodService::MiqAeServiceTenant)
     expect(root['quota_used'][:storage]).to eq(1_000_000)
     expect(root['quota_used'][:cpu]).to eq(0)
-    expect(root['quota_used'][:vms]).to eq(2)
+    expect(root['quota_used'][:vms]).to eq(1)
     expect(root['quota_used'][:provisioned_storage]).to eq(1_074_741_824)
     expect(root['quota_used'][:memory]).to eq(1_073_741_824)
   end


### PR DESCRIPTION
Modified spec test count to reflect change made by branic to exclude VMs with no EMS in the Quota used calculation.

I have included branic's change in this PR.  

https://github.com/ManageIQ/manageiq-content/pull/129

