### PR TITLE
Refactoring cloud vm retirement start_retirement method 

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -1,30 +1,64 @@
 #
 # Description: This method sets the retirement_state to retiring
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module VM
+        module Retirement
+          module StateMachines
+            module Methods
+              class StartRetirement
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-$evm.log("info", "Listing Root Object Attributes:")
-$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
-$evm.log("info", "===========================================")
+                def main
+                  log_info
+                  @vm = @handle.root['vm']
+                  vm_validation
+                  start_retirement
+                end
 
-vm = $evm.root['vm']
-if vm.nil?
-  $evm.log('error', "VM Object not found")
-  exit MIQ_ABORT
+                private
+
+                def log_info
+                  @handle.log("info", "Listing Root Object Attributes:")
+                  @handle.root.attributes.sort.each { |k, v| @handle.log("info", "\t#{k}: #{v}") }
+                  @handle.log("info", "===========================================")
+                end
+
+                def vm_validation
+                  if @vm.nil?
+                    raise 'VM Object not found'
+                  end
+
+                  if @vm.retired?
+                    raise 'VM is already retired'
+                  end
+
+                  if @vm.retiring?
+                    raise 'VM is already in the process of being retired'
+                  end
+                end
+
+                def start_retirement
+                  @handle.log('info', "VM before start_retirement: #{@vm.inspect} ")
+                  @handle.create_notification(:type => :vm_retiring, :subject => @vm)
+
+                  @vm.start_retirement
+
+                  @handle.log('info', "VM after start_retirement: #{@vm.inspect} ")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end
 
-if vm.retired?
-  $evm.log('error', "VM is already retired. Aborting current State Machine.")
-  exit MIQ_ABORT
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::StartRetirement.new.main
 end
-
-if vm.retiring?
-  $evm.log('error', "VM is in the process of being retired. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
-$evm.log('info', "VM before start_retirement: #{vm.inspect} ")
-$evm.create_notification(:type => :vm_retiring, :subject => vm)
-
-vm.start_retirement
-
-$evm.log('info', "VM after start_retirement: #{vm.inspect} ")

--- a/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
@@ -1,0 +1,39 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::StartRetirement do
+  let(:svc_vm)      { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+  let(:ems)         { FactoryGirl.create(:ems_vmware) }
+  let(:vm)          { FactoryGirl.create(:vm_vmware, :ems_id => ems.id) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:root_hash)   { { 'vm' => svc_vm } }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "without vm" do
+    ae_service.root['vm'] = nil
+    expect { described_class.new(ae_service).main }.to raise_error('VM Object not found')
+  end
+
+  it "with retired vm" do
+    svc_vm.finish_retirement
+    expect { described_class.new(ae_service).main }.to raise_error('VM is already retired')
+  end
+
+  it "with retiring vm" do
+    svc_vm.start_retirement
+    expect { described_class.new(ae_service).main }.to raise_error('VM is already in the process of being retired')
+  end
+
+  it "starts retirement" do
+    allow(ae_service).to receive(:create_notification)
+    expect(ae_service).to receive(:create_notification).with(:type => :vm_retiring, :subject => svc_vm)
+    expect(svc_vm).to receive(:start_retirement)
+    expect { described_class.new(ae_service).main }.to_not raise_error
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb method with spec. This PR is based on the issue bellow.

Links
-------------------
#8

@miq-bot add_label refactoring