### PR TITLE
Add a common class to implement advisory lock

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/advisorylock.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/advisorylock.rb
@@ -1,0 +1,40 @@
+module ManageIQ
+  module Automate
+    module System
+      module CommonMethods
+        module MiqAe
+          class AdvisoryLock
+            def initialize(handle = $evm)
+              @handle = handle
+            end
+
+            def main
+            end
+
+            def acquire_lock(lock_name)
+              hashcode = stable_hashcode(lock_name)
+              result = connection.select_value("select pg_try_advisory_lock(#{hashcode});")
+              (result == 't' || result == true)
+            end
+
+            def release_lock(lock_name)
+              hashcode = stable_hashcode(lock_name)
+              connection.execute("select pg_advisory_unlock(#{hashcode});")
+            end
+
+            private
+
+            def stable_hashcode(lock_name)
+              require 'zlib'
+              Zlib.crc32(lock_name) & 0x7fffffff
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::System::CommonMethods::MiqAe::AdvisoryLock.new.main
+end

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/advisorylock.yaml
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/advisorylock.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: AdvisoryLock
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []


### PR DESCRIPTION
This PR aims at providing a generic lock mechanism for automate code. The concept is explained here: https://hashrocket.com/blog/posts/advisory-locks-in-postgres and an implementation is detailed here: https://gist.github.com/jeffwarnica/3fa2b94195d64b11ccc083155245133f. The idea here is to make it available easily in a method/class that can be easily embedded in other methods.