### PR TITLE
[WIP] Get the correct group when a user belongs to multiple groups.

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Lifecycle.class/provisioning.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Lifecycle.class/provisioning.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - Relationship5:
-      value: "/Cloud/VM/Provisioning/Profile/${/#user.normalized_ldap_group}#get_state_machine"
+      value: "/Cloud/VM/Provisioning/Profile/${/#miq_group.description}#get_state_machine"
   - Relationship6:
       value: "/Cloud/VM/Provisioning/StateMachines/${/#state_machine}/${/#miq_provision.provision_type}"

--- a/content/automate/ManageIQ/Infrastructure/Configured_System/Lifecycle.class/provisioning.yaml
+++ b/content/automate/ManageIQ/Infrastructure/Configured_System/Lifecycle.class/provisioning.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - Relationship5:
-      value: "/Infrastructure/Configured_System/Provisioning/Profile/${/#user.normalized_ldap_group}#get_state_machine"
+      value: "/Infrastructure/Configured_System/Provisioning/Profile/${/#miq_group.description}#get_state_machine"
   - Relationship6:
       value: "/Infrastructure/Configured_System/Provisioning/StateMachines/${/#state_machine}/${/#miq_provision_task.request_type}"

--- a/content/automate/ManageIQ/Infrastructure/Host/Lifecycle.class/provisioning.yaml
+++ b/content/automate/ManageIQ/Infrastructure/Host/Lifecycle.class/provisioning.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - Relationship5:
-      value: "/Infrastructure/Host/Provisioning/Profile/${/#user.normalized_ldap_group}#get_state_machine"
+      value: "/Infrastructure/Host/Provisioning/Profile/${/#miq_group.description}#get_state_machine"
   - Relationship6:
       value: "/Infrastructure/Host/Provisioning/StateMachines/${/#state_machine}/${/#miq_host_provision.provision_type}"

--- a/content/automate/ManageIQ/Infrastructure/VM/Lifecycle.class/migrate.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Lifecycle.class/migrate.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - Relationship5:
-      value: "/Infrastructure/VM/Migrate/Profile/${/#user.normalized_ldap_group}#get_state_machine"
+      value: "/Infrastructure/VM/Migrate/Profile/${/#miq_group.description}#get_state_machine"
   - Relationship6:
       value: "/Infrastructure/VM/Migrate/StateMachines/${/#state_machine}/default"

--- a/content/automate/ManageIQ/Infrastructure/VM/Lifecycle.class/provisioning.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Lifecycle.class/provisioning.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - Relationship5:
-      value: "/Infrastructure/VM/Provisioning/Profile/${/#user.normalized_ldap_group}#get_state_machine"
+      value: "/Infrastructure/VM/Provisioning/Profile/${/#miq_group.description}#get_state_machine"
   - Relationship6:
       value: "/Infrastructure/VM/Provisioning/StateMachines/${/#state_machine}/${/#miq_provision.provision_type}"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_created.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_created.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#user.normalized_ldap_group}#get_auto_approval_state_machine"
+      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#miq_group.description}#get_auto_approval_state_machine"
   - rel6:
       value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/StateMachines/${/#state_machine}/Default"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_created.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_created.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/${/#ae_provider_category}/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#user.normalized_ldap_group}#get_auto_approval_state_machine"
+      value: "/${/#ae_provider_category}/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#miq_group.description}#get_auto_approval_state_machine"
   - rel6:
       value: "/${/#ae_provider_category}/${/#miq_request.resource.ci_type}/Provisioning/StateMachines/${/#state_machine}/Default"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_updated.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_updated.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/${/#ae_provider_category}/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#user.normalized_ldap_group}#get_auto_approval_state_machine"
+      value: "/${/#ae_provider_category}/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#miq_group.description}#get_auto_approval_state_machine"
   - rel6:
       value: "/${/#ae_provider_category}/${/#miq_request.resource.ci_type}/Provisioning/StateMachines/${/#state_machine}/Default"

--- a/content/automate/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_created.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_created.yaml
@@ -11,6 +11,6 @@ object:
   - guard:
       value: "${/#miq_request.process}"
   - rel5:
-      value: "/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#user.normalized_ldap_group}#get_auto_approval_state_machine"
+      value: "/${/#miq_request.resource.ci_type}/Provisioning/Profile/${/#miq_group.description}#get_auto_approval_state_machine"
   - rel6:
       value: "/${/#miq_request.resource.ci_type}/Provisioning/StateMachines/${/#state_machine}/Default"

--- a/content/automate/ManageIQ/System/Request.class/service_provision_info.yaml
+++ b/content/automate/ManageIQ/System/Request.class/service_provision_info.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Service/Provisioning/Profile/${/#user.normalized_ldap_group}#${process#message}"
+      value: "/Service/Provisioning/Profile/${/#miq_group.description}#${process#message}"

--- a/content/automate/ManageIQ/System/Request.class/ui_configured_system_provision_info.yaml
+++ b/content/automate/ManageIQ/System/Request.class/ui_configured_system_provision_info.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/Configured_System/Provisioning/Profile/${/#user.normalized_ldap_group}#${process#message}"
+      value: "/Infrastructure/Configured_System/Provisioning/Profile/${/#miq_group.description}#${process#message}"

--- a/content/automate/ManageIQ/System/Request.class/ui_host_provision_info.yaml
+++ b/content/automate/ManageIQ/System/Request.class/ui_host_provision_info.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/Host/Provisioning/Profile/${/#user.normalized_ldap_group}#${process#message}"
+      value: "/Infrastructure/Host/Provisioning/Profile/${/#miq_group.description}#${process#message}"

--- a/content/automate/ManageIQ/System/Request.class/ui_provision_info.yaml
+++ b/content/automate/ManageIQ/System/Request.class/ui_provision_info.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/${/#ae_provider_category}/VM/Provisioning/Profile/${/#user.normalized_ldap_group}#${process#message}"
+      value: "/${/#ae_provider_category}/VM/Provisioning/Profile/${/#miq_group.description}#${process#message}"

--- a/content/automate/ManageIQ/System/Request.class/ui_vm_migrate_info.yaml
+++ b/content/automate/ManageIQ/System/Request.class/ui_vm_migrate_info.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/VM/Migrate/Profile/${/#user.normalized_ldap_group}#${process#message}"
+      value: "/Infrastructure/VM/Migrate/Profile/${/#miq_group.description}#${process#message}"


### PR DESCRIPTION
Need to pass the user's group in to automate when the provision starts.
User's current group might have changed before the provision finishes.
So the user's current group from DB may be different from the user's group when the request is sent into automate.

Part of https://github.com/ManageIQ/manageiq/pull/15696.
Depends on https://github.com/ManageIQ/manageiq-automation_engine/pull/61.

https://bugzilla.redhat.com/show_bug.cgi?id=1467364

@miq-bot add_label bug, euwe/yes, fine/yes