### PR TITLE
v2v: Fix filtering of drivers ISO to display

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos.rb
@@ -21,7 +21,7 @@ module ManageIQ
                       values_hash[nil] = '-- no ISO datastore for provider --'
                     else
                       values_hash[nil] = '-- select drivers ISO from list --'
-                      provider.iso_datastore.iso_images.pluck(:name).grep(/toolsSetup/).each do |iso|
+                      provider.iso_datastore.iso_images.pluck(:name).grep(/tools.*setup/i).each do |iso|
                         values_hash[iso] = iso
                       end
                     end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos_spec.rb
@@ -27,6 +27,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListDriverIs
         oVirt-toolsSetup-4.0-1.fc24.iso
         oVirt-toolsSetup-4.1-3.fc24.iso
         another-random-image.iso
+        rhev-tools-setup.iso
         oVirt-toolsSetup-4.2-4.fc25.iso
       ).map { |iso| FactoryGirl.create(:iso_image, :name => iso) }
       FactoryGirl.create(:iso_datastore, :iso_images => iso_images)
@@ -47,6 +48,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListDriverIs
         oVirt-toolsSetup-4.0-1.fc24.iso
         oVirt-toolsSetup-4.1-3.fc24.iso
         oVirt-toolsSetup-4.2-4.fc25.iso
+        rhev-tools-setup.iso
       ).each { |iso| isos[iso] = iso }
 
       expect(ae_service.object['values']).to eq(isos)


### PR DESCRIPTION
Formerly the list_dirver_isos method only took under account ISOs with names of
the form of 'RHEV-toolsSetup_3.5_15.iso' or 'oVirt-toolsSetup-4.1-3.fc24.iso'
and ISOs with names like 'rhev-tools-setup.iso' were ignored.

Fixed the filtering regex to cover both cases.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1471823