### PR TITLE
Add event state machine for refresh.

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/reconfigvm_task_complete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/reconfigvm_task_complete.yaml
@@ -9,6 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh_sync?target=src_vm"
-  - rel5:
-      value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_reconfigure&param="
+      value: "/System/Event/StateMachines/Refresh/default?refresh_target=src_vm&policy_event=vm_reconfigure&policy_target=src_vm"

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__class__.yaml
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__class__.yaml
@@ -1,0 +1,133 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Refresh State Machine
+    display_name: 
+    name: Refresh
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: pre
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: ''
+      on_exit: ''
+      on_error: ''
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: refresh
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: check_refreshed
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: post
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: ''
+      on_exit: ''
+      on_error: ''
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: policy
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: finished
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.rb
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.rb
@@ -1,0 +1,64 @@
+#
+# Description: This method checks the refresh completion.
+#
+
+module ManageIQ
+  module Automate
+    module System
+      module Event
+        module StateMachines
+          module Refresh
+            class CheckRefreshed
+              STATE_FINISHED = 'Finished'.freeze
+              STATUS_OK = 'Ok'.freeze
+
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                check_status(refresh_task)
+              end
+
+              private
+
+              def check_status(task)
+                case task.state
+                when STATE_FINISHED
+                  if task.status == STATUS_OK
+                    @handle.root['ae_result'] = 'ok'
+                  else
+                    @handle.root['ae_result'] = 'error'
+                    @handle.log(:error, "Refresh task ended with error: #{task.message}")
+                  end
+                else
+                  @handle.root['ae_result'] = 'retry'
+                  @handle.root['ae_retry_interval'] = '1.minute'
+                end
+              end
+
+              def refresh_task
+                task_id = @handle.get_state_var(:refresh_task_id).first
+                @handle.log(:info, "Stored refresh task ID: [#{task_id}]")
+                fetch_task(task_id)
+              end
+
+              def fetch_task(task_id)
+                @handle.vmdb(:miq_task).find_by(:id => task_id).tap do |task|
+                  if task.nil?
+                    @handle.log(:error, "Refresh task with id: #{task_id} not found")
+                    raise "Refresh task with id: #{task_id} not found"
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::System::Event::StateMachines::Refresh::CheckRefreshed.new.main
+end

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.yaml
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: check_refreshed
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.rb
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.rb
@@ -1,0 +1,51 @@
+#
+# Description: This method starts a synchronous refresh and save the
+#              task id in the state variables so we can use it when
+#              waiting for the refresh to finish.
+#
+
+module ManageIQ
+  module Automate
+    module System
+      module Event
+        module StateMachines
+          module Refresh
+            class TargetRefresh
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                task_id = event.refresh(refresh_target, true)
+                raise "Refresh task not created" if task_id.blank?
+                @handle.set_state_var(:refresh_task_id, task_id)
+              end
+
+              private
+
+              def event
+                @handle.root["event_stream"].tap do |event|
+                  if event.nil?
+                    @handle.log(:error, 'Event object is nil')
+                    raise 'Event object not found'
+                  end
+                end
+              end
+
+              def refresh_target
+                @handle.object["refresh_target"].tap do |target|
+                  @handle.log(:info, "Refresh target: [#{target}]")
+                  raise "Refresh target not found" if target.nil?
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::System::Event::StateMachines::Refresh::TargetRefresh.new.main
+end

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.yaml
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: target_refresh
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/default.yaml
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/default.yaml
@@ -1,0 +1,16 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: default
+    inherits: 
+    description: 
+  fields:
+  - refresh:
+      value: METHOD::target_refresh
+  - check_refreshed:
+      value: METHOD::check_refreshed
+  - policy:
+      value: "/System/event_handlers/event_action_policy?target=${#policy_target}&policy_event=${#policy_event}&param="

