### PR TITLE
fixed failing tests due to ManageIQ/manageiq-providers-ovirt#73

### DIFF
--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers_spec.rb
@@ -3,7 +3,7 @@ require_domain_file
 describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListInfraProviders do
   let!(:vmware)     { FactoryGirl.create(:ems_vmware) }
   let!(:old_redhat) { FactoryGirl.create(:ems_redhat_v3) }
-  let!(:new_redhat) { FactoryGirl.create(:ems_redhat_v4) }
+  let!(:new_redhat) { FactoryGirl.create(:ems_redhat_v4, :api_version => '4.1.5') }
 
   let(:root_object) { Spec::Support::MiqAeMockObject.new }
 


### PR DESCRIPTION
The tests have been broken by ManageIQ/manageiq-providers-ovirt#73
because the requirement for a api version have been strenghtened from 4.1+ to
4.1.5+.

Fixes: https://github.com/ManageIQ/manageiq-content/issues/165