### PR TITLE
Removed the schema values for PreDeleteFromProvider.

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
@@ -178,7 +178,7 @@ object:
       datatype: string
       priority: 9
       owner: 
-      default_value: "#/Cloud/VM/Retirement/StateMachines/Methods/PreDeleteFromProvider"
+      default_value: 
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
@@ -198,7 +198,7 @@ object:
       datatype: string
       priority: 10
       owner: 
-      default_value: "#/Infrastructure/VM/Retirement/StateMachines/Methods/PreDeleteFromProvider"
+      default_value: 
       substitute: true
       message: create
       visibility: 


### PR DESCRIPTION
Removed the schema values for PreDeleteFromProvider in /Infrastructure and /Cloud VM retirement state machine classes.

The Infrastructure/cloud vm retirement state machines have a commented out entry for predeletefromprovider which could (and did) give users the impression they can uncomment it for additional functionality which is not the case.

https://bugzilla.redhat.com/show_bug.cgi?id=1518858