### PR TITLE
Add a state to restore VM attributes during migration.

### DIFF
--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.rb
@@ -1,0 +1,46 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Infrastructure
+        module VM
+          module Common
+            class RestoreVmAttributes
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                task = @handle.root['service_template_transformation_plan_task']
+                source_vm = task.source
+                destination_vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
+                @handle.log(:info, "VM: #{destination_vm.inspect}")
+                @handle.log(:info, "VM Id: #{destination_vm.id}")
+
+                # Reconnect destination VM to service
+                destination_vm.add_to_service(source_vm.service) unless source_vm.service.nil?
+                source_vm.remove_from_service
+
+                # Restore tags of the source VM
+                source_vm.tags.each do |tag|
+                  destination_vm.tag_assign(tag) unless tag =~ /^folder_path_/
+                end
+
+                # Restore custom attributes of the source VM
+                source_vm.custom_keys.each do |ca|
+                  destination_vm.custom_set(ca, source_vm.custom_get(ca))
+                end
+              rescue => e
+                @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+                raise
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes.new.main
+end

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.rb
@@ -17,8 +17,10 @@ module ManageIQ
                 @handle.log(:info, "VM Id: #{destination_vm.id}")
 
                 # Reconnect destination VM to service
-                destination_vm.add_to_service(source_vm.service) unless source_vm.service.nil?
-                source_vm.remove_from_service
+                if source_vm.service
+                  destination_vm.add_to_service(source_vm.service)
+                  source_vm.remove_from_service
+                end
 
                 # Restore tags of the source VM
                 source_vm.tags.each do |tag|

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.yaml
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: RestoreVmAttributes
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
@@ -42,12 +42,20 @@ object:
         => "Collapse Snapshots", task_message => "Pre-migration")
   - State17:
       value: "/Transformation/StateMachines/VMTransformation/${state_var#transformation_type}_${state_var#transformation_method}?state_ancestry=${#state_ancestry}/${#ae_state}"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 95, description
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 94, description
         => "Transform VM")
-      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 95, description
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 94, description
         => "Transform VM")
-      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 95, description
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 94, description
         => "Transform VM")
+  - State23:
+      value: "/Transformation/Infrastructure/VM/Common/RestoreVmAttributes"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
+        => "Restore VM Attributes", task_message => "Migrating")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
+        => "Restore VM Attributes", task_message => "Migrating")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
+        => "Restore VM Attributes", task_message => "Migrating")
   - State26:
       value: "/Transformation/Infrastructure/VM/${state_var#source_ems_type}/SetMigrated"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description


### PR DESCRIPTION
When migrating a virtual machine that was already tagged, had custom atributes, or was associated to a service, all this information is lost. This PR restore the information from the source virtual machine.

Associated BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1594783