### PR TITLE
v2v: Extend 'VM Transform' dialog to select VMs by tag

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
@@ -15,9 +15,10 @@ module ManageIQ
 
               def main
                 validate_root_args(%w(vm dialog_provider dialog_cluster dialog_storage dialog_sparse))
-                if !@handle.root['dialog_tag_category'].empty? && !@handle.root['dialog_tag_name'].empty?
+                if @handle.root['dialog_tag_category'].present? && @handle.root['dialog_tag_name'].present?
                   tag = "/#{@handle.root['dialog_tag_category']}/#{@handle.root['dialog_tag_name']}"
-                  tagged_vms = @handle.vmdb(:vm).find_tagged_with(:all => tag, :ns => '/managed')
+                  tagged_vms = @handle.vmdb('ManageIQ_Providers_Vmware_InfraManager_Vm')
+                                      .find_tagged_with(:all => tag, :ns => '/managed')
                   tagged_vms.each do |vm|
                     create_request(vm, '')
                   end
@@ -43,7 +44,7 @@ module ManageIQ
                   :message       => 'create',
                   :attrs         => {
                     'Vm::vm'      => vm.id,
-                    'name'        => target_name.empty? ? vm.name : target_name,
+                    'name'        => target_name.present? ? target_name : vm.name,
                     'provider_id' => @handle.root['dialog_provider'],
                     'cluster_id'  => @handle.root['dialog_cluster'],
                     'storage_id'  => @handle.root['dialog_storage'],

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
@@ -14,27 +14,16 @@ module ManageIQ
               end
 
               def main
-                validate_root_args %w(vm dialog_name dialog_provider dialog_cluster dialog_storage dialog_sparse)
-
-                options = {
-                  :namespace     => 'Infrastructure/VM/Transform/StateMachines',
-                  :class_name    => 'VmImport',
-                  :instance_name => 'default',
-                  :message       => 'create',
-                  :attrs         => {
-                    'Vm::vm'      => @handle.root['vm'].id,
-                    'name'        => @handle.root['dialog_name'],
-                    'provider_id' => @handle.root['dialog_provider'],
-                    'cluster_id'  => @handle.root['dialog_cluster'],
-                    'storage_id'  => @handle.root['dialog_storage'],
-                    'sparse'      => @handle.root['dialog_sparse'],
-                    'drivers_iso' => @handle.root['dialog_install_drivers'] && @handle.root['dialog_drivers_iso']
-                  },
-                  :user_id       => @handle.root['user'].id
-                }
-
-                auto_approve = true
-                @handle.execute('create_automation_request', options, @handle.root['user'].userid, auto_approve)
+                validate_root_args %w(vm dialog_provider dialog_cluster dialog_storage dialog_sparse)
+                if not @handle.root['dialog_tag_category'].empty? and not @handle.root['dialog_tag_name'].empty?
+                  tag = "/#{@handle.root['dialog_tag_category']}/#{@handle.root['dialog_tag_name']}"
+                  tagged_vms = @handle.vmdb(:vm).find_tagged_with(:all => tag, :ns => '/managed')
+                  tagged_vms.each do |vm|
+                    create_request(vm, '')
+                  end
+                else
+                  create_request(@handle.root['vm'], @handle.root['dialog_name'])
+                end
               end
 
               def validate_root_args(arg_names)
@@ -44,6 +33,28 @@ module ManageIQ
                   @handle.log(:error, msg)
                   raise msg
                 end
+              end
+
+              def create_request(vm, target_name)
+                options = {
+                    :namespace     => 'Infrastructure/VM/Transform/StateMachines',
+                    :class_name    => 'VmImport',
+                    :instance_name => 'default',
+                    :message       => 'create',
+                    :attrs         => {
+                        'Vm::vm'      => vm.id,
+                        'name'        => target_name.empty? ? vm.name : target_name,
+                        'provider_id' => @handle.root['dialog_provider'],
+                        'cluster_id'  => @handle.root['dialog_cluster'],
+                        'storage_id'  => @handle.root['dialog_storage'],
+                        'sparse'      => @handle.root['dialog_sparse'],
+                        'drivers_iso' => @handle.root['dialog_install_drivers'] && @handle.root['dialog_drivers_iso']
+                    },
+                    :user_id       => @handle.root['user'].id
+                }
+
+                auto_approve = true
+                @handle.execute('create_automation_request', options, @handle.root['user'].userid, auto_approve)
               end
             end
           end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
@@ -14,8 +14,8 @@ module ManageIQ
               end
 
               def main
-                validate_root_args %w(vm dialog_provider dialog_cluster dialog_storage dialog_sparse)
-                if not @handle.root['dialog_tag_category'].empty? and not @handle.root['dialog_tag_name'].empty?
+                validate_root_args(%w(vm dialog_provider dialog_cluster dialog_storage dialog_sparse))
+                if !@handle.root['dialog_tag_category'].empty? && !@handle.root['dialog_tag_name'].empty?
                   tag = "/#{@handle.root['dialog_tag_category']}/#{@handle.root['dialog_tag_name']}"
                   tagged_vms = @handle.vmdb(:vm).find_tagged_with(:all => tag, :ns => '/managed')
                   tagged_vms.each do |vm|
@@ -37,20 +37,20 @@ module ManageIQ
 
               def create_request(vm, target_name)
                 options = {
-                    :namespace     => 'Infrastructure/VM/Transform/StateMachines',
-                    :class_name    => 'VmImport',
-                    :instance_name => 'default',
-                    :message       => 'create',
-                    :attrs         => {
-                        'Vm::vm'      => vm.id,
-                        'name'        => target_name.empty? ? vm.name : target_name,
-                        'provider_id' => @handle.root['dialog_provider'],
-                        'cluster_id'  => @handle.root['dialog_cluster'],
-                        'storage_id'  => @handle.root['dialog_storage'],
-                        'sparse'      => @handle.root['dialog_sparse'],
-                        'drivers_iso' => @handle.root['dialog_install_drivers'] && @handle.root['dialog_drivers_iso']
-                    },
-                    :user_id       => @handle.root['user'].id
+                  :namespace     => 'Infrastructure/VM/Transform/StateMachines',
+                  :class_name    => 'VmImport',
+                  :instance_name => 'default',
+                  :message       => 'create',
+                  :attrs         => {
+                    'Vm::vm'      => vm.id,
+                    'name'        => target_name.empty? ? vm.name : target_name,
+                    'provider_id' => @handle.root['dialog_provider'],
+                    'cluster_id'  => @handle.root['dialog_cluster'],
+                    'storage_id'  => @handle.root['dialog_storage'],
+                    'sparse'      => @handle.root['dialog_sparse'],
+                    'drivers_iso' => @handle.root['dialog_install_drivers'] && @handle.root['dialog_drivers_iso']
+                  },
+                  :user_id       => @handle.root['user'].id
                 }
 
                 auto_approve = true

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
@@ -10,8 +10,12 @@ module ManageIQ
               end
 
               def main
-                os = @handle.root['vm'].operating_system
-                is_windows = os.try(:product_name) =~ /windows/i
+                if not @handle.root['vm'].nil?
+                  os = @handle.root['vm'].operating_system
+                  is_windows = os.try(:product_name) =~ /windows/i
+                else
+                  is_windows = false
+                end
                 checkbox_values = {
                   'value'     => is_windows ? 't' : 'f',
                   'read_only' => false,

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
@@ -10,7 +10,7 @@ module ManageIQ
               end
 
               def main
-                if not @handle.root['vm'].nil?
+                if !@handle.root['vm'].nil?
                   os = @handle.root['vm'].operating_system
                   is_windows = os.try(:product_name) =~ /windows/i
                 else

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories.rb
@@ -1,0 +1,43 @@
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class ListTagCategories
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                multi_vm = @handle.root['vm'].nil?
+
+                values_hash = {}
+                values_hash[nil] = '<None>'
+
+                if multi_vm
+                  categories = @handle.vmdb(:classification).categories
+                  categories.each do |category|
+                    values_hash[category.name] = category.description
+                  end
+                end
+                list_values = {
+                  'sort_by'   => :description,
+                  'data_type' => :string,
+                  'required'  => false,
+                  'visible'   => multi_vm,
+                  'values'    => values_hash
+                }
+                list_values.each { |key, value| @handle.object[key] = value }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagCategories.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: list_tag_categories
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
@@ -17,11 +17,13 @@ module ManageIQ
 
                 if multi_vm
                   category_name = @handle.root['dialog_tag_category']
-                  @handle.log(:info, "Selected tag category: #{category_name}")
-                  category = @handle.vmdb(:classification).find_by_name(category_name)
-                  unless category.nil?
-                    category.entries.each do |tag|
-                      values_hash[tag.name] = tag.description
+                  if category_name.present?
+                    @handle.log(:info, "Selected tag category: #{category_name}")
+                    category = @handle.vmdb(:classification).find_by_name(category_name)
+                    unless category.nil?
+                      category.entries.each do |tag|
+                        values_hash[tag.name] = tag.description
+                      end
                     end
                   end
                 end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
@@ -18,7 +18,7 @@ module ManageIQ
                 if multi_vm
                   category_name = @handle.root['dialog_tag_category']
                   @handle.log(:info, "Selected tag category: #{category_name}")
-                  category = @handle.vmdb(:classification).find_by(:name => category_name)
+                  category = @handle.vmdb(:classification).find_by_name(category_name)
                   unless category.nil?
                     category.entries.each do |tag|
                       values_hash[tag.name] = tag.description

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
@@ -18,7 +18,7 @@ module ManageIQ
                 if multi_vm
                   category_name = @handle.root['dialog_tag_category']
                   @handle.log(:info, "Selected tag category: #{category_name}")
-                  category = @handle.vmdb(:classification).find_by_name(category_name)
+                  category = @handle.vmdb(:classification).find_by(:name => category_name)
                   unless category.nil?
                     category.entries.each do |tag|
                       values_hash[tag.name] = tag.description

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
@@ -1,0 +1,47 @@
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class ListTagNames
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                multi_vm = @handle.root['vm'].nil?
+
+                values_hash = {}
+                values_hash[nil] = '<None>'
+
+                if multi_vm
+                  category_name = @handle.root['dialog_tag_category']
+                  @handle.log(:info, "Selected tag category: #{category_name}")
+                  category = @handle.vmdb(:classification).find_by_name(category_name)
+                  unless category.nil?
+                    category.entries.each do |tag|
+                      values_hash[tag.name] = tag.description
+                    end
+                  end
+                end
+                list_values = {
+                  'sort_by'   => :description,
+                  'data_type' => :string,
+                  'required'  => false,
+                  'visible'   => multi_vm,
+                  'values'    => values_hash
+                }
+                list_values.each { |key, value| @handle.object[key] = value }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: list_tag_names
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name.rb
@@ -1,0 +1,32 @@
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Transform
+          module Import
+            class ShowName
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                multi_vm = @handle.root['vm'].nil?
+
+                input_values = {
+                  'data_type' => :string,
+                  'required'  => false,
+                  'visible'   => !multi_vm,
+                }
+                input_values.each { |key, value| @handle.object[key] = value }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ShowName.new.main
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: show_name
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_tag_categories.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_tag_categories.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: list_tag_categories
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: list_tag_categories

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_tag_names.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/list_tag_names.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: list_tag_names
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: list_tag_names

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/show_name.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/show_name.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: show_name
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: show_name

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories_spec.rb
@@ -1,0 +1,41 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagCategories do
+  let(:provider) { FactoryGirl.create(:ems_redhat) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(
+        'dialog_provider' => provider.id.to_s
+    )
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  def create_tags
+    FactoryGirl.create(:classification_department_with_tags)
+  end
+
+  it 'should return list of categories' do
+    create_tags
+
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['sort_by']).to eq(:description)
+    expect(ae_service.object['data_type']).to eq(:string)
+    expect(ae_service.object['required']).to eq(false)
+    expect(ae_service.object['visible']).to eq(true)
+
+    categories = { nil => '<None>' }
+    Classification.categories.each do |category|
+      categories[category.name] = category.description
+    end
+
+    expect(ae_service.object['values']).to eq(categories)
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagCateg
 
   let(:root_object) do
     Spec::Support::MiqAeMockObject.new(
-        'dialog_provider' => provider.id.to_s
+      'dialog_provider' => provider.id.to_s
     )
   end
 

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
@@ -4,10 +4,10 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames
   let(:provider) { FactoryGirl.create(:ems_redhat) }
 
   let(:root_object) do
-    Spec::Support::MiqAeMockObject.new({
-        'dialog_provider' => provider.id.to_s,
-        'dialog_tag_category' => 'department'
-    })
+    Spec::Support::MiqAeMockObject.new(
+      'dialog_provider' => provider.id.to_s,
+      'dialog_tag_category' => 'department'
+    )
   end
 
   let(:ae_service) do
@@ -32,7 +32,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames
     expect(ae_service.object['required']).to eq(false)
     expect(ae_service.object['visible']).to eq(true)
 
-    tag_names = { nil => '<Noe>' }
+    tag_names = { nil => '<None>' }
     Classification.find_by_name('department').entries.each do |tag|
       tag_names[tag.name] = tag.description
     end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
@@ -1,0 +1,42 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames do
+  let(:provider) { FactoryGirl.create(:ems_redhat) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new({
+        'dialog_provider' => provider.id.to_s,
+        'dialog_tag_category' => 'department'
+    })
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  def create_tags
+    FactoryGirl.create(:classification_department_with_tags)
+  end
+
+  it 'should return list of categories' do
+    create_tags
+
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['sort_by']).to eq(:description)
+    expect(ae_service.object['data_type']).to eq(:string)
+    expect(ae_service.object['required']).to eq(false)
+    expect(ae_service.object['visible']).to eq(true)
+
+    tag_names = { nil => '<Noe>' }
+    Classification.find_by_name('department').entries.each do |tag|
+      tag_names[tag.name] = tag.description
+    end
+
+    expect(ae_service.object['values']).to eq(tag_names)
+  end
+end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames
 
   let(:root_object) do
     Spec::Support::MiqAeMockObject.new(
-      'dialog_provider' => provider.id.to_s,
+      'dialog_provider'     => provider.id.to_s,
       'dialog_tag_category' => 'department'
     )
   end

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name_spec.rb
@@ -1,0 +1,37 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ShowName do
+  let(:provider) { FactoryGirl.create(:ems_redhat) }
+
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new(
+      'dialog_provider' => provider.id.to_s
+    )
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it 'should hide name field if VM is not set' do
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['data_type']).to eq(:string)
+    expect(ae_service.object['required']).to eq(false)
+    expect(ae_service.object['visible']).to eq(false)
+  end
+
+  it 'should show name field if VM is set' do
+    ae_service.root['vm'] = Spec::Support::MiqAeMockObject.new
+
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['data_type']).to eq(:string)
+    expect(ae_service.object['required']).to eq(false)
+    expect(ae_service.object['visible']).to eq(true)
+  end
+end


### PR DESCRIPTION
Added tag category and tag name fields to the 'VM Transform' dialog to
be able to select VMs for V2V by tag. Hide these fields if the dialog is
open from VM details view. Hide VM name input field if the dialog is
open from VM list view. Start several V2V requests if several VMs are
selected by tag.

Depends on https://github.com/ManageIQ/manageiq-providers-ovirt/pull/115
Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/2501