### PR TITLE
Only data storage domains in VM transform dialog

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
@@ -23,7 +23,7 @@ module ManageIQ
                       values_hash[nil] = 'None'
                     else
                       provider.storages.each do |storage|
-                        values_hash[storage.id] = storage.name
+                        values_hash[storage.id] = storage.name if storage.storage_domain_type == "data"
                       end
                     end
                   end


### PR DESCRIPTION
In VM transform dialog allow to select only data storage domains as the
destination of VM transformation.

Depends on https://github.com/ManageIQ/manageiq/pull/16719

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1516706