### PR TITLE
Do targeted refresh in Stack check provisioned

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -47,10 +47,15 @@ module ManageIQ
 
               def refresh_provider(service)
                 provider = service.orchestration_manager
+                stack    = service.orchestration_stack
 
-                @handle.log("info", "Refreshing provider #{provider.name}")
+                @handle.log("info", "Refreshing provider '#{provider.name}' and stack '#{stack.name}'")
                 @handle.set_state_var('provider_last_refresh', provider.last_refresh_date.to_i)
-                provider.refresh
+                refreshed_stack = @handle.vmdb(:orchestration_stack).find_by(:name    => stack.name,
+                                                                             :ems_ref => stack.ems_ref)
+                if refreshed_stack
+                  refreshed_stack.refresh
+                end
               end
 
               def refresh_may_have_completed?(service)

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -51,11 +51,7 @@ module ManageIQ
 
                 @handle.log("info", "Refreshing provider '#{provider.name}' and stack '#{stack.name}'")
                 @handle.set_state_var('provider_last_refresh', provider.last_refresh_date.to_i)
-                refreshed_stack = @handle.vmdb(:orchestration_stack).find_by(:name    => stack.name,
-                                                                             :ems_ref => stack.ems_ref)
-                if refreshed_stack
-                  refreshed_stack.refresh
-                end
+                @handle.vmdb(:orchestration_stack).refresh(provider.id, stack.ems_ref)
               end
 
               def refresh_may_have_completed?(service)


### PR DESCRIPTION
Do targeted refresh in Stack check provisioned, if targeted
refresh is allowed.

Needs PRs:
- [x] https://github.com/ManageIQ/manageiq-automation_engine/pull/68
- [x] https://github.com/ManageIQ/manageiq/pull/15936