### PR TITLE
Add checks for retirement of correct child service in bundle

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired.rb
@@ -1,37 +1,71 @@
-#
-# Description: This method checks to see that all of the service resources are retired before retiring the service.
-#
+module ManageIQ
+  module Automate
+    module Service
+      module Retirement
+        module StateMachines
+          module Methods
+            class CheckServiceRetired
+              def initialize(handle = $evm)
+                @handle = handle
+              end
 
-service = $evm.root['service']
-if service.nil?
-  $evm.log('error', "Service Object not found")
-  exit MIQ_ABORT
-end
+              def main
+                service
 
-$evm.log('info', "Checking if all service resources have been retired.")
+                @handle.log('info', "Checking if all service resources have been retired.")
+                result = 'ok'
+                service.service_resources.each do |sr|
+                  next if sr.resource.nil?
+                  next if sr.resource_type == "Service" && @handle.vmdb(:service).find(sr[:resource_id]).has_parent
+                  next unless sr.resource.respond_to?(:retired?)
+                  result = check_service_resource_retirement(sr)
+                end
 
-result = 'ok'
+                @handle.log('info', "Service: #{service.name} Resource retirement check returned <#{result}>")
+                result(result)
+              end
 
-service.service_resources.each do |sr|
-  next if sr.resource.nil?
-  next unless sr.resource.respond_to?(:retired?)
-  $evm.log('info', "Checking if service resource for service: #{service.name} resource ID: #{sr.id} is retired")
-  if sr.resource.retired?
-    $evm.log('info', "resource: #{sr.resource.name} is already retired.")
-  else
-    result = 'retry'
-    $evm.log('info', "resource: #{sr.resource.name} is not retired, setting retry.")
+              private
+
+              def service
+                @handle.root["service"].tap do |service|
+                  if service.nil?
+                    @handle.log(:error, 'Service is nil')
+                    raise 'Service not found'
+                  end
+                end
+              end
+
+              def check_service_resource_retirement(sr)
+                @handle.log('info', "Checking if service resource for service: #{service.name} resource ID: #{sr.id} is retired")
+                if sr.resource.retired?
+                  @handle.log('info', "resource: #{sr.resource.name} is already retired.")
+                  'ok'
+                else
+                  @handle.log('info', "resource: #{sr.resource.name} is not retired, setting retry.")
+                  'retry'
+                end
+              end
+
+              def result(param)
+                case param
+                when 'retry'
+                  @handle.log('info', "Service: #{service.name} resource is not retired, setting retry.")
+                  @handle.root['ae_result']         = 'retry'
+                  @handle.root['ae_retry_interval'] = '1.minute'
+                when 'ok'
+                  @handle.log('info', "All resources are retired for service: #{service.name}. ")
+                  @handle.root['ae_result'] = 'ok'
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end
 
-$evm.log('info', "Service: #{service.name} Resource retirement check returned <#{result}>")
-case result
-when 'retry'
-  $evm.log('info', "Service: #{service.name} resource is not retired, setting retry.")
-  $evm.root['ae_result']         = 'retry'
-  $evm.root['ae_retry_interval'] = '1.minute'
-when 'ok'
-  # Bump State
-  $evm.log('info', "All resources are retired for service: #{service.name}. ")
-  $evm.root['ae_result'] = 'ok'
+if __FILE__ == $PROGRAM_NAME
+  ManageIQ::Automate::Service::Retirement::StateMachines::Methods::CheckServiceRetired.new.main
 end

--- a/spec/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired_spec.rb
+++ b/spec/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired_spec.rb
@@ -1,0 +1,52 @@
+require_domain_file
+
+describe ManageIQ::Automate::Service::Retirement::StateMachines::Methods::CheckServiceRetired do
+  let(:admin) { FactoryGirl.create(:user_admin) }
+  let(:request) { FactoryGirl.create(:service_retire_request, :requester => admin) }
+  let(:service) { FactoryGirl.create(:service) }
+  let(:task) { FactoryGirl.create(:service_retire_task, :destination => service, :miq_request => request) }
+  let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceRetireTask.find(task.id) }
+  let(:svc_service) { MiqAeMethodService::MiqAeServiceService.find(service.id) }
+  let(:vm) { FactoryGirl.create(:vm) }
+  let(:retired_vm) { FactoryGirl.create(:vm, :retired => true) }
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new('service'             => svc_service,
+                                       'service_retire_task' => svc_task,
+                                       'service_action'      => 'Retirement')
+  end
+  let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
+
+  sleep(3.minutes)
+  it_behaves_like "automate_engine_call", domain_file
+
+  context "with non retired resource" do
+    it "check" do
+      service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service.id, :resource_id => vm.id)
+      expect(ae_service).to receive(:log).exactly(4).times
+      described_class.new(ae_service).main
+
+      expect(ae_service.root['ae_result']).to eq('retry')
+    end
+  end
+
+  context " with retired resource" do
+    it "check" do
+      service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service.id, :resource_id => retired_vm.id)
+      expect(ae_service).to receive(:log).exactly(3).times
+      described_class.new(ae_service).main
+
+      expect(ae_service.root['ae_result']).to eq('ok')
+    end
+  end
+
+  context "nil service" do
+    let(:root_object) do
+      Spec::Support::MiqAeMockObject.new('service'             => nil,
+                                         'service_retire_task' => task,
+                                         'service_action'      => 'Retirement')
+    end
+    it "check" do
+      expect { described_class.new(ae_service).main }.to raise_error('Service object has not been provided')
+    end
+  end
+end


### PR DESCRIPTION
We should only retire service bundle children that have resource_type of service and that have a parent.