### PR TITLE
also log the name of the actual VM to simplify debugging

### DIFF
--- a/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_ip.rb
+++ b/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_ip.rb
@@ -18,7 +18,7 @@ class WaitForIP
   def check_ip_addr_available(vm)
     ip_list = vm.ipaddresses
     @handle.log(:info, "Current Power State #{vm.power_state}")
-    @handle.log(:info, "IP addresses for VM #{ip_list}")
+    @handle.log(:info, "IP addresses for VM #{vm.name}: #{ip_list}")
 
     if ip_list.empty?
       vm.refresh


### PR DESCRIPTION
with this little change, it is easier to debug for which VM we are waiting for. This can ease debugging, in particular if multiple playbooks run in parallel.