### PR TITLE
Calculate quota using service dialogs overrides.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -27,7 +27,7 @@ def get_total_requested(options_hash, prov_option)
 end
 
 def request_totals(template_totals, dialog_totals)
-  [template_totals, dialog_totals].max
+  dialog_totals.positive? ? dialog_totals : template_totals
 end
 
 def collect_template_totals(prov_option)
@@ -195,7 +195,38 @@ end
 
 def collect_dialog_totals(prov_option, options_hash)
   dialog_values(prov_option, options_hash, dialog_array = [])
-  collect_totals(dialog_array)
+  total = collect_totals(dialog_array)
+  if prov_option == :number_of_cpus
+    options_hash.each do |_sequence_id, options|
+      if options.keys.include?(:number_of_sockets) || options.keys.include?(:cores_per_socket)
+        $evm.log(:info, "Recalculating number of cpus based on dialog overrides")
+        total = recalculate_number_of_cpus(service_resource, options[:number_of_sockets].to_i, options[:cores_per_socket].to_i)
+      end
+    end
+  end
+  total
+end
+
+def service_resource
+  resource = nil
+  @service_template.service_resources.each do |child_service_resource|
+    next if @service_template.service_type == 'composite'
+    next if @service_template.prov_type.starts_with?("generic")
+    resource = child_service_resource.resource
+  end
+  resource
+end
+
+def recalculate_number_of_cpus(resource, override_number_of_sockets, override_cores_per_socket)
+  $evm.log(:info, "Recalculating the number_of_cpus resource: #{resource} override_number_of_sockets: #{override_number_of_sockets} override_cores_per_socket: #{override_cores_per_socket}")
+  if override_number_of_sockets.positive? && override_cores_per_socket.positive?
+    cpu_in_request = override_number_of_sockets * override_cores_per_socket
+  elsif override_number_of_sockets.positive?
+    cpu_in_request = get_option_value(resource, :cores_per_socket) * override_number_of_sockets
+  elsif override_cores_per_socket.positive?
+    cpu_in_request = get_option_value(resource, :number_of_sockets) * override_cores_per_socket
+  end
+  cpu_in_request * get_option_value(resource, :number_of_vms) if cpu_in_request.to_i.positive?
 end
 
 def dialog_values(prov_option, options_hash, dialog_array)

--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -115,7 +115,7 @@ describe "Quota Validation" do
 
   context "vmware service item with dialog override number_of_vms = 5" do
     let(:result_counts_hash) do
-      {:storage => 512.megabytes, :cpu => 4, :vms => 5, :memory => 1.gigabytes}
+      {:storage => 2560.megabytes, :cpu => 20, :vms => 5, :memory => 5.gigabytes}
     end
     let(:result_dialog) do
       {"dialog_option_0_number_of_vms" => "5"}
@@ -129,6 +129,16 @@ describe "Quota Validation" do
     end
     let(:result_dialog) do
       {"dialog_option_0_storage" => "2147483648"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override number_of_vms = 5, sockets = 3 and cores = 4 = 12" do
+    let(:result_counts_hash) do
+      {:storage => 2560.megabytes, :cpu => 60, :vms => 5, :memory => 5.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_vms" => "5", "dialog_option_0_number_of_sockets" => "3", "dialog_option_0_cores_per_socket" => "4"}
     end
     it_behaves_like "requested"
   end
@@ -196,7 +206,7 @@ describe "Quota Validation" do
       :disk_add => [{"disk_size_in_mb" => "10", "persistent" => true, "thin_provisioned" => true,\
       "dependent" => true, "bootable" => false}]})
       ws = run_automate_method(reconfigure_attrs)
-      check_results(ws.root['quota_requested'], 10.megabytes, 2, 0, 4096.megabytes)
+      check_results(ws.root['quota_requested'], 10.megabytes, 2, 1, 4096.megabytes)
     end
 
     it "minus 1 cpu and minus 2048 memory" do
@@ -204,7 +214,7 @@ describe "Quota Validation" do
       @reconfigure_request.update_attributes(:options => {:src_ids => [@vm_vmware.id], :cores_per_socket => 1,\
       :number_of_sockets => 1, :number_of_cpus => 1, :vm_memory => 2048, :request_type => :vm_reconfigure})
       ws = run_automate_method(reconfigure_attrs)
-      check_results(ws.root['quota_requested'], 0, -1, 0, -2048.megabytes)
+      check_results(ws.root['quota_requested'], 0, -1, 1, -2048.megabytes)
     end
 
     it "no change" do
@@ -212,7 +222,7 @@ describe "Quota Validation" do
       @reconfigure_request.update_attributes(:options => {:src_ids => [@vm_vmware.id], :cores_per_socket => 2,\
       :number_of_sockets => 1, :number_of_cpus => 2, :vm_memory => 4096, :request_type => :vm_reconfigure})
       ws = run_automate_method(reconfigure_attrs)
-      check_results(ws.root['quota_requested'], 0, 0, 0, 0.megabytes)
+      check_results(ws.root['quota_requested'], 0, 0, 1, 0.megabytes)
     end
   end
 end

--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -50,6 +50,89 @@ describe "Quota Validation" do
     end
   end
 
+  shared_examples_for "requested" do
+    it "check" do
+      setup_model("vmware")
+      build_small_environment
+      build_vmware_service_item
+      @service_request.options[:dialog] = result_dialog
+      @service_request.save
+      expect(@service_request.options[:dialog]).to include(result_dialog)
+      ws = run_automate_method(service_attrs)
+      expect(ws.root['quota_requested']).to include(result_counts_hash)
+    end
+  end
+
+  context "vmware service item with dialog override number_of_sockets = 3" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 6, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_sockets" => "3"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override cores_per_socket = 4" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 8, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_cores_per_socket" => "4"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override sockets = 3 and cores = 4 = 12" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 12, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_sockets" => "3", "dialog_option_0_cores_per_socket" => "4"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override number_of_cpus = 5" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 5, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_cpus" => "5"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override vm_memory = 2147483648" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 4, :vms => 1, :memory => 2.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_vm_memory" => "2147483648"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override number_of_vms = 5" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 4, :vms => 5, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_vms" => "5"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override storage = 2147483648" do
+    let(:result_counts_hash) do
+      {:storage => 2.gigabytes, :cpu => 4, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_storage" => "2147483648"}
+    end
+    it_behaves_like "requested"
+  end
+
   context "Service Bundle provisioning quota" do
     it "Bundle of 2, google and vmware" do
       create_service_bundle([google_template, vmware_template])


### PR DESCRIPTION
Changed requested method to use dialog overrides in quota calculations.

Modified requested method to calculate quota based on dialog values for:
number_of_sockets, cores_per_socket, number_of_cpus, vm_memory and storage.

This can be tested by using service dialogs using these values.

https://bugzilla.redhat.com/show_bug.cgi?id=1497912

Testing

Create a service using service dialog overrides values for the above values.
You can use one or more override values.
Order the service, change some values and run.

Note: Latest commit added quota calculations for number_of_vms in a service dialog for Infrastructure. 

I am including screenshots of a dialog using some values.
<img width="903" alt="test_dialog 1" src="https://user-images.githubusercontent.com/11841651/32008165-8b6fdcb6-b979-11e7-8835-c3ff74625156.png">

<img width="1098" alt="test_dialog 2" src="https://user-images.githubusercontent.com/11841651/32008178-93806c72-b979-11e7-928d-813c9a8ae39e.png">
