### PR TITLE
New refresh method callable from the automate

### DIFF
--- a/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: refresh
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: builtin
+  inputs:
+  - field:
+      aetype: 
+      name: target
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh_sync.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh_sync.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: refresh_sync
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: builtin
+  inputs:
+  - field:
+      aetype: 
+      name: target
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/System/event_handlers.class/refresh.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/refresh.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: refresh
+    inherits: 
+    description: 
+  fields:
+  - meth1:
+      value: refresh

--- a/content/automate/ManageIQ/System/event_handlers.class/refresh_sync.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/refresh_sync.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: refresh_sync
+    inherits: 
+    description: 
+  fields:
+  - meth1:
+      value: refresh_sync


### PR DESCRIPTION
New refresh method callable from the automate, it tries
to call targeted manager refresh if defined, otherwise fallback to
full refresh.

This is needed for invoking https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb#L101