### PR TITLE
Remove input for new refresh method

### DIFF
--- a/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh.yaml
@@ -9,24 +9,4 @@ object:
     scope: instance
     language: ruby
     location: builtin
-  inputs:
-  - field:
-      aetype: 
-      name: target
-      display_name: 
-      datatype: string
-      priority: 1
-      owner: 
-      default_value: 
-      substitute: true
-      message: create
-      visibility: 
-      collect: 
-      scope: 
-      description: 
-      condition: 
-      on_entry: 
-      on_exit: 
-      on_error: 
-      max_retries: 
-      max_time: 
+  inputs: []

--- a/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh_sync.yaml
+++ b/content/automate/ManageIQ/System/event_handlers.class/__methods__/refresh_sync.yaml
@@ -9,24 +9,4 @@ object:
     scope: instance
     language: ruby
     location: builtin
-  inputs:
-  - field:
-      aetype: 
-      name: target
-      display_name: 
-      datatype: string
-      priority: 1
-      owner: 
-      default_value: 
-      substitute: true
-      message: create
-      visibility: 
-      collect: 
-      scope: 
-      description: 
-      condition: 
-      on_entry: 
-      on_exit: 
-      on_error: 
-      max_retries: 
-      max_time: 
+  inputs: []


### PR DESCRIPTION
Remove input for new refresh method, since there is a validation
requiring this input and we use this method without parameters
for now.