### PR TITLE
Email instances for /Infrastructure/Configured_System provisioning.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -258,7 +258,7 @@ object:
       datatype: string
       priority: 13
       owner: 
-      default_value: "/Infrastructure/Configured_System/Provisioning/Email/Provision_complete?event=configured_system_provisioned"
+      default_value: "/System/Notification/Email/InfrastructureConfiguredSystemMiqProvisionComplete?event=configured_system_provisioned"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisioncomplete.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisioncomplete.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionComplete
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_provision.miq_request.get_option(:owner_email)} || ${/#miq_provision.miq_request.requester.email}"
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequest.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequest.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionRequest
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}"
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestapproverapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestapproverapproved.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionRequestApproverApproved
+    inherits: 
+    description: 
+  fields:
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestapproverdenied.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestapproverdenied.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionRequestApproverDenied
+    inherits: 
+    description: 
+  fields:
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestapproverpending.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestapproverpending.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionRequestApproverPending
+    inherits: 
+    description: 
+  fields:
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestrequesterapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestrequesterapproved.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionRequestRequesterApproved
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}"
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestrequesterdenied.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestrequesterdenied.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionRequestRequesterDenied
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}"
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestrequesterpending.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructureconfiguredsystemmiqprovisionrequestrequesterpending.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureConfiguredSystemMiqProvisionRequestRequesterPending
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}"
+  - sendmail:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_approved.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_approved.yaml
@@ -9,4 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Email/Request_Approved"
+      value: "/System/Notification/Email/InfrastructureConfiguredSystemMiqProvisionRequestRequesterApproved"
+  - rel6:
+      value: "/System/Notification/Email/InfrastructureConfiguredSystemMiqProvisionRequestApproverApproved"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_denied.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_denied.yaml
@@ -9,4 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Email/Request_denied"
+      value: "/System/Notification/Email/InfrastructureConfiguredSystemMiqProvisionRequestRequesterDenied"
+  - rel6:
+      value: "/System/Notification/Email/InfrastructureConfiguredSystemMiqProvisionRequestApproverDenied"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_pending.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionconfiguredsystemrequest_pending.yaml
@@ -9,4 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/${/#miq_request.resource.ci_type}/Provisioning/Email/Request_pending"
+      value: "/System/Notification/Email/InfrastructureConfiguredSystemMiqProvisionRequestRequesterPending"
+  - rel6:
+      value: "/System/Notification/Email/InfrastructureConfiguredSystemMiqProvisionRequestApproverPending"


### PR DESCRIPTION
    Added 8 instances in System/Notification/Email class for Infrastructure/Configured_System.
    Modified EmailOwner value in State Machine class to
    use new instance.

    Modified 3 System/Policy instances to use new email instances:
    System/Policy.class/miqprovisionconfiguredsystemrequest_approved
    System/Policy.class/miqprovisionconfiguredsystemrequest_pending
    System/Policy.class/miqprovisionconfiguredsystemrequest_denied

    Since the original emails were not enabled, these are not enabled.  They all have the value of #stop_email which will suppress the email.

https://bugzilla.redhat.com/show_bug.cgi?id=1314871
https://www.pivotaltracker.com/epic/show/3861726
