### PR TITLE
Add Azure events for targeted refresh

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/images_delete_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/images_delete_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: images_delete_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/loadbalancers_delete_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/loadbalancers_delete_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: loadBalancers_delete_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/locks_delete_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/locks_delete_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: locks_delete_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/locks_write_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/locks_write_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: locks_write_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/networksecuritygroups_delete_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/networksecuritygroups_delete_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: networkSecurityGroups_delete_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/networksecuritygroups_securityrules_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/networksecuritygroups_securityrules_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: networkSecurityGroups_securityRules_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/publicipaddresses_delete_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/publicipaddresses_delete_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: publicIPAddresses_delete_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualmachines_generalize_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualmachines_generalize_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: virtualMachines_generalize_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualnetworks_delete_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualnetworks_delete_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: virtualNetworks_delete_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualnetworks_subnets_endrequest.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Azure.class/virtualnetworks_subnets_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: virtualNetworks_subnets_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"


### PR DESCRIPTION
Provide automated refresh on events which are recognized by `event_target_parser` in Azure.

Related to: https://github.com/ManageIQ/manageiq-providers-azure/pull/222
