### PR TITLE
v2v: Storage mapping for mass migration

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
@@ -13,30 +13,67 @@ module ManageIQ
                 @handle = handle
               end
 
+              def initialize_storage_map(provider_id)
+                @storage_map = {}
+                provider = @handle.vmdb(:ext_management_system, provider_id)
+                return unless provider.present?
+                provider.storages.each do |storage|
+                  tag = storage_mapping_tag(storage)
+                  next unless tag.present?
+                  raise_error("Error, several storages are tagged with tag #{tag}") if @storage_map.key?(tag)
+                  @storage_map[tag] = storage.id
+                  @handle.log(:info, "Storage with tag #{tag} is mapped to target storage #{storage.name}")
+                end
+              end
+
               def main
-                validate_root_args(%w(vm dialog_provider dialog_cluster dialog_storage dialog_sparse))
+                validate_root_args(%w(dialog_provider dialog_cluster dialog_sparse))
                 if @handle.root['dialog_tag_category'].present? && @handle.root['dialog_tag_name'].present?
                   tag = "/#{@handle.root['dialog_tag_category']}/#{@handle.root['dialog_tag_name']}"
                   tagged_vms = @handle.vmdb('ManageIQ_Providers_Vmware_InfraManager_Vm')
                                       .find_tagged_with(:all => tag, :ns => '/managed')
+                  initialize_storage_map(@handle.root['dialog_provider'])
                   tagged_vms.each do |vm|
-                    create_request(vm, '')
+                    target_storage_id = nil
+                    if vm.storage.present?
+                      tag = storage_mapping_tag(vm.storage)
+                      raise_error("Error, cannot determine the target storage for storage #{vm.storage.name} without tag") unless tag.present?
+                      target_storage_id = @storage_map[tag]
+                      raise_error("Error, no target storage with tag #{tag}") unless target_storage_id.present?
+                    end
+                    create_request(vm, '', target_storage_id)
                   end
                 else
-                  create_request(@handle.root['vm'], @handle.root['dialog_name'])
+                  validate_root_args(%w(vm dialog_storage))
+                  create_request(@handle.root['vm'], @handle.root['dialog_name'], @handle.root['dialog_storage'])
                 end
+              end
+
+              def raise_error(msg)
+                @handle.log(:error, msg)
+                raise msg
               end
 
               def validate_root_args(arg_names)
                 arg_names.each do |name|
                   next if @handle.root[name].present?
-                  msg = "Error, required root attribute: #{name} not found"
-                  @handle.log(:error, msg)
-                  raise msg
+                  raise_error("Error, required root attribute: #{name} not found")
                 end
               end
 
-              def create_request(vm, target_name)
+              def storage_mapping_tag(storage)
+                return nil unless storage.tags.present?
+
+                tag = nil
+                storage.tags.each do |t|
+                  next unless t.start_with?("storage_mapping/")
+                  raise_error("Error, storage #{storage.name} is tagged with several mapping tags") if tag.present?
+                  tag = t
+                end
+                tag
+              end
+
+              def create_request(vm, target_name, storage_id)
                 options = {
                   :namespace     => 'Infrastructure/VM/Transform/StateMachines',
                   :class_name    => 'VmImport',
@@ -47,7 +84,7 @@ module ManageIQ
                     'name'        => target_name.present? ? target_name : vm.name,
                     'provider_id' => @handle.root['dialog_provider'],
                     'cluster_id'  => @handle.root['dialog_cluster'],
-                    'storage_id'  => @handle.root['dialog_storage'],
+                    'storage_id'  => storage_id,
                     'sparse'      => @handle.root['dialog_sparse'],
                     'drivers_iso' => @handle.root['dialog_install_drivers'] && @handle.root['dialog_drivers_iso']
                   },

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
@@ -10,25 +10,29 @@ module ManageIQ
               end
 
               def main
+                multi_vm = @handle.root['vm'].nil?
+
                 values_hash = {}
                 values_hash[nil] = '-- select storage from list --'
 
-                provider_id = @handle.root['dialog_provider']
-                @handle.log(:info, "Selected provider: #{provider_id}")
-                if provider_id.present? && provider_id != '!'
-                  provider = @handle.vmdb(:ext_management_system, provider_id)
-                  if provider.nil?
-                    values_hash[nil] = 'None'
-                  else
-                    provider.storages.each do |storage|
-                      values_hash[storage.id] = storage.name
+                unless multi_vm
+                  provider_id = @handle.root['dialog_provider']
+                  if provider_id.present? && provider_id != '!'
+                    provider = @handle.vmdb(:ext_management_system, provider_id)
+                    if provider.nil?
+                      values_hash[nil] = 'None'
+                    else
+                      provider.storages.each do |storage|
+                        values_hash[storage.id] = storage.name
+                      end
                     end
                   end
                 end
                 list_values = {
                   'sort_by'   => :description,
                   'data_type' => :string,
-                  'required'  => true,
+                  'required'  => !multi_vm,
+                  'visible'   => !multi_vm,
                   'values'    => values_hash
                 }
                 list_values.each { |key, value| @handle.object[key] = value }


### PR DESCRIPTION
When migrating several VMs, user must tag a source storage and the
corresponding target storage with a tag from `storage_mapping` category.
With the help of these tags, `CreateVmImportRequest` will automatically
detect the target storage for each VM instead of using one target
storage for all VMs as it happens currently.