### PR TITLE
Add support for MAC address in network mapping

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -14,26 +14,24 @@ module ManageIQ
           end
 
           def network_mappings(task, vm)
-            mappings = []
-            vm.hardware.nics.select { |n| n.device_type == 'ethernet' }.each do |nic|
+            vm.hardware.nics.select { |n| n.device_type == 'ethernet' }.collect do |nic|
               source_network = nic.lan
               destination_network = task.transformation_destination(source_network)
               raise "[#{vm.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping. Aborting." if destination_network.nil?
-              mappings << {
+              {
                 :source      => source_network.name,
                 :destination => destination_network.name,
                 :mac_address => nic.address
               }
             end
-            mappings
           end
 
           def storage_mappings(task, vm)
-            vm.hardware.disks.select { |d| d.device_type == 'disk' }.each do |disk|
+            vm.hardware.disks.select { |d| d.device_type == 'disk' }.collect do |disk|
               source_storage = disk.storage
               destination_storage = task.transformation_destination(disk.storage)
               raise "[#{vm.name}] Disk #{disk.device_name} [#{source_storage.name}] has no mapping. Aborting." if destination_storage.nil?
-              virtv2v_disks << {
+              {
                 :path    => disk.filename,
                 :size    => disk.size,
                 :percent => 0,


### PR DESCRIPTION
This PR is the automate side to enable support for Distributed Virtual Switch (DVS) and Distributed Port Group (DPG). The solution is to allow mapping based on the MAC address rather than the source network name. Richard W.M. Jones has implemented the `--mac` option in virt-v2v [1]. I have created a PR to add the support for this option in virt-v2v-wrapper [2]. This code simply adds the MAC address of the NICs to the network mappings hash, so that it is passed to virt-v2v-wrapper.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1594515

[1] https://www.redhat.com/archives/libguestfs/2018-July/msg00004.html
[2] https://github.com/oVirt/ovirt-ansible-v2v-conversion-host/pull/6