### PR TITLE
Added a retry_interval to VM Migrate state machine.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration.rb
@@ -37,6 +37,7 @@ module ManageIQ
                   reason = reason[7..-1] if reason[0..6] == 'Error: '
                   @handle.root['ae_reason'] = reason
                 when 'retry'
+                  @handle.root['ae_retry_interval'] = 1.minute
                   @handle.root['ae_result'] = 'retry'
                 when 'ok'
                   # Bump State

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration_spec.rb
@@ -25,57 +25,69 @@ describe ManageIQ::Automate::Infrastructure::VM::Migrate::StateMachines::Checkmi
     end
   end
 
-  shared_examples_for "#task_status" do
-    it "check" do
-      miq_request_task.update_attributes(:state => state, :status => status)
-      allow(ae_service).to receive(:inputs) { {'state' => state} }
-      described_class.new(ae_service).main
-      expect(ae_service.root['ae_result']).to eq(return_status)
+  context "checks for state and status" do
+    let(:interval) { nil }
+
+    shared_examples_for "#task_status" do
+      it "checks for return_status and interval" do
+        miq_request_task.update_attributes(:state => state, :status => status)
+        allow(ae_service).to receive(:inputs) { {'state' => state} }
+        described_class.new(ae_service).main
+        expect(ae_service.root['ae_result']).to eq(return_status)
+        expect(ae_service.root['ae_retry_interval']).to eq(interval)
+      end
+    end
+
+    context "returns 'ok' if state finished and status Ok" do
+      let(:return_status) { "ok" }
+      let(:state) { "finished" }
+      let(:status) { "Ok" }
+
+      it_behaves_like "#task_status"
+    end
+
+    context "returns 'ok' if state migrated and status Ok" do
+      let(:return_status) { "ok" }
+      let(:state) { "migrated" }
+      let(:status) { "Ok" }
+
+      it_behaves_like "#task_status"
+    end
+
+    context "returns 'retry' if state pending and status Ok" do
+      let(:return_status) { "retry" }
+      let(:state) { "pending" }
+      let(:status) { "Ok" }
+      let(:interval) { 1.minute }
+
+      it_behaves_like "#task_status"
+    end
+
+    context "returns 'retry' if state pending and status Error" do
+      let(:return_status) { "retry" }
+      let(:state) { "pending" }
+      let(:status) { "Error" }
+      let(:interval) { 1.minute }
+
+      it_behaves_like "#task_status"
+    end
+
+    context "returns 'error' if state finished and status Error" do
+      let(:return_status) { "error" }
+      let(:state) { "finished" }
+      let(:status) { "Error" }
+
+      it_behaves_like "#task_status"
+    end
+
+    context "returns 'error' if state migrated and status Error" do
+      let(:return_status) { "error" }
+      let(:state) { "migrated" }
+      let(:status) { "Error" }
+
+      it_behaves_like "#task_status"
     end
   end
-
-  context "returns 'ok' if state finished and status Ok" do
-    let(:return_status) { "ok" }
-    let(:state) { "finished" }
-    let(:status) { "Ok" }
-    it_behaves_like "#task_status"
-  end
-
-  context "returns 'ok' if state migrated and status Ok" do
-    let(:return_status) { "ok" }
-    let(:state) { "migrated" }
-    let(:status) { "Ok" }
-    it_behaves_like "#task_status"
-  end
-
-  context "returns 'retry' if state pending and status Ok" do
-    let(:return_status) { "retry" }
-    let(:state) { "pending" }
-    let(:status) { "Ok" }
-    it_behaves_like "#task_status"
-  end
-
-  context "returns 'retry' if state pending and status Error" do
-    let(:return_status) { "retry" }
-    let(:state) { "pending" }
-    let(:status) { "Error" }
-    it_behaves_like "#task_status"
-  end
-
-  context "returns 'error' if state finished and status Error" do
-    let(:return_status) { "error" }
-    let(:state) { "finished" }
-    let(:status) { "Error" }
-    it_behaves_like "#task_status"
-  end
-
-  context "returns 'error' if state migrated and status Error" do
-    let(:return_status) { "error" }
-    let(:state) { "migrated" }
-    let(:status) { "Error" }
-    it_behaves_like "#task_status"
-  end
-
   context "with no vm" do
     let(:root_hash) { {} }
 


### PR DESCRIPTION
Added ae_retry_interval of 1 minute to CheckMigration method for /Infrastructure/VM/Migrate/StateMachines/Methods.
This will cause the state machine to wait 1 minute after a retry to try again.
Updated test to include interval value.

https://bugzilla.redhat.com/show_bug.cgi?id=1527985