### PR TITLE
Refactoring cloud vm retirement check_deleted_from_provider method

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/check_deleted_from_provider.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/check_deleted_from_provider.rb
@@ -1,14 +1,38 @@
 #
 # Description: This method checks to see if the VM has been deleted from the provider
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module VM
+        module Retirement
+          module StateMachines
+            module Methods
+              class CheckDeletedFromProvider
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-vm = $evm.root['vm']
+                def main
+                  vm = @handle.root['vm']
+                  @handle.root['ae_result'] = 'ok'
 
-$evm.root['ae_result'] = 'ok'
-
-if vm && $evm.get_state_var('vm_deleted_from_provider')
-  if vm.ext_management_system
-    $evm.root['ae_result']         = 'retry'
-    $evm.root['ae_retry_interval'] = '15.seconds'
+                  if vm && @handle.get_state_var('vm_deleted_from_provider')
+                    if vm.ext_management_system
+                      @handle.root['ae_result']         = 'retry'
+                      @handle.root['ae_retry_interval'] = '15.seconds'
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::CheckDeletedFromProvider.new.main
 end

--- a/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/check_deleted_from_provider_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/check_deleted_from_provider_spec.rb
@@ -1,0 +1,29 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::CheckDeletedFromProvider do
+  let(:svc_vm)         { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+  let(:ems)            { FactoryGirl.create(:ems_vmware) }
+  let(:vm)             { FactoryGirl.create(:vm_vmware, :ems_id => ems.id) }
+  let(:root_object)    { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:root_hash)      { { 'vm' => svc_vm } }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "returns 'ok'" do
+    described_class.new(ae_service).main
+    expect(ae_service.root['ae_result']).to(eq('ok'))
+  end
+
+  it "returns 'retry'" do
+    ae_service.set_state_var('vm_deleted_from_provider', true)
+    described_class.new(ae_service).main
+    expect(ae_service.root['ae_result']).to(eq('retry'))
+    expect(ae_service.root['ae_retry_interval']).to(eq('15.seconds'))
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring  content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/check_deleted_from_provider.rb method and adding a new spec. This PR is based on the issue bellow.

Links
-------------------
#8 

@miq-bot add_label refactoring