### PR TITLE
Deprecate old email methods.

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -15,6 +15,7 @@ module ManageIQ
               end
 
               def main
+                @handle.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
                 @handle.log("info", "Starting vm_retire_extend")
                 check_retire_extend(vm)
                 @handle.log("info", "Ending vm_retire_extend")

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retirement_emails.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retirement_emails.rb
@@ -11,6 +11,7 @@
 #    requester replies to the email
 # 3. signature - used to stamp the email with a custom signature
 #
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 vm = $evm.object['vm']
 if vm.nil?
   vm_id = $evm.object['vm_id'].to_i

--- a/content/automate/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/provision_complete.rb
+++ b/content/automate/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/provision_complete.rb
@@ -1,3 +1,4 @@
 #
 # Description: Place holder for Provision Complete email #
 #
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")

--- a/content/automate/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/request_approved.rb
+++ b/content/automate/ManageIQ/Infrastructure/Configured_System/Provisioning/Email.class/__methods__/request_approved.rb
@@ -1,3 +1,4 @@
 #
 # Description: Place holder for Provision Request Approved email #
 #
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")

--- a/content/automate/ManageIQ/Infrastructure/VM/Migrate/Email.class/__methods__/vmmigraterequest_approved.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Migrate/Email.class/__methods__/vmmigraterequest_approved.rb
@@ -12,6 +12,7 @@
 # 3. signature - used to stamp the email with a custom signature
 #
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request object
 miq_request = $evm.root["miq_request"]
 

--- a/content/automate/ManageIQ/Infrastructure/VM/Migrate/Email.class/__methods__/vmmigratetask_complete.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Migrate/Email.class/__methods__/vmmigratetask_complete.rb
@@ -11,6 +11,7 @@
 # 3. signature - used to stamp the email with a custom signature
 #
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Look in the Root Object for the request
 miq_task = $evm.root['vm_migrate_task']
 miq_server = $evm.root['miq_server']

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovision_complete.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovision_complete.rb
@@ -11,6 +11,7 @@
 # 3. signature - used to stamp the email with a custom signature
 #
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get vm from miq_provision object
 prov = $evm.root['miq_provision']
 vm = prov.vm

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_approved.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_approved.rb
@@ -91,6 +91,7 @@ def emailapprover(miq_request, appliance)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_denied.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_denied.rb
@@ -103,6 +103,7 @@ def emailapprover(miq_request, appliance, msg, provisionRequestApproval)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_pending.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovisionrequest_pending.rb
@@ -102,6 +102,7 @@ def emailapprover(miq_request, appliance, msg, provisionRequestApproval)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?

--- a/content/automate/ManageIQ/Infrastructure/VM/Reconfigure/Email.class/__methods__/vmreconfigure_request_approved.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Reconfigure/Email.class/__methods__/vmreconfigure_request_approved.rb
@@ -12,6 +12,7 @@
 # 3. signature - used to stamp the email with a custom signature
 #
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request object
 miq_request = $evm.root["miq_request"]
 

--- a/content/automate/ManageIQ/Infrastructure/VM/Reconfigure/Email.class/__methods__/vmreconfigure_task_complete.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Reconfigure/Email.class/__methods__/vmreconfigure_task_complete.rb
@@ -11,6 +11,7 @@
 # 3. signature - used to stamp the email with a custom signature
 #
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 vm = $evm.root['vm']
 
 raise "VM object not specified" if vm.nil?

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -15,6 +15,7 @@ module ManageIQ
               end
 
               def main
+                @handle.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
                 @handle.log("info", "Starting vm_retire_extend")
                 check_retire_extend(vm)
                 @handle.log("info", "Ending vm_retire_extend")

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retirement_emails.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retirement_emails.rb
@@ -10,6 +10,7 @@
 # 3. signature - used to stamp the email with a custom signature
 #
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Look in the current object for a VM
 vm = $evm.object['vm']
 if vm.nil?

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/serviceprovision_complete.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/serviceprovision_complete.rb
@@ -1,3 +1,4 @@
 #
 # Description: Place holder for Service Provision Complete email #
 #
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_approved.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_approved.rb
@@ -94,6 +94,7 @@ def emailapprover(miq_request, appliance)
   $evm.execute(:send_email, to, from, subject, body)
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 # Get miq_request from root
 miq_request = $evm.root['miq_request']
 raise "miq_request missing" if miq_request.nil?

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_denied.rb
@@ -81,6 +81,7 @@ def email_requester(appliance, msg)
   send_mail(to, from, subject, requester_text(appliance, msg))
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 @miq_request = $evm.root['miq_request']
 $evm.log(:info, "miq_request id: #{@miq_request.id} approval_state: #{@miq_request.approval_state}")
 $evm.log(:info, "options: #{@miq_request.options.inspect}")

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_pending.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_pending.rb
@@ -76,6 +76,7 @@ def email_requester(appliance)
   send_mail(to, from, subject, requester_text(appliance))
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 @miq_request = $evm.root['miq_request']
 $evm.log(:info, "miq_request id: #{@miq_request.id} approval_state: #{@miq_request.approval_state}")
 $evm.log(:info, "options: #{@miq_request.options.inspect}")

--- a/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_warning.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/Email.class/__methods__/servicetemplateprovisionrequest_warning.rb
@@ -69,6 +69,7 @@ def email_requester(appliance, msg)
   send_mail(to, from, subject, requester_text(appliance, msg))
 end
 
+$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
 @miq_request = $evm.root['miq_request']
 $evm.log(:info, "miq_request id: #{@miq_request.id} approval_state: #{@miq_request.approval_state}")
 $evm.log(:info, "options: #{@miq_request.options.inspect}")


### PR DESCRIPTION
Added deprecated log message to 19 methods.
New email will use System/Notification/Email class for all instances and methods.

2 methods in Cloud/VM/Retirement/Email class.
2 methods in Infrastructure/Configured_System/Provisioning/Email class.
2 methods in Infrastructure/VM/Migrate/Email class.
4 methods in Infrastructure/VM/Provisioning/Email class.
2 methods in Infrastructure/VM/Reconfigure/Email class.
2 methods in Infrastructure/VM/Retirement/Email class.
5 methods in Service/Provisioning/Email class.