### PR TITLE
Email instances for Cloud and Infrastructure retirement.

### DIFF
--- a/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/vm_retire_warn.yaml
+++ b/content/automate/ManageIQ/System/Event/MiqEvent/POLICY.class/vm_retire_warn.yaml
@@ -13,6 +13,6 @@ object:
   - rel4:
       value: "/System/Process/parse_provider_category"
   - rel5:
-      value: "/${/#ae_provider_category}/VM/Retirement/Email/vm_retirement_emails"
+      value: "/System/Notification/Email/${/#ae_provider_category}VmRetireWarn"
   - rel6:
       value: "/System/event_handlers/event_enforce_policy"

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmenteredretirement.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmenteredretirement.yaml
@@ -1,0 +1,19 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudOrchestrationVmEnteredRetirement
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Stack : ${/#orchestration_stack} has entered retirement.'
+  - body:
+      value: 'Hello,"<br/><br/>Your Stack named : ${/#orchestration_stack} has been
+        retired. <br/><br/>You will have up to 3 days to un-retire this stack. Afterwhich
+        time the stack will be deleted.<br/><br/> Thank you,<br/>${#signature}"'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmretired.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmretired.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudOrchestrationVmRetired
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} || ${/#miq_request.get_option(:owner_email)} ||
+        ${/#miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Stack Retirement Alert for : ${/#orchestration_stack}.'
+  - body:
+      value: 'Hello,<br/><br/>Your Stack named : ${/#orchestration_stack} has been
+        retired.<br/><br/> Thank you<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmretirewarn.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmretirewarn.yaml
@@ -1,0 +1,19 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudOrchestrationVmRetireWarn
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Stack Retirement Warning for : ${/#orchestration_stack}.'
+  - body:
+      value: 'Hello,<br/><br/>Your Stack named : ${/#orchestration_stack} has been
+        retired. <br/><br/>You will have up to 3 days to un-retire this stack. Afterwhich
+        time the stack will be deleted.<br/><br/> Thank you,<br/>${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudvmenteredretirement.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudvmenteredretirement.yaml
@@ -1,0 +1,19 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudVmEnteredRetirement
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Virtual Machine : ${/#vm} has entered retirement.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine named : ${/#vm} has been retired.
+        <br/><br/>You will have up to 3 days to un-retire this VM. Afterwhich time
+        the VM will be deleted. <br/><br/> Thank you<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretired.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretired.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudVmRetired
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_provision.miq_request.get_option(:owner_email)}
+        || ${/#miq_provision.miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Your Virtual Machine : ${/#vm} has been retired.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine named : ${/#vm} has been retired.<br/><br/>
+        Thank you<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretireextend.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretireextend.yaml
@@ -1,0 +1,20 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudVmRetireExtend
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Virtual Machine Retirement extended for : ${/#vm}.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine : ${/#vm} will now be retired on
+        : ${/#vm.retires_on}. <br/><br/>If you need to use this Virtual Machine past
+        this date please request an <br/><br/>extension by contacting Support. <br/><br/>
+        Thank you,<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretirewarn.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretirewarn.yaml
@@ -1,0 +1,20 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudVmRetireWarn
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Virtual Machine Retirement Warning for : ${/#vm}.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine : ${/#vm} will now be retired on
+        : ${/#vm.retires_on}. <br/><br/>If you need to use this Virtual Machine past
+        this date please request an <br/><br/>extension by contacting Support. <br/><br/>
+        Thank you,<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmenteredretirement.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmenteredretirement.yaml
@@ -1,0 +1,19 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureVmEnteredRetirement
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Virtual Machine : ${/#vm} has entered retirement.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine named : ${/#vm} has been retired.
+        <br/><br/>You will have up to 3 days to un-retire this VM. Afterwhich time
+        the VM will be deleted. <br/><br/> Thank you<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretired.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretired.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureVmRetired
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_provision.miq_request.get_option(:owner_email)}
+        || ${/#miq_provision.miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Your Virtual Machine : ${/#vm} has been retired.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine named : ${/#vm} has been retired.<br/><br/>
+        Thank you<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretireextend.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretireextend.yaml
@@ -1,0 +1,20 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureVmRetireExtend
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Virtual Machine Retirement extended for : ${/#vm}.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine : ${/#vm} will now be retired on
+        : ${/#vm.retires_on}. <br/><br/>If you need to use this Virtual Machine past
+        this date please request an <br/><br/>extension by contacting Support. <br/><br/>
+        Thank you,<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretirewarn.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretirewarn.yaml
@@ -1,0 +1,19 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: InfrastructureVmRetireWarn
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#vm.owner.email} ||${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Virtual Machine Retirement Warning for : ${/#vm}.'
+  - body:
+      value: 'Hello,<br/><br/>Your Virtual Machine will now be retired on : ${/#vm.retires_on}.
+        <br/><br/>If you need to use this Virtual Machine past this date please request
+        an <br/><br/>extension by contacting Support. <br/><br/> Thank you,<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Request.class/vm_retire_extend.yaml
+++ b/content/automate/ManageIQ/System/Request.class/vm_retire_extend.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/${/#ae_provider_category}/VM/Retirement/Email/vm_retire_extend"
+      value: "/System/Notification/Email/${/#ae_provider_category}VmRetireExtend?event=vm_retire_extend"


### PR DESCRIPTION
Added 11 instances in System/Notification/Email class for retirement.

3 for Cloud Orchestration retirement
4 for Cloud Vm retirement
4 for Infrastructure VM retirement

Modified 2 System instances to use new email instances.
Appended  ${/Configuration/Email/Default#default_recipient}" in 'to' field

https://bugzilla.redhat.com/show_bug.cgi?id=1314871
https://www.pivotaltracker.com/epic/show/3861726