### PR TITLE
Email instances for Infra VM provisioning.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/__class__.yaml
@@ -178,7 +178,7 @@ object:
       datatype: string
       priority: 9
       owner: 
-      default_value: "/Infrastructure/VM/Provisioning/Email/MiqProvision_complete?event=template_provisioned"
+      default_value: "/System/Notification/Email/InfrastructureMiqProvisionComplete?event=template_provisioned"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/__class__.yaml
@@ -278,7 +278,7 @@ object:
       datatype: string
       priority: 14
       owner: 
-      default_value: "/Infrastructure/VM/Provisioning/Email/MiqProvision_Complete?event=vm_provisioned"
+      default_value: "/System/Notification/Email/InfrastructureMiqProvisionComplete?event=vm_provisioned"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/clone_to_vm.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/clone_to_vm.yaml
@@ -11,4 +11,4 @@ object:
   - PreProvision:
       value: "/Infrastructure/VM/Provisioning/StateMachines/Methods/PreProvision_Clone_to_VM#${/#miq_provision.source.vendor}"
   - EmailOwner:
-      value: "/Infrastructure/VM/Provisioning/Email/MiqProvision_Complete?event=vm_cloned"
+      value: "/System/Notification/Email/InfrastructureMiqProvisionComplete?event=vm_cloned"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisioncomplete.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisioncomplete.yaml
@@ -1,0 +1,17 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureMiqProvisionComplete
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_provision.miq_request.get_option(:owner_email)} || ${/#miq_provision.miq_request.requester.email}"
+  - subject:
+      value: 'Request ID ${/#miq_provision.miq_request.id} - Your Virtual Machine
+        Request has Completed - Vm Name: <${/#miq_provision.vm.name}>'
+  - customize:
+      value: miq_provision_complete

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestapproverapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestapproverapproved.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureMiqProvisionRequestApproverApproved
+    inherits: 
+    description: 
+  fields:
+  - subject:
+      value: Request ID ${/#miq_request.id} - Virtual Machine Request from <${/#miq_request.requester.email}>
+        was Approved, pending Quota Validation.
+  - body:
+      value: 'Approver, <br><br>A Virtual Machine Request received from ${/#miq_request.requester.email}
+        was Approved.<br><br>Approvers reason: ${/#miq_request.reason}<br><br>To view
+        this Request go to: <a href=''https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}''>https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}</a><br><br>
+        Thank you,<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestapproverdenied.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestapproverdenied.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureMiqProvisionRequestApproverDenied
+    inherits: 
+    description: 
+  fields:
+  - subject:
+      value: Request ID ${/#miq_request.id} - Virtual Machine Request from <${/#miq_request.requester.email}>
+        was Denied.
+  - body:
+      value: 'Approver, <br><br>A Virtual Machine Request received from ${/#miq_request.requester.email}
+        was Denied.<br><br>${/#miq_request.resource.message}.<br><br>Approvers notes:
+        ${/#miq_request.reason}<br><br>For more information you can go to: <a href=''https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}''>https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}</a><br><br>
+        Thank you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestapproverpending.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestapproverpending.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureMiqProvisionRequestApproverPending
+    inherits: 
+    description: 
+  fields:
+  - subject:
+      value: Request ID ${/#miq_request.id} - Virtual Machine Request from <${/#miq_request.requester.email}>
+        Pending Approval.
+  - body:
+      value: 'Approver, <br><br>A Virtual Machine Request received from ${/#miq_request.requester.email}
+        is Pending.<br><br>${/#miq_request.resource.message}.<br><br>Approvers notes:
+        ${/#miq_request.reason}<br><br>For more information you can go to: <a href=''https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}''>https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}</a><br><br>
+        Thank you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestrequesterapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestrequesterapproved.yaml
@@ -1,0 +1,21 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureMiqProvisionRequestRequesterApproved
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        \ "
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Virtual Machine Request was Approved,
+        pending Quota Validation.
+  - body:
+      value: 'Hello ${/#user.name},<br><br>Your Virtual Machine Request was Approved.
+        If Quota validation is successful you will be notified via email when the
+        host is available.<br><br>To view this Request go to: <a href=''https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}''>https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}</a><br><br>
+        Thank you,<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestrequesterdenied.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestrequesterdenied.yaml
@@ -1,0 +1,19 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureMiqProvisionRequestRequesterDenied
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email} "
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Virtual Machine Request was Denied.
+  - body:
+      value: 'Hello,<br><br>Your Virtual Machine Request was Denied.<br><br>${/#miq_request.resource.message}.<br><br>Approvers
+        notes: ${/#miq_request.reason}<br><br>For more information you can go to:
+        <a href=''https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}''>https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}</a><br><br>
+        Thank you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestrequesterpending.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructuremiqprovisionrequestrequesterpending.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureMiqProvisionRequestRequesterPending
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email} "
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Virtual Machine Request is Pending.
+  - body:
+      value: 'Hello,<br><br>Please review your Virtual Machine Request and wait for
+        approval from an Administrator.<br><br>To view this Request go to: <a href=''https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}''>https://${/#miq_server.ipaddress}:3000/miq_request/show/${/#miq_request.id}</a><br><br>
+        Thank you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/miqserveralert.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/miqserveralert.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MIQServerAlert
+    inherits: 
+    description: 
+  fields:
+  - customize:
+      value: miq_server_alert


### PR DESCRIPTION
Added 7 instances in System/Notification/Email class for Infra/VM provisioning.

Modified EmailOwner value in 2 State Machine classes and clone_to_vm instance to
use new instances.

/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/__class__.yaml
/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/__class__.yaml
/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/clone_to_vm.yaml

https://bugzilla.redhat.com/show_bug.cgi?id=1314871
https://www.pivotaltracker.com/epic/show/3861726