### PR TITLE
Change check for start_retirement to not initialized vs retiring

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -22,6 +22,11 @@ if stack.retiring?
   exit MIQ_ABORT
 end
 
+unless stack.retirement_initialized?
+  $evm.log('error', "Stack has not been initialized for retirement. Aborting current State Machine.")
+  exit MIQ_ABORT
+end
+
 $evm.log('info', "Stack before start_retirement: #{stack.inspect} ")
 $evm.create_notification(:type => :vm_retiring, :subject => stack)
 

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -40,6 +40,10 @@ module ManageIQ
                   if @vm.retiring?
                     raise 'VM is already in the process of being retired'
                   end
+
+                  unless @vm.retirement_initialized?
+                    raise 'VM has not been initialized for retirement. Aborting current State Machine.'
+                  end
                 end
 
                 def start_retirement

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -22,6 +22,11 @@ if vm.retiring?
   exit MIQ_ABORT
 end
 
+unless vm.retirement_initialized?
+  $evm.log('error', "VM has not been initialized for retirement. Aborting current State Machine.")
+  exit MIQ_ABORT
+end
+
 $evm.log('info', "VM before start_retirement: #{vm.inspect} ")
 
 $evm.create_notification(:type => :vm_retiring, :subject => vm)

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -20,6 +20,11 @@ if service.retiring?
   exit MIQ_ABORT
 end
 
+unless service.retirement_initialized?
+  $evm.log('error', "Service has not been initialized for retirement. Aborting current State Machine.")
+  exit MIQ_ABORT
+end
+
 $evm.create_notification(:type => :service_retiring, :subject => service)
 service.start_retirement
 

--- a/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
@@ -17,8 +17,13 @@ describe "Orchestration retirement state machine Methods Validation" do
     let(:method_name) { "StartRetirement" }
 
     it "starts a retirement request" do
+      stack.update_attributes(:retirement_state => 'initializing')
       ws
       expect(OrchestrationStack.where(:id => stack.id).first.retirement_state).to eq('retiring')
+    end
+
+    it "aborts if not initialized" do
+      expect { ws }.to raise_error(MiqAeException::AbortInstantiation, 'Method exited with rc=MIQ_ABORT')
     end
 
     it "aborts if stack is already retired" do

--- a/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
@@ -34,6 +34,7 @@ describe ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::Star
     allow(ae_service).to receive(:create_notification)
     expect(ae_service).to receive(:create_notification).with(:type => :vm_retiring, :subject => svc_vm)
     expect(svc_vm).to receive(:start_retirement)
+    svc_vm.retirement_state = 'initializing'
     expect { described_class.new(ae_service).main }.to_not raise_error
   end
 end


### PR DESCRIPTION
Previously this check was for retiring but with https://github.com/ManageIQ/manageiq/pull/17280 we're adding a state of initializing to prevent more than one worker from entering the state machine for the same service. The previous retiring check needs to be an initializing check. 

## Depends on
https://github.com/ManageIQ/manageiq-automation_engine/pull/173