### PR TITLE
Add a precanned physical server automation event

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/LenovoXclarity.class/serverpoweredoffevent.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/LenovoXclarity.class/serverpoweredoffevent.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: ServerPoweredOffEvent
+    name: PLAT0106
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_policy?target=physical_server&policy_event=physical_server_shutdown&param="


### PR DESCRIPTION
This PR adds a precanned automation event for servers that have been powered off. This event will create an internal event ("physical_server_shutdown") so that it can be handled by a control policy.

The policy is defined in https://github.com/ManageIQ/manageiq/pull/17624