### PR TITLE
v2v: Pre-check install_drivers checkbox for windows VMs

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
@@ -1,0 +1,34 @@
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class InstallDrivers
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                os = @handle.root['vm'].operating_system
+                is_windows = os.try(:product_name) =~ /windows/i
+                checkbox_values = {
+                  'value'     => is_windows ? 't' : 'f',
+                  'read_only' => false,
+                  'visible'   => true
+                }
+                checkbox_values.each do |key, value|
+                  @handle.object[key] = value
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::InstallDrivers.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: install_drivers
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/install_drivers.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/install_drivers.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: install_drivers
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: install_drivers

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers_spec.rb
@@ -1,0 +1,55 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::InstallDrivers do
+  let(:operating_system) { FactoryGirl.create(:operating_system, :product_name => os_name) }
+  let(:vm)               { FactoryGirl.create(:vm_vmware, :operating_system => operating_system) }
+  let(:svc_model_vm)     { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(vm.id) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(:vm => svc_model_vm)
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  context 'for windows VM' do
+    let(:os_name) { 'Windows 10' }
+
+    it 'should pre-check the checkbox' do
+      described_class.new(ae_service).main
+
+      expect(ae_service.object['value']).to eq('t')
+      expect(ae_service.object['read_only']).to eq(false)
+      expect(ae_service.object['visible']).to eq(true)
+    end
+  end
+
+  context 'for linux VM' do
+    let(:os_name) { 'RHEL 7' }
+
+    it 'should leave the checkbox unchecked' do
+      described_class.new(ae_service).main
+
+      expect(ae_service.object['value']).to eq('f')
+      expect(ae_service.object['read_only']).to eq(false)
+      expect(ae_service.object['visible']).to eq(true)
+    end
+  end
+
+  context 'for undefined OS' do
+    let(:operating_system) { nil }
+
+    it 'should leave the checkbox unchecked' do
+      described_class.new(ae_service).main
+
+      expect(ae_service.object['value']).to eq('f')
+      expect(ae_service.object['read_only']).to eq(false)
+      expect(ae_service.object['visible']).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Depends on fix to `Dialog#init_fields_with_values` (PR https://github.com/ManageIQ/manageiq/pull/15810)

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1472843