### PR TITLE
Move the task message into check for task presence

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
@@ -28,7 +28,7 @@ module ManageIQ
                 updated_message  = "Server [#{@handle.root['miq_server'].name}] "
                 updated_message += "Step [#{@handle.root['ae_state']}] "
                 updated_message += "Status [#{status}] "
-                updated_message += "Message [#{task.message}] "
+                updated_message += "Message [#{task.message}] " if task
                 updated_message += "Current Retry Number [#{@handle.root['ae_state_retries']}]"\
                                     if @handle.root['ae_result'] == 'retry'
                 if task


### PR DESCRIPTION
The updated message should only include the task message if the task exists. 