### PR TITLE
Email instances for Cloud VM provisioning.

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/__class__.yaml
@@ -278,7 +278,7 @@ object:
       datatype: string
       priority: 14
       owner: 
-      default_value: "/Cloud/VM/Provisioning/Email/MiqProvision_Complete?event=vm_provisioned"
+      default_value: "/System/Notification/Email/CloudMiqProvisionComplete?event=vm_provisioned"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/clone_to_vm.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/clone_to_vm.yaml
@@ -13,4 +13,4 @@ object:
   - PostProvision:
       value: "/Cloud/VM/Provisioning/StateMachines/Methods/PostProvision#${/#miq_provision.source.vendor}"
   - EmailOwner:
-      value: "/Cloud/VM/Provisioning/Email/MiqProvision_Complete?event=vm_cloned"
+      value: "/System/Notification/Email/CloudMiqProvisionComplete?event=vm_cloned"

--- a/content/automate/ManageIQ/System/Notification/Email.class/__methods__/miq_provision_customize_body.rb
+++ b/content/automate/ManageIQ/System/Notification/Email.class/__methods__/miq_provision_customize_body.rb
@@ -1,0 +1,74 @@
+# This customizes and sets the body
+
+module ManageIQ
+  module Automate
+    module System
+      module Notification
+        module Email
+          class MiqProvisionCustomizeBody
+            def initialize(handle = $evm)
+              @handle = handle
+            end
+
+            def main
+              build_body
+            end
+
+            private
+
+            def build_body
+              to = @handle.object['to']
+              signature = @handle.object['signature']
+              # VM Provisioned Email Body
+              body = "Hello,"
+              body += "<br><br>Your request to provision a Virtual Machine was approved and completed on #{@time}"
+              body += "<br><br>Virtual Machine #{vm['name']}<b> will be available in approximately 15 minutes</b>. "
+              body += "<br><br>For Windows VM access is available via RDP and for Linux VM access is available via putty/ssh, etc."
+              body += " Or you can use the Console Access feature found in the detail view of your VM. "
+              if vm['retires_on'].respond_to?('strftime')
+                body += "<br><br>This VM will automatically be retired on #{vm['retires_on'].strftime('%A, %B %d, %Y')},"
+                body += " unless you request an extension. "
+              end
+              if vm.retirement_warn
+                body += " You will receive a warning #{vm.retirement_warn} days before #{vm['name']} "
+                body += "set retirement date."
+              end
+              body += " As the designated owner you will receive expiration warnings at this email address: #{to}"
+              body += "<br><br>If you are not already logged in, you can access and manage your Virtual Machine here "
+              body += "<a href=#{vm_href}>"
+              body += "#{vm_href}</a>"
+              body += "<br><br> If you have any issues with your new virtual machine please contact Support."
+              body += "<br><br> Thank you,"
+              body += "<br> #{signature}"
+              @handle.object['body'] = body
+            end
+
+            def prov
+              @prov ||= @handle.root["miq_provision"].tap do |prov|
+                raise "ERROR - miq_provision object not passed in" unless prov
+              end
+            end
+
+            def vm_href
+              @vm_href ||= vm.show_url
+            end
+
+            def time
+              @time ||= Time.zone.now.strftime('%A, %B %d, %Y at %I:%M%p').to_s
+            end
+
+            def vm
+              @vm ||= prov.vm.tap do |vm|
+                raise "ERROR - VM not found" unless vm
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::System::Notification::Email::MiqProvisionCustomizeBody.new.main
+end

