### PR TITLE
Check for both owner email and requester email for user quota.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #
 # Description: calculate entity used quota values
 #
@@ -23,8 +24,12 @@ module ManageIQ
               quota_used = consumption(quota_source)
               @handle.log("info", "Quota Used: #{quota_used.inspect}")
 
-              quota_active = active_provision_counts
-              @handle.log("info", "Quota #{active_method_name}: #{quota_active.inspect}")
+              quota_source_type = root_quota_source_type
+              @handle.log("info", "Quota source type: #{quota_source_type}")
+
+              validate_user_email if quota_source_type == 'user'
+              quota_active = active_provision_counts(quota_source_type)
+              @handle.log("info", "Quota #{active_method_name(quota_source_type)}: #{quota_active.inspect}")
 
               merge_counts(quota_used, quota_active)
             end
@@ -32,6 +37,11 @@ module ManageIQ
             def quota_source
               raise "ERROR - quota_source not found" unless @handle.root['quota_source']
               @handle.root['quota_source']
+            end
+
+            def root_quota_source_type
+              raise "ERROR - quota_source_type not found" unless @handle.root['quota_source_type']
+              @handle.root['quota_source_type'].downcase
             end
 
             def consumption(source)
@@ -44,14 +54,20 @@ module ManageIQ
               }
             end
 
-            def active_method_name
-              quota_source = @handle.root['quota_source_type'].downcase
-              source = quota_source == 'user' ? 'owner' : quota_source
+            def active_method_name(quota_source_type)
+              source = quota_source_type == 'user' ? 'owner' : quota_source_type
               "active_provisions_by_#{source}".to_sym
             end
 
-            def active_provision_counts
-              active_provisions = @handle.root['miq_request'].check_quota(active_method_name)
+            def validate_user_email
+              email = @handle.root['miq_request'].get_option(:owner_email) || @handle.root['miq_request'].requester.email
+              return if email.present?
+              @handle.log(:error, "Owner email not specified for User Quota")
+              raise "ERROR - Owner email not specified for User Quota"
+            end
+
+            def active_provision_counts(quota_source_type)
+              active_provisions = @handle.root['miq_request'].check_quota(active_method_name(quota_source_type))
               {:cpu                 => active_provisions[:cpu],
                :memory              => active_provisions[:memory],
                :vms                 => active_provisions[:count],
@@ -70,6 +86,6 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
+if $PROGRAM_NAME == __FILE__
   ManageIQ::Automate::System::CommonMethods::QuotaMethods::Used.new.main
 end


### PR DESCRIPTION
Changed used method to check for owner email or requester email when quota is set to user.
Previously the method was only looking for owner_email and when that wasn't available we encountered an error.

The method now will raise an error if both are not found.  If you are running a service provision which doesn't allow a requester email
and the user doesn't have an email address, we will raise this error:

ERROR - Owner email not specified for User Quota

Added tests for all possible email values for user quota.

https://bugzilla.redhat.com/show_bug.cgi?id=1509977