### PR TITLE
Add policy resolution call to vm_destroy for providers.

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_instance_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_instance_delete.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualmachines_delete_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualmachines_delete_endrequest.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/destroyvm_task_complete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/destroyvm_task_complete.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: 
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/src_vm_disconnect_storage"
   - rel5:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Google.class/gceoperationdone_compute.instances.delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Google.class/gceoperationdone_compute.instances.delete.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/compute.instance.delete.end.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/compute.instance.delete.end.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm.yaml
@@ -8,7 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/event_action_refresh?target=src_vm"
-  - rel5:
-      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_unregister&param="

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
@@ -11,6 +11,6 @@ object:
   - rel4:
       value: "/System/event_handlers/src_vm_disconnect_storage"
   - rel5:
-      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_unregister&param="
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel6:
       value: "/System/event_handlers/event_action_refresh?target=src_vm"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_template_finished.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_template_finished.yaml
@@ -8,7 +8,7 @@ object:
     inherits: 
     description: 
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/event_action_refresh?target=src_vm"
-  - rel5:
-      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_unregister&param="

--- a/content/automate/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-delete.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: A virtual machine was deleted.
   fields:
+  - rel3:
+      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
       value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
vm_destroy is the policy event raised when a VM is deleted from disk from VMware side.
vm_unregister is the policy event raised when a VM is removed from inventory from VMware side.

Add vm_destroy call for all providers. 

Seems VMware is the only one which has the option to remove VM from inventory besides delete VM from disk. @agrare @bronaghs, is it right? 

Part of https://github.com/ManageIQ/manageiq/pull/16557.

https://bugzilla.redhat.com/show_bug.cgi?id=1506520

@miq-bot add_label bug, fine/yes, gaprindashvili/yes