### PR TITLE
Add extra empty states to allow pre and post states.

### DIFF
--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
@@ -251,3 +251,363 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: state
+      name: State13
+      display_name: 
+      datatype: 
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State14
+      display_name: 
+      datatype: 
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State15
+      display_name: 
+      datatype: 
+      priority: 15
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State16
+      display_name: 
+      datatype: 
+      priority: 16
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State17
+      display_name: 
+      datatype: 
+      priority: 17
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State18
+      display_name: 
+      datatype: 
+      priority: 18
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State19
+      display_name: 
+      datatype: 
+      priority: 19
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State20
+      display_name: 
+      datatype: 
+      priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State21
+      display_name: 
+      datatype: 
+      priority: 21
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State22
+      display_name: 
+      datatype: 
+      priority: 22
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State23
+      display_name: 
+      datatype: 
+      priority: 23
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State24
+      display_name: 
+      datatype: 
+      priority: 24
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State25
+      display_name: 
+      datatype: 
+      priority: 25
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State26
+      display_name: 
+      datatype: 
+      priority: 26
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State27
+      display_name: 
+      datatype: 
+      priority: 27
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State28
+      display_name: 
+      datatype: 
+      priority: 28
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State29
+      display_name: 
+      datatype: 
+      priority: 29
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State30
+      display_name: 
+      datatype: 
+      priority: 30
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
@@ -8,7 +8,7 @@ object:
     inherits: 
     description: 
   fields:
-  - State1:
+  - State2:
       value: "/Transformation/Common/AssessTransformation"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Assess Migration", task_message => "Validating")
@@ -16,7 +16,7 @@ object:
         => "Assess Migration", task_message => "Validating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Assess Migration", task_message => "Validating")
-  - State2:
+  - State5:
       value: "/Transformation/Common/AcquireTransformationHost"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Acquire Transformation Host", task_message => "Pre-migration")
@@ -24,7 +24,7 @@ object:
         => "Acquire Transformation Host", task_message => "Pre-migration")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Acquire Transformation Host", task_message => "Pre-migration")
-  - State3:
+  - State11:
       value: "/Transformation/Infrastructure/VM/Common/PowerOff"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Power off", task_message => "Pre-migration")
@@ -32,7 +32,7 @@ object:
         => "Power off", task_message => "Pre-migration")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Power off", task_message => "Pre-migration")
-  - State4:
+  - State14:
       value: "/Transformation/Infrastructure/VM/${state_var#source_ems_type}/CollapseSnapshots"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Collapse Snapshots", task_message => "Pre-migration")
@@ -40,7 +40,7 @@ object:
         => "Collapse Snapshots", task_message => "Pre-migration")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Collapse Snapshots", task_message => "Pre-migration")
-  - State5:
+  - State17:
       value: "/Transformation/StateMachines/VMTransformation/${state_var#transformation_type}_${state_var#transformation_method}?state_ancestry=${#state_ancestry}/${#ae_state}"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 95, description
         => "Transform VM")
@@ -48,7 +48,7 @@ object:
         => "Transform VM")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 95, description
         => "Transform VM")
-  - State6:
+  - State26:
       value: "/Transformation/Infrastructure/VM/${state_var#source_ems_type}/SetMigrated"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Mark source as migrated", task_message => "Migrating")
@@ -56,6 +56,6 @@ object:
         => "Mark source as migrated", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Mark source as migrated", task_message => "Migrating")
-  - State7:
+  - State28:
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Virtual machine migrated", task_message => "Migration complete")

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/vmwarews2rhevm_vddk.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/vmwarews2rhevm_vddk.yaml
@@ -8,7 +8,7 @@ object:
     inherits: 
     description: 
   fields:
-  - State1:
+  - State2:
       value: "/Transformation/TransformationHosts/${state_var#transformation_host_type}/VMTransform_${state_var#source_ems_type}2${state_var#destination_ems_type}_${state_var#transformation_method}"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Convert disks", task_message => "Migrating")
@@ -16,7 +16,7 @@ object:
         => "Convert disks", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Convert disks", task_message => "Migrating")
-  - State2:
+  - State5:
       value: "/Transformation/TransformationHosts/${state_var#transformation_host_type}/VMCheckTransformed_${state_var#source_ems_type}2${state_var#destination_ems_type}_${state_var#transformation_method}"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 85, description
         => "Convert disks", task_message => "Migrating")
@@ -25,7 +25,7 @@ object:
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 85, description
         => "Convert disks", task_message => "Migrating")
       max_retries: '1500'
-  - State3:
+  - State8:
       value: "/Transformation/Infrastructure/VM/${state_var#destination_ems_type}/CheckVmInInventory"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
         => "Refresh inventory", task_message => "Migrating")
@@ -34,7 +34,7 @@ object:
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
         => "Refresh inventory", task_message => "Migrating")
       max_retries: '200'
-  - State4:
+  - State11:
       value: "/Transformation/Infrastructure/VM/${state_var#destination_ems_type}/SetDescription"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Update description of VM", task_message => "Migrating")
@@ -42,7 +42,7 @@ object:
         => "Update description of VM", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Update description of VM", task_message => "Migrating")
-  - State5:
+  - State14:
       value: "/Transformation/Infrastructure/VM/Common/PowerOn"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Power-on VM", task_message => "Migrating")
@@ -50,7 +50,7 @@ object:
         => "Power-on VM", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Power-on VM", task_message => "Migrating")
-  - State6:
+  - State17:
       value: "/Transformation/Infrastructure/VM/${state_var#destination_ems_type}/CheckPoweredOn"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 7, description
         => "Power-on VM", task_message => "Migrating")


### PR DESCRIPTION
Request from the field. When configuring the migration process, one might want to add pre or post actions for each of the pre-defined states. With nested state machines, it opens a big opportunity for deep customization, while not affecting the current behavior.

I have already added extra states for future PRs.