--- a/content/automate/ManageIQ/System/Event/StateMachines/__namespace__.yaml
+++ b/content/automate/ManageIQ/System/Event/StateMachines/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: StateMachines
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/spec/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed_spec.rb
+++ b/spec/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed_spec.rb
@@ -1,0 +1,44 @@
+require_domain_file
+
+describe ManageIQ::Automate::System::Event::StateMachines::Refresh::CheckRefreshed do
+  let(:event) { FactoryGirl.create(:event_stream) }
+  let(:task)  { FactoryGirl.create(:miq_task) }
+
+  let(:svc_event) { MiqAeMethodService::MiqAeServiceEventStream.find(event.id) }
+  let(:svc_task)  { MiqAeMethodService::MiqAeServiceMiqTask.find(task.id) }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(Spec::Support::MiqAeMockObject.new({})).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = Spec::Support::MiqAeMockObject.new({})
+      service.object = current_object
+    end
+  end
+
+  it 'when task is finished with "ok"' do
+    ae_service.set_state_var(:refresh_task_id, [task.id])
+    task.update_attributes(:state => 'Finished')
+    described_class.new(ae_service).main
+    expect(ae_service.root['ae_result']).to eq('ok')
+  end
+
+  it 'when task is finished with "error"' do
+    ae_service.set_state_var(:refresh_task_id, [task.id])
+    task.update_attributes(:state => 'Finished', :status => 'Timeout')
+    described_class.new(ae_service).main
+    expect(ae_service.root['ae_result']).to eq('error')
+  end
+
+  it 'when task is active' do
+    ae_service.set_state_var(:refresh_task_id, [task.id])
+    task.update_attributes(:state => 'Active')
+    described_class.new(ae_service).main
+    expect(ae_service.root['ae_result']).to eq('retry')
+    expect(ae_service.root['ae_retry_interval']).to eq('1.minute')
+  end
+
+  it 'when specified task does not exist' do
+    ae_service.set_state_var(:refresh_task_id, [99])
+    expect { described_class.new(ae_service).main }.to raise_error('Refresh task with id: 99 not found')
+  end
+end

--- a/spec/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh_spec.rb
+++ b/spec/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh_spec.rb
@@ -1,0 +1,34 @@
+require_domain_file
+
+describe ManageIQ::Automate::System::Event::StateMachines::Refresh::TargetRefresh do
+  let(:ems)         { FactoryGirl.create(:ems_vmware) }
+  let(:vm)          { FactoryGirl.create(:vm_vmware, :ext_management_system => ems) }
+  let(:event)       { FactoryGirl.create(:ems_event, :vm_or_template => vm) }
+  let(:svc_event)   { MiqAeMethodService::MiqAeServiceEventStream.find(event.id) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new('event_stream' => event) }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      service.object = Spec::Support::MiqAeMockObject.new('refresh_target' => 'src_vm')
+    end
+  end
+
+  it 'when event object is not found' do
+    ae_service.root['event_stream'] = nil
+    expect { described_class.new(ae_service).main }.to raise_error(RuntimeError, "Event object not found")
+  end
+
+  it 'when refresh target is specified' do
+    described_class.new(ae_service).main
+    expect(ae_service.get_state_var(:refresh_task_id)).to be_truthy
+  end
+
+  it 'when refresh target is not specified' do
+    ae_service.object['refresh_target'] = nil
+    expect { described_class.new(ae_service).main }.to raise_error(RuntimeError, "Refresh target not found")
+  end
+
+  it 'when specified target does not exist' do
+    ae_service.object['refresh_target'] = 'src_host'
+    expect { described_class.new(ae_service).main }.to raise_error(RuntimeError, "Refresh task not created")
+  end
+end


### PR DESCRIPTION
This event state machine replaces the builtin method event_action_refresh_sync that waits for the completion of refresh and hence blocks the worker. 

Part of https://github.com/ManageIQ/manageiq/pull/16868.
https://bugzilla.redhat.com/show_bug.cgi?id=1534631

@miq-bot add_label bug,  fine/yes, gaprindashvili/yes

cc @mkanoor @gmcculloug @tinaafitz 