### PR TITLE
AWS DetachVolume event switchboard setting.

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/detachvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/detachvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: DetachVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
This PR will configure an event in the event switchboard for the Amazon EBS DetachVolume event.

### Testing:

- Add an AWS provider
- Identify a VM with an EBS cloud volume attached
- Through the AWS console, detach the volume from the VM 
- In the ManageIQ UI, make sure the volume is no longer attached to the VM. This will indicate an event was received and went through the event switchboard where an EMS refresh was kicked off.

### Links:

https://www.pivotaltracker.com/story/show/146650341
https://bugzilla.redhat.com/show_bug.cgi?id=1472975