### PR TITLE
Refactoring cloud vm provisioning profile methods

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/get_deploy_dialog.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/get_deploy_dialog.rb
@@ -1,26 +1,48 @@
 #
 # Description: Dynamically choose dialog based on Category:environment chosen in pre-dialog
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module VM
+        module Provisioning
+          module Profile
+            class GetDeployDialog
+              def initialize(handle = $evm)
+                @handle = handle
+              end
 
-# Set to true to dynamically choose dialog name based on environment tag
-run_env_dialog = false
+              # Set run_env_dialog to true to dynamically choose dialog name based on environment tag
+              def main(run_env_dialog = false)
+                if run_env_dialog
+                  # Get incoming environment tags from pre-dialog
+                  dialog_input_vm_tags = @handle.root['dialog_input_vm_tags']
 
-if run_env_dialog
-  # Get incoming environment tags from pre-dialog
-  dialog_input_vm_tags = $evm.root['dialog_input_vm_tags']
+                  # Use a regular expression to grab the environment from the incoming tag category
+                  # I.e. environment/dev for Category:environment Tag:dev
+                  regex = /(.*)(\/)(\w*)/i
 
-  # Use a regular expression to grab the environment from the incoming tag category
-  # I.e. environment/dev for Category:environment Tag:dev
-  regex = /(.*)(\/)(\w*)/i
+                  # If the regular express matches dynamically choose the next dialog
+                  if regex =~ dialog_input_vm_tags
+                    cat = Regexp.last_match[1]
+                    tag = Regexp.last_match[3]
+                    @handle.log("info", "Category: <#{cat}> Tag: <#{tag}>")
+                    dialog_name = "miq_provision_dialogs-deploy-#{tag}"
 
-  # If the regular express matches dynamically choose the next dialog
-  if regex =~ dialog_input_vm_tags
-    cat = Regexp.last_match[1]
-    tag = Regexp.last_match[3]
-    $evm.log("info", "Category: <#{cat}> Tag: <#{tag}>")
-    dialog_name = 'miq_provision_dialogs-deploy-#{tag}'
+                    ## Set dialog name in the root object to be picked up by dialogs
+                    @handle.root['dialog_name'] = dialog_name
+                    @handle.log("info", "Launching <#{dialog_name}>")
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
-  ## Set dialog name in the root object to be picked up by dialogs
-  $evm.root['dialog_name'] = dialog_name
-  $evm.log("info", "Launching <#{dialog_name}>")
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Cloud::VM::Provisioning::Profile::GetDeployDialog.new.main
 end

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/vm_dialog_name_prefix.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/vm_dialog_name_prefix.rb
@@ -1,20 +1,40 @@
 #
 # Description: This is the default method to determine the dialog prefix name to use
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module VM
+        module Provisioning
+          module Profile
+            class VmDialogNamePrefix
+              def initialize(handle = $evm)
+                @handle = handle
+              end
 
-platform  = $evm.root['platform']
-$evm.log("info", "Detected Platform:<#{platform}>")
+              # Set run_env_dialog to true to dynamically choose dialog name based on environment tag
+              def main
+                platform = @handle.root['platform']
+                @handle.log("info", "Detected Platform:<#{platform}>")
 
-if platform.nil?
-  source_id = $evm.root['dialog_input_src_vm_id']
-  source    = $evm.vmdb('vm_or_template', source_id) unless source_id.nil?
-  if source
-    platform = source.model_suffix.downcase
-  else
-    platform = "vmware"
+                if platform.nil?
+                  source_id = @handle.root['dialog_input_src_vm_id']
+                  source    = @handle.vmdb('vm_or_template', source_id) unless source_id.nil?
+                  platform  = source ? source.model_suffix.downcase : "vmware"
+                end
+
+                dialog_name_prefix = "miq_provision_#{platform}_dialogs"
+                @handle.object['dialog_name_prefix'] = dialog_name_prefix
+                @handle.log("info", "Platform:<#{platform}> dialog_name_prefix:<#{dialog_name_prefix}>")
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end
 
-dialog_name_prefix = "miq_provision_#{platform}_dialogs"
-$evm.object['dialog_name_prefix'] = dialog_name_prefix
-$evm.log("info", "Platform:<#{platform}> dialog_name_prefix:<#{dialog_name_prefix}>")
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Cloud::VM::Provisioning::Profile::VmDialogNamePrefix.new.main
+end

--- a/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/get_deploy_dialog_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/get_deploy_dialog_spec.rb
@@ -1,0 +1,35 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::VM::Provisioning::Profile::GetDeployDialog do
+  let(:cat)         { 'environment' }
+  let(:tag)         { 'dev' }
+  let(:root_hash)   { { 'dialog_input_vm_tags' => "#{cat}/#{tag}" } }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it 'sets dialog name in the root object' do
+    described_class.new(ae_service).main(true)
+    expect(ae_service.root['dialog_name']).to(eq("miq_provision_dialogs-deploy-#{tag}"))
+  end
+
+  context 'does not set dialog name' do
+    it '#not matching dialog_input_vm_tags attribute' do
+      ae_service.root['dialog_input_vm_tags'] = 'not_matching_string'
+      described_class.new(ae_service).main(true)
+      expect(ae_service.root['dialog_name']).to(eq(nil))
+    end
+
+    it '#run_env_dialog flag is false' do
+      expect(ae_service).not_to(receive(:log))
+      described_class.new(ae_service).main
+      expect(ae_service.root['dialog_name']).to(eq(nil))
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/vm_dialog_name_prefix_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Profile.class/__methods__/vm_dialog_name_prefix_spec.rb
@@ -1,0 +1,35 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::VM::Provisioning::Profile::VmDialogNamePrefix do
+  let(:platform)        { 'test_platform' }
+  let(:root_hash)       { { 'platform' => platform } }
+  let(:root_object)     { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:vm_template)     { FactoryGirl.create(:template_amazon) }
+  let(:svc_vm_template) { MiqAeMethodService::MiqAeServiceVmOrTemplate.find(vm_template.id) }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "sets dialog_name_prefix from 'root['platform']'" do
+    described_class.new(ae_service).main
+    expect(ae_service.object['dialog_name_prefix']).to(eq("miq_provision_#{platform}_dialogs"))
+  end
+
+  it 'sets dialog_name_prefix from vmdb' do
+    ae_service.root['platform'] = nil
+    ae_service.root['dialog_input_src_vm_id'] = svc_vm_template.id
+    described_class.new(ae_service).main
+    expect(ae_service.object['dialog_name_prefix']).to(eq("miq_provision_#{svc_vm_template.model_suffix.downcase}_dialogs"))
+  end
+
+  it 'sets default dialog_name_prefix' do
+    ae_service.root['platform'] = nil
+    described_class.new(ae_service).main
+    expect(ae_service.object['dialog_name_prefix']).to(eq("miq_provision_vmware_dialogs"))
+  end
+end


### PR DESCRIPTION
Purpose or Intent
---------------------

Refactoring `Cloud/VM/Provisioning/Profile.class/__methods__/*.rb` methods and adding the specs for them. This PR is based on the issue bellow.

Links
-------------------
Issue: #8 

@miq-bot add_label refactoring