### PR TITLE
Log the full error message from the provider

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -12,6 +12,7 @@ case result
 when 'error'
   $evm.root['ae_result'] = 'error'
   reason = $evm.root['miq_provision'].message
+  $evm.log('error', "ProvisionCheck error <#{reason}>")
   reason = reason[7..-1] if reason[0..6] == 'Error: '
   $evm.root['ae_reason'] = reason
 when 'retry'

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -13,6 +13,7 @@ case result
 when 'error'
   $evm.root['ae_result'] = 'error'
   reason = $evm.root['miq_provision'].message
+  $evm.log('error', "ProvisionCheck error <#{reason}>")
   reason = reason[7..-1] if reason[0..6] == 'Error: '
   $evm.root['ae_reason'] = reason
 when 'retry'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1385038

There was some confusion in this ticket if the error was being
generated by Automate or if it came from the provider. If we log the
full error message from the provider it would help debugging.