### PR TITLE
Event switchboard entries for Amazon EBS events.

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/attachvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/attachvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AttachVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/copysnapshot.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/copysnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CopySnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/createsnapshot.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/createsnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CreateSnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/createvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/createvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CreateVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/deletesnapshot.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/deletesnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: DeleteSnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/deletevolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/deletevolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: DeleteVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
This PR will configure entries in the event switchboard for AWS EBS cloud volume and snapshot events. The specific events are listed below and will trigger an EMS refresh to keep the AWS inventory up to date.

### Links:

https://bugzilla.redhat.com/show_bug.cgi?id=1449235
https://www.pivotaltracker.com/story/show/146650341

### Testing:

 

1. Add an AWS provider
2. Take note of the number of EBS cloud volumes
3. Add a new EBS cloud volume through the AWS Console
4. Ensure the new EBS cloud volume appears under: Storage / Block Storage / Volumes. This will indicate an event was received and went through the event switchboard where an EMS refresh was kicked off.
5.  Follow the same steps for:
- DeleteVolume
- AttachVolume
- CreateSnapshot
- DeleteSnapshot
- CopySnapshot