### PR TITLE
[GAPRINDASHVILI] Support symlinked spec directories (for testing client Automate domains)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/manageiq
 /spec/reports/
 /tmp/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -34,32 +34,29 @@ Now you are ready to begin development.  You can run the specs with
 
 Please be sure to add specs for any new automate methods you create, and follow
 the [ManageIQ development guidelines](https://github.com/ManageIQ/guides/blob/master/coding_style_and_standards.md).
-Thanks for your contribution!
+
 
 ## Testing your own Automate Domain
 
 It is possible to test your own ManageIQ Automate Domain methods leveraging this framework.
 
-Individual Automate methods need to be converted to the [Class Style](https://github.com/ManageIQ/manageiq-content/issues/8), and
-tests written.
+Individual Automate methods need to be converted to the [Class Style](https://github.com/ManageIQ/manageiq-content/issues/8), and tests written.
 
 1. In `content/automate/` symlink in the top of your exported Automate domain
 2. In `spec/content/automate` symlink in to the top of your _spec.rb tree (which matches above)
+3. In `spec/factories` symlink in to the top of a directory of helpers/factories of share test doubles.
 
 ### Embedded Method Testing & Mocking
 
-For Automate "Methods" intended to be Embedded Methods, the ruby code, to be both available for use in
-Automate, and testable here, requires additional decorations, as does the calling Automate code.
+For Automate "Methods" intended to be Embedded Methods, the ruby code, to be both available for use in Automate, and testable here, requires additional decorations, as does the calling Automate code.
 
-1. The Embedded Method methods are Module methods (other languages would call them "static"), that not
-attached to a (ruby) Class
-2. The calling Automate Method, in the `class` definition can `include` the full name of the Embedded "method"
-3. The Embedded Method developer should provide required mock/stub/double factories
-4. The Embedded Method developer should also provide reasonable test coverage of their Methods
+1. The Embedded Method methods are Module methods (other languages would call them "static"), that not attached to a (ruby) Class.
+2. The calling Automate Method, in the `class` definition can `include` the full name of the Embedded "method", making the Embedded Method a ruby _mixin_.
+3. The Embedded Method developer should provide required mock/stub/double factories.
+4. The Embedded Method developer should also provide reasonable test coverage of their Methods.
 
-   The Embedded Method _spec will need to create a concrete, if dummy, Class to test Module methods.
-5. By convention, the mock/stub/double factories live in `spec/factories`, so symlink in to the top directory of
-all "factories" or other helpers you have.
+   For testing the Embedded Method _spec.rb, you will need to create a concrete, if dummy, Class to test Module methods.
+5. By convention, the mock/stub/double factories live in `spec/factories`, so symlink in to the top directory of all "factories" or other helpers you have.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ Please be sure to add specs for any new automate methods you create, and follow
 the [ManageIQ development guidelines](https://github.com/ManageIQ/guides/blob/master/coding_style_and_standards.md).
 Thanks for your contribution!
 
+## Testing your own Automate Domain
+
+It is possible to test your own ManageIQ Automate Domain methods leveraging this framework.
+
+Individual Automate methods need to be converted to the [Class Style](https://github.com/ManageIQ/manageiq-content/issues/8), and
+tests written.
+
+1. In `content/automate/` symlink in the top of your exported Automate domain
+2. In `spec/content/automate` symlink in to the top of your _spec.rb tree (which matches above)
+
+### Embedded Method Testing & Mocking
+
+For Automate "Methods" intended to be Embedded Methods, the ruby code, to be both available for use in
+Automate, and testable here, requires additional decorations, as does the calling Automate code.
+
+1. The Embedded Method methods are Module methods (other languages would call them "static"), that not
+attached to a (ruby) Class
+2. The calling Automate Method, in the `class` definition can `include` the full name of the Embedded "method"
+3. The Embedded Method developer should provide required mock/stub/double factories
+4. The Embedded Method developer should also provide reasonable test coverage of their Methods
+
+   The Embedded Method _spec will need to create a concrete, if dummy, Class to test Module methods.
+5. By convention, the mock/stub/double factories live in `spec/factories`, so symlink in to the top directory of
+all "factories" or other helpers you have.
+
+
 ## License
 
 The gem is available as open source under the terms of the [Apache License 2.0](LICENSE.txt).

--- a/lib/tasks_private/spec.rake
+++ b/lib/tasks_private/spec.rake
@@ -6,5 +6,7 @@ end
 RSpec::Core::RakeTask.new(:spec => ["app:test:initialize", "app:evm:compile_sti_loader"]) do |t|
   spec_dir = File.expand_path("../../spec", __dir__)
   EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
-  t.pattern = FileList[spec_dir + '/**/*_spec.rb'].exclude(spec_dir + '/manageiq/**/*_spec.rb')
+  # allow for including symlink'd automate domains
+  t.pattern = FileList[spec_dir + '/automation/**/*_spec.rb', spec_dir + '/content/automate/**{,/*/**}/*_spec.rb']
+              .exclude(spec_dir + '/manageiq/**/*_spec.rb').uniq!
 end

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::
   let(:orchestration_stack)   { FactoryGirl.create(:orchestration_stack_amazon, :name => "name", :outputs => [output]) }
 
   let(:miq_request_task) do
-    FactoryGirl.create(:miq_request_task,
+    FactoryGirl.create(:service_template_provision_task,
                        :destination => service_orchestration,
                        :miq_request => request)
   end

--- a/spec/factories/Cflab
+++ b/spec/factories/Cflab
@@ -1,0 +1,1 @@
+/home/jwarnica/Projects/manageiq-content-sample-tests/factories/Cflab

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ end
 
 Dir[ManageIQ::AutomationEngine::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
 
+Dir[__dir__ + "/../spec/factories/**{,/*/**}/*.rb"].each { |f| require f }
+
 RSpec.configure do |config|
   config.include Spec::Support::AutomationHelper
 


### PR DESCRIPTION
In working on testing some custom automate code, I noticed that the rake tasks were not picking up on symlinks into _spec.rb locations. This seems to allow that.