### PR TITLE
Deprecate old Cloud Vm Provisioning email methods

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovision_complete.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovision_complete.rb
@@ -12,6 +12,7 @@
 # 3. signature - used to stamp the email with a custom signature
 #
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get vm from miq_provision object
 prov = $evm.root['miq_provision']
 vm = prov.vm

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_approved.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_approved.rb
@@ -108,6 +108,7 @@ def emailapprover(miq_request, appliance)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_denied.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_denied.rb
@@ -120,6 +120,7 @@ def emailapprover(miq_request, appliance, msg, provisionRequestApproval)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_pending.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_pending.rb
@@ -118,6 +118,7 @@ def emailapprover(miq_request, appliance, msg, provisionRequestApproval)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?


### PR DESCRIPTION
Added deprecated log message to methods.
New email will use System/Notification/Email class for all instances and methods.

![deprecate old cloudvmprovisioning](https://user-images.githubusercontent.com/11841651/41921776-9d664ab8-7931-11e8-888a-3899ee20fac6.png)
