### PR TITLE
Email instances for Automation/Management/AnsibleTower provisioning.

### DIFF
--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -278,7 +278,7 @@ object:
       datatype: string
       priority: 14
       owner: 
-      default_value: "/AutomationManagement/AnsibleTower/Service/Provisioning/Email/ServiceProvision_complete?event=service_provisioned"
+      default_value: "/System/Notification/Email/AutomationManagementAnsibleTowerServiceProvisionComplete?event=service_provisioned"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/System/Notification/Email.class/automationmanagementansibletowerserviceprovisioncomplete.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/automationmanagementansibletowerserviceprovisioncomplete.yaml
@@ -1,0 +1,15 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AutomationManagementAnsibleTowerServiceProvisionComplete
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_provision.miq_request.get_option(:owner_email)} || ${/#miq_provision.miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - mail_method:
+      value: "#stop_email"

--- a/content/automate/ManageIQ/System/Notification/Email.class/automationmanagementansibletowerservicetemplateprovisionrequestapproverapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/automationmanagementansibletowerservicetemplateprovisionrequestapproverapproved.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AutomationManagementAnsibleTowerServiceTemplateProvisionRequestApproverApproved
+    inherits: 
+    description: 
+  fields:
+  - subject:
+      value: Request ID ${/#miq_request.id} - Service Request received from ${/#miq_request.requester.email}
+        was Approved.
+  - body:
+      value: 'Approver,<br/><br/>Service Request received from ${/#miq_request.requester.email}
+        was Approved.<br/><br/>Approvers reason : ${/#miq_request.reason}<br/><br/>To
+        view this Request go to : <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br/><br/>
+        Thank you,<br/> ${#signature}'

--- a/content/automate/ManageIQ/System/Notification/Email.class/automationmanagementansibletowerservicetemplateprovisionrequestrequesterapproved.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/automationmanagementansibletowerservicetemplateprovisionrequestrequesterapproved.yaml
@@ -1,0 +1,21 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AutomationManagementAnsibleTowerServiceTemplateProvisionRequestRequesterApproved
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_request.get_option(:owner_email)} || ${/#miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: Request ID ${/#miq_request.id} - Your Service Request was Approved, pending
+        Quota Validation.
+  - body:
+      value: 'Hello,<br/><br/>Your Service Request was Approved. If Service provisioning
+        is successful you will be notified via email when the Service is available.<br/><br/>Approvers
+        notes : ${/#miq_request.reason}<br/><br/>To view this Request go to : <a href=${/#miq_request.show_url}>${/#miq_request.show_url}</a><br/><br/>
+        Thank you,<br/> ${#signature}'


### PR DESCRIPTION
Added 3 instances in System/Notification/Email class.
Modified EmailOwner value in State Machine class to
use new instance.

Since the original emails were not enabled, these are not enabled.
Completion email is just a placeholder and System/Policy instance is missing for approval emails.

https://bugzilla.redhat.com/show_bug.cgi?id=1314871
https://www.pivotaltracker.com/epic/show/3861726