### PR TITLE
Deprecate old Cloud Orchestration Retirement email method.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/Email.class/__methods__/stack_retirement_emails.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/Email.class/__methods__/stack_retirement_emails.rb
@@ -11,6 +11,7 @@
 #    requester replies to the email
 # 3. signature - used to stamp the email with a custom signature
 #
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 stack = $evm.object['orchestration_stack']
 if stack.nil?
   stack_id = $evm.object['orchestration_stack_id'].to_i


### PR DESCRIPTION
Added deprecated log message to method.
New email will use System/Notification/Email class for all instances and method.

![deprecate old cloudorchestrationretirement](https://user-images.githubusercontent.com/11841651/41920167-20b58b3a-792e-11e8-9e9c-e1efb136cb6f.png)
