### PR TITLE
Refactoring cloud vm retirement finish_retirement method

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
@@ -1,7 +1,34 @@
 #
 # Description: This method marks the VM as retired
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module VM
+        module Retirement
+          module StateMachines
+            module Methods
+              class FinishRetirement
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-vm = $evm.root['vm']
-vm.finish_retirement if vm
-$evm.create_notification(:type => :vm_retired, :subject => vm) if vm
+                def main
+                  vm = @handle.root['vm']
+                  if vm
+                    vm.finish_retirement
+                    @handle.create_notification(:type => :vm_retired, :subject => vm)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::FinishRetirement.new.main
+end

--- a/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement_spec.rb
@@ -1,0 +1,32 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::FinishRetirement do
+  let(:svc_vm)      { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+  let(:ems)         { FactoryGirl.create(:ems_vmware) }
+  let(:vm)          { FactoryGirl.create(:vm_vmware, :ems_id => ems.id) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:root_hash)   { { 'vm' => svc_vm } }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "retires vm" do
+    expect(svc_vm).to receive(:finish_retirement)
+    expect(ae_service).to receive(:create_notification).with(:type => :vm_retired, :subject => svc_vm)
+    described_class.new(ae_service).main
+  end
+
+  describe "doesn't retire vm" do
+    let(:root_hash) {}
+
+    it 'vm is nil' do
+      expect(ae_service).not_to receive(:create_notification)
+      described_class.new(ae_service).main
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb method and adding a new spec. This PR is based on the issue bellow.

Links
-------------------
#8