### PR TITLE
[FINE] Remove the options hash which is new in version 5.9.

### DIFF
--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.yaml
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.yaml
@@ -9,5 +9,4 @@ object:
     scope: instance
     language: ruby
     location: inline
-    options: {}
   inputs: []

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.yaml
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.yaml
@@ -9,5 +9,4 @@ object:
     scope: instance
     language: ruby
     location: inline
-    options: {}
   inputs: []


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/17081.
Follow up of https://github.com/ManageIQ/manageiq-content/pull/243.

https://bugzilla.redhat.com/show_bug.cgi?id=1550725

@miq-bot add_label bug, fine/yes