### PR TITLE
Deprecate old Cloud Orchestration Reconfiguration email methods

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/Email.class/__methods__/servicereconfigure_complete.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/Email.class/__methods__/servicereconfigure_complete.rb
@@ -1,3 +1,4 @@
 #
 # Description: Place holder for Service Reconfigure Complete email #
 #
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email namespace.")

--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/Email.class/__methods__/servicereconfigurerequest_approved.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/Email.class/__methods__/servicereconfigurerequest_approved.rb
@@ -94,6 +94,7 @@ def emailapprover(miq_request, appliance)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email namespace.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?


### PR DESCRIPTION
Added deprecated log message to methods.
New email will use System/Notification/Email class for all instances and methods.

![deprecate old cloudorchestrationreconfiguration](https://user-images.githubusercontent.com/11841651/41881983-5ea52bdc-78b4-11e8-810d-3fb7bf6a2959.png)
