### PR TITLE
Host removal

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/host_detected.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/host_detected.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=ems"
+      value: "/System/event_handlers/event_action_refresh?target=src_host"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/host_install.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/host_install.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=ems"
+      value: "/System/event_handlers/event_action_refresh?target=src_host"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_add_host.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_add_host.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=src_ems_cluster"
+      value: "/System/event_handlers/event_action_refresh?target=src_host"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_host.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_host.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=src_ems_cluster"
+      value: "/System/event_handlers/event_action_refresh?target=src_host"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_update_host.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_update_host.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=src_ems_cluster"
+      value: "/System/event_handlers/event_action_refresh?target=src_host"


### PR DESCRIPTION
It is not needed to run full refresh when a host is removed we can
target it instead.

Bug-Url:
https://bugzilla.redhat.com/1458713