### PR TITLE
Add basic events handlers for AWS

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_allocateaddress.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_allocateaddress.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_AllocateAddress
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_applysecuritygroupstoloadbalancer.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_applysecuritygroupstoloadbalancer.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_ApplySecurityGroupsToLoadBalancer
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_assignprivateipaddresses.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_assignprivateipaddresses.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_AssignPrivateIpAddresses
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_associateaddress.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_associateaddress.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_AssociateAddress
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_attachnetworkinterface.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_attachnetworkinterface.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_AttachNetworkInterface
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_attachvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_attachvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_AttachVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_authorizesecuritygroupingress.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_authorizesecuritygroupingress.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_AuthorizeSecurityGroupIngress
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_configurehealthcheck.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_configurehealthcheck.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_ConfigureHealthCheck
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_copysnapshot.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_copysnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CopySnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createimage.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createimage.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: CreateSnapshot
+    name: AWS_API_CALL_CreateImage
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createinternetgateway.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createinternetgateway.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateInternetGateway
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createloadbalancer.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createloadbalancer.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateLoadBalancer
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createloadbalancerlisteners.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createloadbalancerlisteners.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateLoadBalancerListeners
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createnetworkinterface.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createnetworkinterface.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateNetworkInterface
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createsecuritygroup.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createsecuritygroup.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateSecurityGroup
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createsnapshot.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createsnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateSnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createstack.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createstack.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateStack
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createsubnet.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createsubnet.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateSubnet
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createtags.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createtags.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateTags
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_CreateVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createvpc.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createvpc.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: DeleteVolume
+    name: AWS_API_CALL_CreateVpc
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deleteloadbalancer.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deleteloadbalancer.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DeleteLoadBalancer
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletesecuritygroup.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletesecuritygroup.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DeleteSecurityGroup
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletesnapshot.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletesnapshot.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: DetachVolume
+    name: AWS_API_CALL_DeleteSnapshot
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletestack.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletestack.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DeleteStack
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletesubnet.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletesubnet.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DeleteSubnet
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletetags.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletetags.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DeleteTags
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletevolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deletevolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DeleteVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deregisterinstancesfromloadbalancer.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deregisterinstancesfromloadbalancer.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DeregisterInstancesFromLoadBalancer
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_detachnetworkinterface.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_detachnetworkinterface.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DetachNetworkInterface
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_detachvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_detachvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_DetachVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_disassociateaddress.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_disassociateaddress.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: DeleteSnapshot
+    name: AWS_API_CALL_DisassociateAddress
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifyloadbalancerattributes.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifyloadbalancerattributes.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_ModifyLoadBalancerAttributes
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifynetworkinterfaceattribute.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifynetworkinterfaceattribute.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_ModifyNetworkInterfaceAttribute
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_rebootinstances.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_rebootinstances.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_RebootInstances
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_registerimage.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_registerimage.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_RegisterImage
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_registerinstanceswithloadbalancer.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_registerinstanceswithloadbalancer.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_RegisterInstancesWithLoadBalancer
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_releaseaddress.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_releaseaddress.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_ReleaseAddress
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_runinstances.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_runinstances.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_RunInstances
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_setloadbalancerpoliciesoflistener.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_setloadbalancerpoliciesoflistener.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_SetLoadBalancerPoliciesOfListener
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_signalresource.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_signalresource.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_SignalResource
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_startinstances.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_startinstances.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_StartInstances
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_stopinstances.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_stopinstances.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: CopySnapshot
+    name: AWS_API_CALL_StopInstances
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_terminateinstances.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_terminateinstances.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_TerminateInstances
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_unassignprivateipaddresses.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_unassignprivateipaddresses.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_API_CALL_UnassignPrivateIpAddresses
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_cloudformation_stack_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_cloudformation_stack_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_CloudFormation_Stack_CREATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_cloudformation_stack_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_cloudformation_stack_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_CloudFormation_Stack_DELETE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_eip_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_eip_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_EIP_CREATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_eip_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_eip_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_EIP_DELETE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_eip_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_eip_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_EIP_UPDATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_instance_stopping.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_instance_stopping.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_Instance_stopping
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_networkinterface_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_networkinterface_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_NetworkInterface_CREATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_networkinterface_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_networkinterface_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_NetworkInterface_DELETE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_networkinterface_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_networkinterface_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_NetworkInterface_UPDATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_securitygroup_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_securitygroup_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_SecurityGroup_CREATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_securitygroup_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_securitygroup_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_SecurityGroup_DELETE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_securitygroup_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_securitygroup_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_SecurityGroup_UPDATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_subnet_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_subnet_delete.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: AttachVolume
+    name: AWS_EC2_Subnet_DELETE
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_subnet_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_subnet_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_Subnet_UPDATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_volume_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_volume_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_Volume_CREATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_volume_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_volume_delete.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: CreateVolume
+    name: AWS_EC2_Volume_DELETE
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_volume_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_volume_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_Volume_UPDATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_vpc_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_vpc_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AWS_EC2_VPC_UPDATE
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_pending.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_pending.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EC2_Instance_State_change_Notification_pending
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_running.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_running.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EC2_Instance_State_change_Notification_running
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_shutting-down.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_shutting-down.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EC2_Instance_State_change_Notification_shutting-down
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_stopped.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_stopped.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EC2_Instance_State_change_Notification_stopped
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_stopping.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_stopping.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EC2_Instance_State_change_Notification_stopping
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_terminated.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/ec2_instance_state_change_notification_terminated.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EC2_Instance_State_change_Notification_terminated
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"


### PR DESCRIPTION
Add basic events handlers for AWS, containing events from
AWS Config, CloudWatch EC2 and CloudWatch with CloudTrail for
API call events.