### PR TITLE
Add changes for service, vm retire request approval

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__class__.yaml
@@ -1,0 +1,73 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: RetirementRequestApproval
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: approval_type
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: auto
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: ValidateRequest
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: validate_request
+      on_exit: 
+      on_error: pending_request
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: ApproveRequest
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: approve_request
+      on_exit: 
+      on_error: pending_request
+      max_retries: '100'
+      max_time: 

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.rb
@@ -1,0 +1,14 @@
+#
+# Description: This method is executed when the provisioning request is auto-approved
+#
+
+# Auto-Approve request
+$evm.log("info", "Checking for auto_approval")
+approval_type = $evm.object['approval_type'].downcase
+if approval_type == 'auto'
+  $evm.log("info", "AUTO-APPROVING")
+  $evm.root["miq_request"].approve("admin", "Auto-Approved")
+else
+  $evm.log("info", "Not Auto-Approved")
+  exit MIQ_ABORT
+end

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: approve_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.rb
@@ -1,0 +1,10 @@
+#
+# Description: This method is executed when the provisioning request is NOT auto-approved
+#
+
+# Get objects
+msg = $evm.object['reason']
+$evm.log('info', msg.to_s)
+
+# Raise automation event: request_pending
+$evm.root["miq_request"].pending

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: pending_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.rb
@@ -1,0 +1,3 @@
+#
+# Description: Placeholder for service request validation
+#

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: validate_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/default.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/default.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Default
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__class__.yaml
@@ -1,0 +1,73 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: RetirementRequestApproval
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: approval_type
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: auto
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: ValidateRequest
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: validate_request
+      on_exit: 
+      on_error: pending_request
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: ApproveRequest
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: approve_request
+      on_exit: 
+      on_error: pending_request
+      max_retries: '100'
+      max_time: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.rb
@@ -1,0 +1,14 @@
+#
+# Description: This method is executed when the provisioning request is auto-approved
+#
+
+# Auto-Approve request
+$evm.log("info", "Checking for auto_approval")
+approval_type = $evm.object['approval_type'].downcase
+if approval_type == 'auto'
+  $evm.log("info", "AUTO-APPROVING")
+  $evm.root["miq_request"].approve("admin", "Auto-Approved")
+else
+  $evm.log("info", "Not Auto-Approved")
+  exit MIQ_ABORT
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: approve_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.rb
@@ -1,0 +1,10 @@
+#
+# Description: This method is executed when the provisioning request is NOT auto-approved
+#
+
+# Get objects
+msg = $evm.object['reason']
+$evm.log('info', msg.to_s)
+
+# Raise automation event: request_pending
+$evm.root["miq_request"].pending

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/pending_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: pending_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.rb
@@ -1,0 +1,3 @@
+#
+# Description: Placeholder for service request validation
+#

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/validate_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: validate_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/default.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/RetirementRequestApproval.class/default.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Default
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/Service/Lifecycle.class/retirement.yaml
+++ b/content/automate/ManageIQ/Service/Lifecycle.class/retirement.yaml
@@ -8,5 +8,7 @@ object:
     inherits: 
     description: 
   fields:
-  - relationship4:
-      value: "/Service/Retirement/StateMachines/ServiceRetirement/Default"
+  - relationship1:
+      value: "/Service/Retirement/StateMachines/Methods/GetRetirementEntryPoint"
+  - relationship2:
+      value: "${/#retirement_entry_point}?service_id=${process#service_id}"

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__class__.yaml
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__class__.yaml
@@ -1,0 +1,73 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: ServiceRetirementRequestApproval
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: approval_type
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: auto
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: ValidateRequest
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: validate_request
+      on_exit: 
+      on_error: pending_request
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: ApproveRequest
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: approve_request
+      on_exit: 
+      on_error: pending_request
+      max_retries: '100'
+      max_time: 

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/approve_request.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/approve_request.rb
@@ -1,0 +1,14 @@
+#
+# Description: This method is executed when the provisioning request is auto-approved
+#
+
+# Auto-Approve request
+$evm.log("info", "Checking for auto_approval")
+approval_type = $evm.object['approval_type'].downcase
+if approval_type == 'auto'
+  $evm.log("info", "AUTO-APPROVING")
+  $evm.root["miq_request"].approve("admin", "Auto-Approved")
+else
+  $evm.log("info", "Not Auto-Approved")
+  exit MIQ_ABORT
+end

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/approve_request.yaml
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/approve_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: approve_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/pending_request.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/pending_request.rb
@@ -1,0 +1,10 @@
+#
+# Description: This method is executed when the provisioning request is NOT auto-approved
+#
+
+# Get objects
+msg = $evm.object['reason']
+$evm.log('info', msg.to_s)
+
+# Raise automation event: request_pending
+$evm.root["miq_request"].pending

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/pending_request.yaml
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/pending_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: pending_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/validate_request.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/validate_request.rb
@@ -1,0 +1,3 @@
+#
+# Description: Placeholder for service request validation
+#

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/validate_request.yaml
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/__methods__/validate_request.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: validate_request
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/default.yaml
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirementRequestApproval.class/default.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Default
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/System/Policy.class/serviceretirerequest_created.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/serviceretirerequest_created.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ServiceRetireRequest_created
+    inherits: 
+    description: 
+  fields:
+  - rel6:
+      value: "/Service/Retirement/StateMachines/ServiceRetirementRequestApproval/Default "

--- a/content/automate/ManageIQ/System/Policy.class/vmretirerequest_created.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/vmretirerequest_created.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: VmRetireRequest_created
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/System/Process/parse_provider_category"
+  - rel6:
+      value: "/${/#ae_provider_category}/${/#miq_request.resource.ci_type}/Retirement/StateMachines/RetirementRequestApproval/Default"

--- a/content/automate/ManageIQ/System/Policy.class/vmretirerequest_starting.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/vmretirerequest_starting.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: VmRetireRequest_starting
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/Process/parse_provider_category"
+  - rel5:
+      value: "/${/#ae_provider_category}/VM/Lifecycle/Retirement?vm_id=${process#vm_id} "


### PR DESCRIPTION
This PR adds the manageiq domain changes necessary for cloud and infra vms and services to do autoapproval for retirement as a request. 