### PR TITLE
v2v: Support virtio-win drivers ISO

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos.rb
@@ -21,7 +21,7 @@ module ManageIQ
                       values_hash[nil] = '-- no ISO datastore for provider --'
                     else
                       values_hash[nil] = '-- select drivers ISO from list --'
-                      provider.iso_datastore.iso_images.pluck(:name).grep(/tools.*setup/i).each do |iso|
+                      provider.iso_datastore.iso_images.pluck(:name).grep(/tools.*setup|virtio-win.*.iso$/i).each do |iso|
                         values_hash[iso] = iso
                       end
                     end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos_spec.rb
@@ -20,6 +20,8 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListDriverIs
     let!(:provider) { FactoryGirl.create(:ems_redhat, :with_clusters, :iso_datastore => iso_datastore) }
     let!(:iso_datastore) do
       iso_images = %w(
+        virtio-win-1.9.0.iso
+        virtio-win-1.9.0_amd64.vfd
         RHEV-toolsSetup_3.5_15.iso
         RHEV-toolsSetup_4.0_7.iso
         random-image.iso
@@ -49,6 +51,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListDriverIs
         oVirt-toolsSetup-4.1-3.fc24.iso
         oVirt-toolsSetup-4.2-4.fc25.iso
         rhev-tools-setup.iso
+        virtio-win-1.9.0.iso
       ).each { |iso| isos[iso] = iso }
 
       expect(ae_service.object['values']).to eq(isos)


### PR DESCRIPTION
In addition to {oVirt,RHEV} setup tools there can be a separate ISO containing
*only* the virtio drivers. This patch adds support to show also these kind of
ISOs since they can be used for the v2v conversion process as well.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1471823