### PR TITLE
Remove check for a state of initialized in 4 start_retirement methods.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -22,11 +22,6 @@ if stack.retiring?
   exit MIQ_ABORT
 end
 
-unless stack.retirement_initialized?
-  $evm.log('error', "Stack has not been initialized for retirement. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
 $evm.log('info', "Stack before start_retirement: #{stack.inspect} ")
 $evm.create_notification(:type => :vm_retiring, :subject => stack)
 

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -40,10 +40,6 @@ module ManageIQ
                   if @vm.retiring?
                     raise 'VM is already in the process of being retired'
                   end
-
-                  unless @vm.retirement_initialized?
-                    raise 'VM has not been initialized for retirement. Aborting current State Machine.'
-                  end
                 end
 
                 def start_retirement

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -22,11 +22,6 @@ if vm.retiring?
   exit MIQ_ABORT
 end
 
-unless vm.retirement_initialized?
-  $evm.log('error', "VM has not been initialized for retirement. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
 $evm.log('info', "VM before start_retirement: #{vm.inspect} ")
 
 $evm.create_notification(:type => :vm_retiring, :subject => vm)

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -20,11 +20,6 @@ if service.retiring?
   exit MIQ_ABORT
 end
 
-unless service.retirement_initialized?
-  $evm.log('error', "Service has not been initialized for retirement. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
 $evm.create_notification(:type => :service_retiring, :subject => service)
 service.start_retirement
 

--- a/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
@@ -17,13 +17,8 @@ describe "Orchestration retirement state machine Methods Validation" do
     let(:method_name) { "StartRetirement" }
 
     it "starts a retirement request" do
-      stack.update_attributes(:retirement_state => 'initializing')
       ws
       expect(OrchestrationStack.where(:id => stack.id).first.retirement_state).to eq('retiring')
-    end
-
-    it "aborts if not initialized" do
-      expect { ws }.to raise_error(MiqAeException::AbortInstantiation, 'Method exited with rc=MIQ_ABORT')
     end
 
     it "aborts if stack is already retired" do

--- a/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
@@ -34,7 +34,6 @@ describe ManageIQ::Automate::Cloud::VM::Retirement::StateMachines::Methods::Star
     allow(ae_service).to receive(:create_notification)
     expect(ae_service).to receive(:create_notification).with(:type => :vm_retiring, :subject => svc_vm)
     expect(svc_vm).to receive(:start_retirement)
-    svc_vm.retirement_state = 'initializing'
     expect { described_class.new(ae_service).main }.to_not raise_error
   end
 end


### PR DESCRIPTION
Updated tests.

This fixes a problem where retirement would fail and continue to retry many times.

https://bugzilla.redhat.com/show_bug.cgi?id=1591470

This replaces https://github.com/ManageIQ/manageiq-content/pull/281