### PR TITLE
Support TTL (Time To Live) value for services.

### DIFF
--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/start.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/start.rb
@@ -8,6 +8,7 @@ module ManageIQ
         module StateMachines
           module GenericLifecycle
             class Start
+              MIN_RETRY_INTERVAL = 1.minute
               def initialize(handle = $evm)
                 @handle = handle
               end
@@ -17,6 +18,7 @@ module ManageIQ
                 @handle.log('info', msg)
                 @handle.create_notification(:level => 'info', :subject => service, :message => msg)
                 @handle.root['ae_result'] = 'ok'
+                retry_interval
               end
 
               private
@@ -27,6 +29,22 @@ module ManageIQ
                     @handle.log(:error, 'Service is nil')
                     raise 'Service not found'
                   end
+                end
+              end
+
+              def execution_ttl
+                service.options[:config_info][service_action.downcase.to_sym][:execution_ttl].to_i
+              end
+
+              def retry_interval
+                ttl = execution_ttl
+                max_retry_count = @handle.root['ae_state_max_retries']
+                return if ttl.zero? || max_retry_count.zero?
+
+                interval = ttl / max_retry_count
+                if interval > MIN_RETRY_INTERVAL
+                  @handle.log('info', "Setting retry interval to #{interval} time to live #{ttl} / #{max_retry_count}")
+                  @handle.root['ae_retry_interval'] = interval
                 end
               end
 

--- a/spec/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/start_spec.rb
+++ b/spec/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/start_spec.rb
@@ -1,23 +1,106 @@
 require_domain_file
 
 describe ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Start do
-  let(:admin) { FactoryGirl.create(:user_admin) }
-  let(:request) { FactoryGirl.create(:service_template_provision_request, :requester => admin) }
-  let(:ansible_tower_manager) { FactoryGirl.create(:automation_manager) }
-  let(:job_template) { FactoryGirl.create(:ansible_configuration_script, :manager => ansible_tower_manager) }
-  let(:service_ansible_tower) { FactoryGirl.create(:service_ansible_tower, :job_template => job_template) }
-  let(:task) { FactoryGirl.create(:service_template_provision_task, :destination => service_ansible_tower, :miq_request => request) }
-  let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(task.id) }
+  let(:request) { FactoryGirl.create(:service_template_provision_request, :requester => FactoryGirl.create(:user_admin)) }
+  let(:job_template) { FactoryGirl.create(:ansible_configuration_script, :manager => FactoryGirl.create(:automation_manager)) }
+  let(:service_ansible_tower) { FactoryGirl.create(:service_ansible_tower, :job_template => job_template, :options => config_info_options) }
   let(:svc_service) { MiqAeMethodService::MiqAeServiceServiceAnsibleTower.find(service_ansible_tower.id) }
-  let(:root_object) { Spec::Support::MiqAeMockObject.new('service' => svc_service, 'service_action' => 'Provision') }
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new('service' => svc_service, 'service_action' => 'Provision',
+                  'ae_state_max_retries' => 100)
+  end
   let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
+  let(:config_info_options) do
+    {
+      :config_info => {
+        :provision  => {
+          :execution_ttl => ttl
+        },
+        :retirement => {
+          :execution_ttl => ttl
+        }
+      }
+    }
+  end
 
-  context "Start" do
-    it "creates notification " do
+  shared_examples_for "#ttl" do
+    it "check" do
       allow(ae_service).to receive(:create_notification)
 
       described_class.new(ae_service).main
-      expect(ae_service.root['ae_result']).to eq("ok")
+      expect(ae_service.root['ae_retry_interval']).to eq(ae_retry_interval)
     end
+  end
+
+  context "Start 7700 ttl, 100 retries eq interval 77" do
+    let(:ae_retry_interval) { 77 }
+    let(:ttl) { 7700 }
+    it_behaves_like "#ttl"
+  end
+
+  context "Start 60000 ttl, 100 retries eq interval 600" do
+    let(:ae_retry_interval) { 600 }
+    let(:ttl) { 60_000 }
+    it_behaves_like "#ttl"
+  end
+
+  context "Start 600 ttl, 100 retries interval nil" do
+    let(:ae_retry_interval) { nil }
+    let(:ttl) { 600 }
+    it_behaves_like "#ttl"
+  end
+
+  context "Start 0 ttl, 100 retries, interval nil" do
+    let(:ae_retry_interval) { nil }
+    let(:ttl) { 0 }
+    it_behaves_like "#ttl"
+  end
+
+  context "Start retirement tests, " do
+    let(:root_object) do
+      Spec::Support::MiqAeMockObject.new('service' => svc_service, 'service_action' => 'Retirement', 'ae_state_max_retries' => 100)
+    end
+
+    context " 7700 ttl, 100 retries eq interval 77" do
+      let(:ae_retry_interval) { 77 }
+      let(:ttl) { 7700 }
+      it_behaves_like "#ttl"
+    end
+
+    context " 60000 ttl, 100 retries eq interval 600" do
+      let(:ae_retry_interval) { 600 }
+      let(:ttl) { 60_000 }
+      it_behaves_like "#ttl"
+    end
+
+    context " 600 ttl, 100 retries eq interval nil" do
+      let(:ae_retry_interval) { nil }
+      let(:ttl) { 600 }
+      it_behaves_like "#ttl"
+    end
+
+    context " 0 ttl, 100 retries, interval nil" do
+      let(:ae_retry_interval) { nil }
+      let(:ttl) { 0 }
+      it_behaves_like "#ttl"
+    end
+  end
+
+  context "Start 6000 ttl, 50 retries eq interval 120" do
+    let(:ae_retry_interval) { 120 }
+    let(:ttl) { 6000 }
+    let(:root_object) do
+      Spec::Support::MiqAeMockObject.new('service' => svc_service, 'service_action' => 'Provision', 'ae_state_max_retries' => 50)
+    end
+    it_behaves_like "#ttl"
+  end
+
+  context "Start 6000 ttl, 0 retries eq interval nil" do
+    let(:ae_retry_interval) { nil }
+    let(:ttl) { 6000 }
+    let(:root_object) do
+      Spec::Support::MiqAeMockObject.new('service' => svc_service, 'service_action' => 'Provision', 'ae_state_max_retries' => 0)
+    end
+    it_behaves_like "#ttl"
   end
 end


### PR DESCRIPTION
Allow specifying the length of time to allow the check_completed step to run in the generic service state-machines.
This will allow long running processes to finish.

UI changes are needed for this.

https://www.pivotaltracker.com/n/projects/1937537/stories/147361947

@miq-bot add_label enhancement, services
@miq-bot assign @gmcculloug
