### PR TITLE
Force full refresh for router based events

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_associateroutetable.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_associateroutetable.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createroute.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createroute.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createroutetable.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_createroutetable.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deleteroute.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deleteroute.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deleteroutetable.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_deleteroutetable.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_disassociateroutetable.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_disassociateroutetable.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_replaceroutetableassociation.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_replaceroutetableassociation.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_routetable_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_routetable_create.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_routetable_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_routetable_delete.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_routetable_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_ec2_routetable_update.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/refresh"
+      value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
Force full refresh for router based events. We are not able to
do targeted refresh for routers, until we have changes that will
land for h-release

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1518826