### PR TITLE
Fixed typo in Service Retirement method.

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
@@ -32,7 +32,7 @@ updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if 
 # Update Status for on_error for all states other than the first state which is start retirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'
-  if step.downcase == 'start retirement'
+  if step.downcase == 'startretirement'
     msg = 'Cannot continue because Service is '
     msg += service ? "#{service.retirement_state}." : 'nil.'
     $evm.log('info', msg)


### PR DESCRIPTION
update_service_retirement_status method had incorrect step name.

This caused a problem when trying to retire a service that is already in the process of being retired.

https://bugzilla.redhat.com/show_bug.cgi?id=1440972

@miq-bot add_label bug, services, fine/yes
@miq-bot assign @gmcculloug