### PR TITLE
Add cloud_subnets to availability zone test

### DIFF
--- a/spec/automation/unit/method_validation/google_auto_placement_spec.rb
+++ b/spec/automation/unit/method_validation/google_auto_placement_spec.rb
@@ -31,7 +31,7 @@ describe "GOOGLE best fit" do
 
   it "provision task object auto placement for cloud network" do
     MiqServer.seed
-    cloud_subnet
+    availability_zone.cloud_subnets << cloud_subnet
     ws.root
 
     expect(miq_provision.reload.options).to include(


### PR DESCRIPTION
Previously, cloud network list was only updated after selection of security group, or change of tab, or a select set of other actions that completely voided the list of parameters passed to the filtering method. This adds a change so that availability zone updates the selection of cloud network, preventing incorrect cloud networks from showing up in the after the zone dropdown changes. This issue was fixed in https://github.com/ManageIQ/manageiq/pull/16688. The google provider test broke because the availability zone wasn't set up to have any subnets which was exposed because of the filtering changes in 16688. This should fix that by adding a network manager to the existing test ems, forcing the ems to not return a nil on the cloud subnet association. 

## Related to:
https://github.com/ManageIQ/manageiq/pull/16811
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518847