--- a/content/automate/ManageIQ/System/Notification/Email.class/__methods__/miq_provision_customize_body.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/__methods__/miq_provision_customize_body.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: miq_provision_customize_body
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisioncomplete.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisioncomplete.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionComplete
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_provision.miq_request.get_option(:owner_email)} || ${/#miq_provision.miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Request ID ${/#miq_provision.miq_request.id} - Your Instance Request
+        has Completed - Vm Name: <${/#miq_provision.vm.name}>'
+  - customize:
+      value: miq_provision_customize_body

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestapproverapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestapproverapproved.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionRequestApproverApproved
+    inherits: 
+    description: 
+  fields:
+  - subject:
+      value: Request ID ${/#miq_request.id} - Instance Request from <${/#miq_request.requester.email}>  was
+        Approved, pending Quota Validation.
+  - body:
+      value: 'Approver, <br><br>An Instance Request received from ${/#miq_request.requester.email}
+        was Approved.<br><br>Approvers reason: ${/#miq_request.reason}<br><br>To view
+        this Request go to: <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br><br>
+        Thank you,<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestapproverdenied.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestapproverdenied.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionRequestApproverDenied
+    inherits: 
+    description: 
+  fields:
+  - subject:
+      value: Request ID ${/#miq_request.id} - Instance Request from <${/#miq_request.requester.email}>
+        was Denied.
+  - body:
+      value: 'Approver, <br><br>An Instance Request received from ${/#miq_request.requester.email}
+        was Denied.<br><br>${/#miq_request.resource.message}.<br><br>Approvers notes:
+        ${/#miq_request.reason}<br><br>For more information you can go to: <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br><br>
+        Thank you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestapproverpending.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestapproverpending.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionRequestApproverPending
+    inherits: 
+    description: 
+  fields:
+  - subject:
+      value: Request ID ${/#miq_request.id} - Instance Request from <${/#miq_request.requester.email}>
+        Pending Approval.
+  - body:
+      value: 'Approver, <br><br>An Instance Request received from ${/#miq_request.requester.email}
+        is Pending.<br><br>${/#miq_request.resource.message}.<br><br>Approvers notes:
+        ${/#miq_request.reason}<br><br>For more information you can go to: <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br><br>
+        Thank you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestrequesterapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestrequesterapproved.yaml
@@ -1,0 +1,21 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionRequestRequesterApproved
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Instance Request was Approved,
+        pending Quota Validation.
+  - body:
+      value: 'Hello,<br><br>Your Instance Request was Approved. If Quota validation
+        is successful you will be notified via email when the host is available.<br><br>To
+        view this Request go to: <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br><br>
+        Thank you,<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestrequesterdenied.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestrequesterdenied.yaml
@@ -1,0 +1,20 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionRequestRequesterDenied
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Instance Request was Denied.
+  - body:
+      value: 'Hello,<br><br>Your Instance Request was Denied.<br><br>${/#miq_request.resource.message}.<br><br>Approvers
+        notes: ${/#miq_request.reason}<br><br>For more information you can go to:
+        <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br><br> Thank
+        you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestrequesterpending.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisionrequestrequesterpending.yaml
@@ -1,0 +1,19 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionRequestRequesterPending
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Instance Request is Pending.
+  - body:
+      value: 'Hello,<br><br>Please review your Instance Request and wait for approval
+        from an Administrator.<br><br>To view this Request go to: <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br><br>
+        Thank you<br> ${#signature}'

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_approved.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_approved.yaml
@@ -9,4 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/${/#ae_provider_category}/VM/Provisioning/Email/MiqProvisionRequest_Approved"
+      value: "/System/Notification/Email/${/#ae_provider_category}MiqProvisionRequestApproverApproved"
+  - rel6:
+      value: "/System/Notification/Email/${/#ae_provider_category}MiqProvisionRequestRequesterApproved"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_denied.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_denied.yaml
@@ -9,4 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/${/#ae_provider_category}/VM/Provisioning/Email/MiqProvisionRequest_denied"
+      value: "/System/Notification/Email/${/#ae_provider_category}MiqProvisionRequestRequesterDenied"
+  - rel6:
+      value: "/System/Notification/Email/${/#ae_provider_category}MiqProvisionRequestApproverDenied"

--- a/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_pending.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqprovisionrequest_pending.yaml
@@ -9,4 +9,6 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/${/#ae_provider_category}/VM/Provisioning/Email/MiqProvisionRequest_pending"
+      value: "/System/Notification/Email/${/#ae_provider_category}MiqProvisionRequestRequesterPending"
+  - rel6:
+      value: "/System/Notification/Email/${/#ae_provider_category}MiqProvisionRequestApproverPending"

--- a/spec/content/automate/ManageIQ/System/Notification/Email.class/__methods__/miq_provision_customize_body_spec.rb
+++ b/spec/content/automate/ManageIQ/System/Notification/Email.class/__methods__/miq_provision_customize_body_spec.rb
@@ -1,0 +1,121 @@
+require_domain_file
+
+describe ManageIQ::Automate::System::Notification::Email::MiqProvisionCustomizeBody do
+  let(:vm_url) { "https://www.manageiq.org/show/vm/1" }
+  let(:svc_miq_provision) { MiqAeMethodService::MiqAeServiceMiqProvision.find(miq_provision.id) }
+  let(:root_hash) do
+    {
+      'miq_provision' => svc_miq_provision,
+      'user'          => MiqAeMethodService::MiqAeServiceUser.find(user.id),
+      'miq_server'    => MiqAeMethodService::MiqAeServiceMiqServer.find(miq_server.id)
+    }
+  end
+
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new('to' => 'touser@example.com', 'from' => 'fromuser@example.com',
+        'signature' => 'Virtualization Infrastructure Team',
+        'customize' => 'miq_provision_complete',
+        'subject' => 'Request ID ')
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
+  let(:svc_model_miq_server) { MiqAeMethodService::MiqAeServiceMiqServer.find(miq_server.id) }
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:svc_vm) { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+  let(:vm) do
+    FactoryGirl.create(:vm_vmware,
+                       :evm_owner       => user,
+                       :retires_on      => Time.zone.now + 30.days,
+                       :retirement_warn => Time.zone.now + 7.days,
+                       :ems_id          => ems.id)
+  end
+
+  let(:ems) { FactoryGirl.create(:ems_vmware_with_authentication) }
+  let(:vm_template) { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
+  let(:options) { {:src_vm_id => [vm_template.id, vm_template.name], :pass => 1} }
+  let(:miq_provision_request) do
+    FactoryGirl.create(:miq_provision_request,
+                       :provision_type => 'template',
+                       :state => 'pending', :status => 'Ok',
+                       :src_vm_id => vm_template.id,
+                       :requester => user)
+  end
+  let(:miq_provision) do
+    FactoryGirl.create(:miq_provision_vmware, :provision_type => 'template',
+                       :state => 'pending', :status => 'Ok',
+                       :miq_request => miq_provision_request,
+                       :vm => vm,
+                       :options => options, :userid => user.userid)
+  end
+
+  it_behaves_like "automate_engine_call", domain_file
+
+  it "Check object values" do
+    allow(svc_miq_provision).to receive(:vm).and_return(svc_vm)
+    allow(svc_vm).to receive(:show_url).and_return(vm_url)
+    described_class.new(ae_service).main
+
+    expect(ae_service.object.attributes).to include(
+      'to'        => 'touser@example.com',
+      'signature' => 'Virtualization Infrastructure Team',
+      'from'      => 'fromuser@example.com',
+      'customize' => 'miq_provision_complete',
+      'subject'   => 'Request ID '
+    )
+  end
+
+  it "Check body values" do
+    allow(svc_miq_provision).to receive(:vm).and_return(svc_vm)
+    allow(svc_vm).to receive(:show_url).and_return(vm_url)
+    described_class.new(ae_service).main
+
+    expect(ae_service.object['body']).to include(vm_url)
+
+    # these two are conditional, retirement information must be specified
+    expect(ae_service.object['body']).to include('This VM will automatically be retired on')
+    expect(ae_service.object['body']).to include('You will receive a warning')
+  end
+
+  it "No Retirement will be retired in Body" do
+    vm.update_attributes!(:retires_on => nil)
+    allow(svc_miq_provision).to receive(:vm).and_return(svc_vm)
+    allow(svc_vm).to receive(:show_url).and_return(vm_url)
+
+    described_class.new(ae_service).main
+    expect(ae_service.object['body']).not_to include('This VM will automatically be retired on')
+  end
+
+  it "No Retirement warning in Body" do
+    vm.update_attributes!(:retirement_warn => nil)
+    allow(svc_miq_provision).to receive(:vm).and_return(svc_vm)
+    allow(svc_vm).to receive(:show_url).and_return(vm_url)
+
+    described_class.new(ae_service).main
+    expect(ae_service.object['body']).not_to include('You will receive a warning')
+  end
+
+  context "with no vm" do
+    let(:vm) { nil }
+
+    it "raises the ERROR - VM not found exception" do
+      expect { described_class.new(ae_service).main }.to raise_error(
+        'ERROR - VM not found'
+      )
+    end
+  end
+
+  context "with no objects" do
+    let(:root_hash) { {} }
+
+    it "raises the ERROR - miq_provision object not passed in exception" do
+      expect { described_class.new(ae_service).main }.to raise_error(
+        'ERROR - miq_provision object not passed in'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Added 7 instances in System/Notification/Email class for Cloud/VM provisioning.

Modified EmailOwner value in State Machine schema and clone_to_vm instance to
use new instances.

Modified 3 System/Policy instances to use new email instances.

MIqProvisionRequest_Approved
MIqProvisionRequest_pending
MIqProvisionRequest_denied

Created miq_provision_customize_body method.
Created test for method.

https://bugzilla.redhat.com/show_bug.cgi?id=1314871
https://www.pivotaltracker.com/epic/show/3861726
