### PR TITLE
Ability to retire a service from service dialog

### DIFF
--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -235,6 +235,14 @@ def parsed_dialog_information
   return merged_options_hash, merged_tags_hash
 end
 
+def service_retires_on_date(dialog_options_hash)
+  service_retires_on_date = dialog_options_hash.fetch(:service_retires_on, nil)
+  unless service_retires_on_date.nil?
+    @service.retires_on = service_retires_on_date unless service_retires_on_date.nil?
+    log_and_update_message(:info, "Service retires on: #{service_retires_on_date}")
+  end
+end
+
 begin
 
   @task = $evm.root['service_template_provision_task']
@@ -247,6 +255,7 @@ begin
   unless dialog_options_hash.blank?
     override_service_name(dialog_options_hash)
     override_service_description(dialog_options_hash)
+    service_retires_on_date(dialog_options_hash)
   end
 
   unless dialog_tags_hash.blank?


### PR DESCRIPTION
As per[1] we can retire a service but including 'service_retire_on' in
service dialog still needs customization in Automate. This is
discussed in [2].

I think ManageIQ Domain should handle 'service_retire_on' dialog
option by default. This will save creating a custom domain just to
fetch 'service_retire_on' value from service catalog.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1300428
[2] http://talk.manageiq.org/t/services-retirement-date/786/2

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1506712