### PR TITLE
Email instances for Host provisioning.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/Host/Provisioning/StateMachines/HostProvision.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/Host/Provisioning/StateMachines/HostProvision.class/__class__.yaml
@@ -258,7 +258,7 @@ object:
       datatype: string
       priority: 13
       owner: 
-      default_value: "/Infrastructure/Host/Provisioning/Email/MiqHostProvision_complete?event=host_provisioned"
+      default_value: "/System/Notification/Email/MiqHostProvisionComplete?event=host_provisioned"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/System/Notification/Email.class/miqhostprovisioncomplete.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/miqhostprovisioncomplete.yaml
@@ -1,0 +1,23 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MiqHostProvisionComplete
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_host_provision.miq_request.get_option(:owner_email)} || ${/#miq_host_provision.miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Request ID ${/#miq_host_provision.miq_request.id} - Your Host Provisioning
+        Request has Completed - Host : ${/#host}.'
+  - body:
+      value: 'Hello,<br/><br/>Your Request to Provision a Host has Completed.  <br/><br/>Host
+        : ${/#host}<b> will be available in approximately 15 minutes</b>.  <br/><br/>If
+        you are not already logged in, you can access and manage your host here :
+        <a href=${/#host.show_url}>${/#host.show_url}</a> <br/><br/> If you have any
+        issues with your new host please contact Support. <br/><br/> Thank you,<br/>
+        ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/miqhostprovisionrequestapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/miqhostprovisionrequestapproved.yaml
@@ -1,0 +1,21 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: MiqHostProvisionRequestApproved
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Host Provisioning Request was Approved,
+        pending Quota Validation.
+  - body:
+      value: 'Hello,<br/><br/>Your host request was approved. If Quota validation
+        is successful you will be notified via email when the host is available.<br/><br/>To
+        view this Request go to : <a href=${/#host.show_url}>${/#host.show_url}</a><br/><br/>
+        Thank you,<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Policy.class/miqhostprovisionrequest_approved.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/miqhostprovisionrequest_approved.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/Infrastructure/Host/Provisioning/Email/MiqHostProvisionRequest_Approved"
+      value: "/System/Notification/Email/MiqHostProvisionRequestApproved"


### PR DESCRIPTION
Added 2 instances in System/Notification/Email class for Host provisioning.

Modified EmailOwner value in State Machine class to
use new instance.

Modified 1 System/Policy instance to use new email instance:
System/Policy.class/miqhostprovisionrequestapproved

https://bugzilla.redhat.com/show_bug.cgi?id=1314871
https://www.pivotaltracker.com/epic/show/3861726