### PR TITLE
Set retry interval to 1 minute for generic service state-machine.

### DIFF
--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/check_completed.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/check_completed.rb
@@ -55,6 +55,7 @@ module ManageIQ
                   end
                 else
                   @handle.root['ae_result'] = 'retry'
+                  @handle.root['ae_retry_interval'] = 1.minute
                 end
               end
             end


### PR DESCRIPTION
Set ae_retry_interval to 1 minute in check_completed method.

https://bugzilla.redhat.com/show_bug.cgi?id=1478200

@miq-bot add_label bug, services, fine/yes
@miq-bot assign @gmcculloug