### PR TITLE
Use proper request_task subclass for provisioning spec.

### DIFF
--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::
   let(:orchestration_stack)   { FactoryGirl.create(:orchestration_stack_amazon, :name => "name", :outputs => [output]) }
 
   let(:miq_request_task) do
-    FactoryGirl.create(:miq_request_task,
+    FactoryGirl.create(:service_template_provision_task,
                        :destination => service_orchestration,
                        :miq_request => request)
   end


### PR DESCRIPTION
Only the ServiceTemplateProvisionTask model exposes the provision_priority method.

Required now that https://github.com/ManageIQ/manageiq/pull/16299 references the `provision_priority` property of ServiceTemplateProvisionTask.

Causing test failures.  Ref https://travis-ci.org/ManageIQ/manageiq-content/jobs/294782150