### PR TITLE
Email instances for Cloud/Orchestration.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -278,7 +278,7 @@ object:
       datatype: string
       priority: 14
       owner: 
-      default_value: "/Cloud/Orchestration/Provisioning/Email/ServiceProvision_complete?event=service_provisioned"
+      default_value: "/System/Notification/Email/CloudOrchestrationServiceProvisionComplete?event=service_provisioned"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationserviceprovisioncomplete.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationserviceprovisioncomplete.yaml
@@ -1,0 +1,15 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudOrchestrationServiceProvisionComplete
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_provision.miq_request.get_option(:owner_email)} || ${/#miq_provision.miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - mail_method:
+      value: "#stop_email"


### PR DESCRIPTION
Added 1 instance in System/Notification/Email class for Cloud/Orchestration.

Modified EmailOwner value in Cloud/Orchestration/Provisioning/StateMachines/Provision schema class.
    
Since the original completion email was not enabled, this completion email is not enabled.
The System/Policy instance for the approval emails is the same as Service provisioning and the System/Policy instances was updated in that PR: https://github.com/ManageIQ/manageiq-content/pull/313

https://bugzilla.redhat.com/show_bug.cgi?id=1314871
https://www.pivotaltracker.com/epic/show/3861726