### PR TITLE
Creating a template and stubbing get_source

### DIFF
--- a/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname_spec.rb
@@ -1,6 +1,7 @@
 require_domain_file
 
 describe ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName do
+  let(:template) { FactoryGirl.create(:template) }
   let(:provision) { MiqProvision.new }
   let(:root_object) { Spec::Support::MiqAeMockObject.new.tap { |ro| ro["miq_provision"] = provision } }
   let(:service) { Spec::Support::MiqAeMockService.new(root_object).tap { |s| s.object = {'vm_prefix' => "abc"} } }
@@ -15,8 +16,12 @@ describe ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName do
   let(:tag2) { FactoryGirl.create(:tag, :name => "/managed/environment/production") }
 
   context "#main" do
+    before do
+      allow(provision).to receive(:get_source).and_return(template)
+    end
+
     it "no vm name from dialog" do
-      provision.update_attributes(:options => {:number_of_vms => 200})
+      provision.update_attributes!(:options => {:number_of_vms => 200})
 
       described_class.new(service).main
 
@@ -24,7 +29,7 @@ describe ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName do
     end
 
     it "vm name from dialog" do
-      provision.update_attributes(:options => {:number_of_vms => 200, :vm_name => "drew"})
+      provision.update_attributes!(:options => {:number_of_vms => 200, :vm_name => "drew"})
 
       described_class.new(service).main
 
@@ -32,7 +37,7 @@ describe ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName do
     end
 
     it "use model and environment tag" do
-      provision.update_attributes(:options => {:number_of_vms => 200, :vm_tags => [classification2.id]})
+      provision.update_attributes!(:options => {:number_of_vms => 200, :vm_tags => [classification2.id]})
 
       described_class.new(service).main
 
@@ -40,7 +45,7 @@ describe ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName do
     end
 
     it "provisions single vm" do
-      provision.update_attributes(:options => {:number_of_vms => 1})
+      provision.update_attributes!(:options => {:number_of_vms => 1})
 
       described_class.new(service).main
 

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Naming.class/__methods__/vmname_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Naming.class/__methods__/vmname_spec.rb
@@ -1,6 +1,7 @@
 require_domain_file
 
 describe ManageIQ::Automate::Infrastructure::VM::Provisioning::Naming::VmName do
+  let(:template) { FactoryGirl.create(:template) }
   let(:provision) { MiqProvision.new }
   let(:root_object) { Spec::Support::MiqAeMockObject.new.tap { |ro| ro["miq_provision"] = provision } }
   let(:service) { Spec::Support::MiqAeMockService.new(root_object).tap { |s| s.object = {'vm_prefix' => "abc"} } }
@@ -15,8 +16,12 @@ describe ManageIQ::Automate::Infrastructure::VM::Provisioning::Naming::VmName do
   let(:tag2) { FactoryGirl.create(:tag, :name => "/managed/environment/production") }
 
   context "#main" do
+    before do
+      allow(provision).to receive(:get_source).and_return(template)
+    end
+
     it "no vm name from dialog" do
-      provision.update_attributes(:options => {:number_of_vms => 200})
+      provision.update_attributes!(:options => {:number_of_vms => 200})
 
       described_class.new(service).main
 
@@ -24,7 +29,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Provisioning::Naming::VmName do
     end
 
     it "vm name from dialog" do
-      provision.update_attributes(:options => {:number_of_vms => 200, :vm_name => "drew"})
+      provision.update_attributes!(:options => {:number_of_vms => 200, :vm_name => "drew"})
 
       described_class.new(service).main
 
@@ -32,7 +37,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Provisioning::Naming::VmName do
     end
 
     it "use model and environment tag" do
-      provision.update_attributes(:options => {:number_of_vms => 200, :vm_tags => [classification2.id]})
+      provision.update_attributes!(:options => {:number_of_vms => 200, :vm_tags => [classification2.id]})
 
       described_class.new(service).main
 
@@ -40,7 +45,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Provisioning::Naming::VmName do
     end
 
     it "provisions single vm" do
-      provision.update_attributes(:options => {:number_of_vms => 1})
+      provision.update_attributes!(:options => {:number_of_vms => 1})
 
       described_class.new(service).main
 


### PR DESCRIPTION
Allows the callbacks to correctly run when saving the `MiqProvision` object