### PR TITLE
[WIP] Changed Cloud VM Provision validate_request max_memory to be consistent.

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.rb
@@ -126,7 +126,8 @@ max_memory = nil
 # Use value from model unless specified above
 max_memory ||= $evm.object['max_memory']
 unless max_memory.nil?
-  $evm.log("info", "Auto-Approval Threshold(Model):<max_memory=#{max_memory}> detected")
+  max_memory = max_memory.to_i.megabytes
+  $evm.log("info", "Auto-Approval Threshold(Model):<max_memory=#{max_memory.to_s(:human_size)}> detected")
 end
 
 # Reset to nil if value is zero
@@ -136,7 +137,8 @@ max_memory = nil if max_memory == '0'
 prov_max_memory = template.tags(:prov_max_memory).first
 # If template is tagged then override
 unless prov_max_memory.nil?
-  $evm.log("info", "Auto-Approval Threshold(Tag):<prov_max_memory=#{prov_max_memory}> from template:<#{template.name}> detected")
+  prov_max_memory = prov_max_memory.to_i.megabytes
+  $evm.log("info", "Auto-Approval Threshold(Tag):<prov_max_memory=#{prov_max_memory.to_s(:human_size)}> from template:<#{template.name}> detected")
   max_memory = prov_max_memory.to_i
 end
 
@@ -145,9 +147,9 @@ unless max_memory.blank?
   desired_mem = requested_memory(prov_resource, desired_nvms)
   if desired_mem && (desired_mem.to_i > max_memory.to_i)
     $evm.log("info", "Auto-Approval Threshold(Warning): Number of vRAM requested: \
-    <#{desired_mem.to_s(:human_size)}> exceeds:<#{max_memory}>")
+    <#{desired_mem.to_s(:human_size)}> exceeds:<#{max_memory.to_s(:human_size)}>")
     approval_req = true
-    reason2 = "Requested Memory #{desired_mem.to_s(:human_size)} limit is #{max_memory}"
+    reason2 = "Requested Memory #{desired_mem.to_s(:human_size)} limit is #{max_memory.to_s(:human_size)}"
   end
 end
 


### PR DESCRIPTION
*** Important Note - This will change the existing cloud request approval behavior and, as a result, should NOT be backported.



The values for approval are confusing as Jeffrey Cutter mentioned in his BZ.

I changed instance values to be in Megabytes.  They were in bytes.
The instance values for quota are in megabytes so the approval values will match now.

![image](https://user-images.githubusercontent.com/11841651/38580397-d559d8e0-3cd7-11e8-995b-86d9d503dc38.png)

The value 1024 was 1 Megabyte, with this change it will be 1 Gigabyte.

Tag values should match the UI and be in gigabytes.  They were in Megabytes.
I changed tag values to be in Gigabytes.

![image](https://user-images.githubusercontent.com/11841651/38580469-0bde7150-3cd8-11e8-953d-0933ed2e80d2.png)

If you set the 1GB tag value on a template, it was 1MB.  Now it will be 1GB.

I also human_sized all the log messages so going forward it will be clear what the values really are.



INFO -- : <AEMethod validate_request> Auto-Approval Request was not auto-approved for the following reasons: (Requested Memory 2 GB limit is 1 GB)

I will be doing another PR for Infrastructure with the same changes.

https://bugzilla.redhat.com/show_bug.cgi?id=1553530