### PR TITLE
Fix servicetemplateprovisionrequest_denied approver_href method.

### DIFF
--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
@@ -21,7 +21,9 @@ def reason
 end
 
 def approver_href(appliance)
-  " <a href='https://#{appliance}/miq_request/show/#{@miq_request.id}'</a>"
+  body = "<a href='https://#{appliance}/miq_request/show/#{@miq_request.id}'"
+  body += ">https://#{appliance}/miq_request/show/#{@miq_request.id}</a>"
+  body
 end
 
 def approver_denied_text(requester_email, msg, reason)

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
@@ -23,7 +23,6 @@ end
 def approver_href(appliance)
   body = "<a href='https://#{appliance}/miq_request/show/#{@miq_request.id}'"
   body += ">https://#{appliance}/miq_request/show/#{@miq_request.id}</a>"
-  body
 end
 
 def approver_denied_text(requester_email, msg, reason)

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
@@ -35,7 +35,7 @@ end
 def approver_text(appliance, msg, requester_email)
   body = "Approver, "
   body += approver_denied_text(requester_email, msg, reason)
-  body += "<br><br>For more information you can go to:"
+  body += "<br><br>For more information you can go to: "
   body += approver_href(appliance)
   body += "<br><br> Thank you,"
   body += "<br> #{signature}"

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
@@ -66,7 +66,7 @@ def requester_text(appliance, msg)
   body = "Hello, "
   body += "<br>#{msg}."
   body += "<br><br>Approvers notes: #{reason}"
-  body += "<br><br>For more information you can go to:"
+  body += "<br><br>For more information you can go to: "
   body += requester_href(appliance)
   body += "<br><br> Thank you,"
   body += "<br> #{signature}"


### PR DESCRIPTION
Link was functional, but displayed link in e-mail was empty.

![image](https://user-images.githubusercontent.com/8230517/40141404-b4803ce6-590a-11e8-92e6-64a7707c633b.png)
