### PR TITLE
[wip]Change the way vm removal from provider is checked

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
@@ -27,7 +27,11 @@ module ManageIQ
               def check_removed_from_provider(vm)
                 @handle.root['ae_result'] = 'ok'
                 if vm.ext_management_system && @handle.get_state_var('vm_removed_from_provider')
-                  vm.refresh
+                  if vm.respond_to?(:exists_on_provider?)
+                    vm.exists_on_provider? ? vm.refresh : return
+                  else
+                    vm.refresh
+                  end
                   @handle.root['ae_result'] = 'retry'
                   @handle.root['ae_retry_interval'] = '60.seconds'
                 end


### PR DESCRIPTION
The vm removal was based on refresh failing with exception.
It is now based on an explicit check to validate if it exists on the provider or not.

This is part of a fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1478108
This depends on: https://github.com/ManageIQ/manageiq-automation_engine/pull/66