### PR TITLE
[WIP] Changed Infra VM Provision validate_request max_memory to be consistent.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.rb
@@ -113,7 +113,8 @@ max_memory = nil
 # Use value from model unless specified above
 max_memory ||= $evm.object['max_memory']
 unless max_memory.nil?
-  $evm.log("info", "Auto-Approval Threshold(Model):<max_memory=#{max_memory}> detected")
+  max_memory = max_memory.to_i.megabytes
+  $evm.log("info", "Auto-Approval Threshold(Model):<max_memory=#{max_memory.to_s(:human_size)}> detected")
 end
 
 # Reset to nil if value is zero
@@ -123,17 +124,20 @@ max_memory = nil if max_memory == '0'
 prov_max_memory = template.tags(:prov_max_memory).first
 # If template is tagged then override
 unless prov_max_memory.nil?
-  $evm.log("info", "Auto-Approval Threshold(Tag):<prov_max_memory=#{prov_max_memory}> from template:<#{template.name}> detected")
+  prov_max_memory = prov_max_memory.to_i.megabytes
+  $evm.log("info", "Auto-Approval Threshold(Tag):<prov_max_memory=#{prov_max_memory.to_s(:human_size)}> from template:<#{template.name}> detected")
   max_memory = prov_max_memory.to_i
 end
 
 # Validate max_memory if not nil or empty
 unless max_memory.blank?
   desired_mem = prov_resource.get_option(:vm_memory)
+  desired_mem = desired_mem.to_i.megabytes
   if desired_mem && (desired_mem.to_i > max_memory.to_i)
-    $evm.log('warn', "Auto-Approval Threshold(Warning): Number of vRAM requested:<#{desired_mem}> exceeds:<#{max_memory}>")
+    $evm.log('warn', "Auto-Approval Threshold(Warning): Number of vRAM requested: \
+    <#{desired_mem.to_s(:human_size)}> exceeds:<#{max_memory.to_s(:human_size)}>")
     approval_req = true
-    reason2 = "Requested Memory #{desired_mem}MB limit is #{max_memory}MB"
+    reason2 = "Requested Memory #{desired_mem.to_s(:human_size)} limit is #{max_memory.to_s(:human_size)}"
   end
 end
 

--- a/spec/automation/unit/method_validation/vmware_validate_request_spec.rb
+++ b/spec/automation/unit/method_validation/vmware_validate_request_spec.rb
@@ -1,0 +1,69 @@
+describe "Auto Approval Request Validation for Infrastructure" do
+  include Spec::Support::QuotaHelper
+  let(:ws) { MiqAeEngine.instantiate("/System/Request/Call_Method?#{method}&#{args}&#{@value}", @user) }
+  let(:method) do
+    "namespace=/ManageIQ/Infrastructure/VM/Provisioning/StateMachines&class=ProvisionRequestApproval&method=validate_request"
+  end
+  let(:args) { "status=fred&MiqProvisionRequest::miq_request=#{@miq_provision_request.id}" }
+
+  before do
+    setup_model("vmware")
+    add_call_method
+  end
+
+  it "exceed cpus" do
+    @value = "max_cpus=3"
+    msg = "Request was not auto-approved for the following reasons: (Requested CPUs 4 limit is 3) "
+    expect(ws.root["ae_result"]).to eq("error")
+    expect(ws.root["reason"]).to eq(msg)
+  end
+
+  it "not exceed cpus" do
+    @value = "max_cpus=4"
+    expect(ws.root["ae_result"]).to be_nil
+  end
+
+  it "exceed memory" do
+    @value = "max_memory=1"
+    msg = "Request was not auto-approved for the following reasons: (Requested Memory 1 GB limit is 1 MB) "
+    expect(ws.root["reason"]).to eq(msg)
+    expect(ws.root["ae_result"]).to eq("error")
+  end
+
+  it "not exceed memory" do
+    @value = "max_memory=2048"
+    expect(ws.root["ae_result"]).to be_nil
+  end
+
+  it "exceed retirement" do
+    @miq_provision_request.options[:retirement] = 3.days.seconds
+    @miq_provision_request.save
+    @value = "max_retirement_days=1"
+    msg = "Request was not auto-approved for the following reasons: (Requested Retirement Days 3 limit is 1) "
+    expect(ws.root["reason"]).to eq(msg)
+    expect(ws.root["ae_result"]).to eq("error")
+  end
+
+  it "not exceed retirement" do
+    @miq_provision_request.options[:retirement] = 1
+    @miq_provision_request.save
+    @value = "max_retirement_days=1"
+    expect(ws.root["ae_result"]).to be_nil
+  end
+
+  it "exceed vms" do
+    @miq_provision_request.options[:number_of_vms] = 2
+    @miq_provision_request.save
+    @value = "max_vms=1"
+    msg = "Request was not auto-approved for the following reasons: (Requested VMs 2 limit is 1) "
+    expect(ws.root["reason"]).to eq(msg)
+    expect(ws.root["ae_result"]).to eq("error")
+  end
+
+  it "not exceed vms" do
+    @miq_provision_request.options[:number_of_vms] = 1
+    @miq_provision_request.save
+    @value = "max_vms=1"
+    expect(ws.root["ae_result"]).to be_nil
+  end
+end


### PR DESCRIPTION
*** Important Note - This will change the existing infrastructure request approval behavior and, as a result, should NOT be backported.

See similar changes for cloud PR: https://github.com/ManageIQ/manageiq-content/pull/273
Added tests for VMware.

The values for approval are confusing as Jeffrey Cutter mentioned in his BZ.

I changed instance values to be in Megabytes. They were in bytes.
The instance values for quota are in megabytes so the approval values will match now.

Tag values should match the UI and be in gigabytes. They were in Megabytes.
I changed tag values to be in Gigabytes.

I also human_sized all the log messages so going forward it will be clear what the values really are.

https://bugzilla.redhat.com/show_bug.cgi?id=1553530