### PR TITLE
 Refactoring cloud vm retirement approve_request method 

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.rb
@@ -1,14 +1,39 @@
 #
 # Description: This method is executed when the provisioning request is auto-approved
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module VM
+        module Retirement
+          module StateMachines
+            module RetirementRequestApproval
+              class ApproveRequest
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-# Auto-Approve request
-$evm.log("info", "Checking for auto_approval")
-approval_type = $evm.object['approval_type'].downcase
-if approval_type == 'auto'
-  $evm.log("info", "AUTO-APPROVING")
-  $evm.root["miq_request"].approve("admin", "Auto-Approved")
-else
-  $evm.log("info", "Not Auto-Approved")
-  exit MIQ_ABORT
+                def main
+                  # Auto-Approve request
+                  @handle.log('info', 'Checking for auto_approval')
+                  approval_type = @handle.object['approval_type'].try(:downcase)
+                  if approval_type == 'auto'
+                    @handle.log('info', 'AUTO-APPROVING')
+                    @handle.root['miq_request'].approve('admin', 'Auto-Approved')
+                  else
+                    @handle.log('info', 'Not Auto-Approved')
+                    raise 'Not Auto-Approved'
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::RetirementRequestApproval::ApproveRequest.new.main
 end

--- a/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request_spec.rb
@@ -1,0 +1,27 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::RetirementRequestApproval::ApproveRequest do
+  let(:svc_request) { MiqAeMethodService::MiqAeServiceMiqProvisionRequest.find(request.id) }
+  let(:request)     { FactoryGirl.create(:miq_provision_request, :with_approval) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:root_hash)   { { 'miq_request' => svc_request } }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      current_object['approval_type'] = 'auto'
+      service.object = current_object
+    end
+  end
+
+  it 'approves request' do
+    expect(svc_request).to(receive(:approve).with('admin', 'Auto-Approved'))
+    described_class.new(ae_service).main
+  end
+
+  it 'does not approve request' do
+    ae_service.object['approval_type'] = nil
+    expect { described_class.new(ae_service).main }.to raise_error('Not Auto-Approved')
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring `Cloud/VM/Retirement/StateMachines/RetirementRequestApproval.class/__methods__/approve_request.rb` method with new spec. This PR is based on the issue bellow.

Links
-------------------
#8 

@miq-bot add_label refactoring