### PR TITLE
Deprecate old AutomationManagement email methods.

### DIFF
--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/Email.class/__methods__/serviceprovision_complete.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/Email.class/__methods__/serviceprovision_complete.rb
@@ -1,3 +1,4 @@
 #
 # Description: Place holder for Service Provision Complete email #
 #
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_approved.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_approved.rb
@@ -94,6 +94,7 @@ def emailapprover(miq_request, appliance)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?


### PR DESCRIPTION
Added deprecated log message to methods.
New email will use System/Notification/Email class for all instances and methods.
![deprecate old automationmanagement email](https://user-images.githubusercontent.com/11841651/41873791-0e40a970-7894-11e8-8e46-3e1fd4e8a6ab.png)
