### PR TITLE
Fix message when import fails

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__class__.yaml
@@ -128,8 +128,7 @@ object:
       condition: 
       on_entry: update_vm_import_status(status => 'Checking for VM Import completion')
       on_exit: update_vm_import_status(status => 'Waiting for VM Import completion')
-      on_error: update_vm_import_status(status => 'Error in checking for VM Import
-        completion')
+      on_error: update_vm_import_status(status => 'Error encountered during VM import')
       max_retries: '100'
       max_time: 
   - field:


### PR DESCRIPTION
This message is shown when the import of the VM fails (on the provider side)
even it's phrasing suggested that there was an error in checking for the task
completiton.

Changed the phrasing to make it clear that the check properly detected that the
import failed.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1473169