### PR TITLE
Add support for pre/post-migration playbook

### DIFF
--- a/content/automate/ManageIQ/Transformation/Ansible.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__class__.yaml
@@ -1,0 +1,33 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Ansible
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: method
+      name: execute
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -1,0 +1,68 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Ansible
+        class CheckPlaybookAsAService
+          def initialize(handle = $evm)
+            @handle = handle
+          end
+
+          def set_retry(message, interval = '1.minutes')
+            @handle.log(:info, "#{message}. Retrying.")
+            @handle.root['ae_result'] = 'retry'
+            @handle.root['ae_retry_interval'] = interval
+          end
+
+          def job_status(job)
+            { :job_id => job.id, :job_status => job.status }
+          end
+
+          def set_ansible_job(task, service_request, transformation_hook)
+            job = nil
+            service_request_task = service_request.miq_request_tasks.first
+            unless service_request_task.nil?
+              stack = service_request_task.destination.service_resources.first
+              job = stack.resource unless stack.nil?
+            end
+            playbooks_status = task.get_option(:playbooks) || {}
+
+            if playbooks_status[transformation_hook].nil?
+              if job.nil?
+                set_retry('Ansible job has not started yet.', '15.seconds')
+              else
+                playbooks_status[transformation_hook] = job_status(job)
+                task.set_option(:playbooks, playbooks_status)
+              end
+            end
+          end
+
+          def main
+            transformation_hook = @handle.inputs['transformation_hook']
+
+            task = @handle.root['service_template_transformation_plan_task']
+            service_request_id = task.get_option("#{transformation_hook}_ansible_playbook_service_request_id")
+            service_request = @handle.vmdb(:miq_request).find_by(:id => service_request_id)
+
+            set_ansible_job(task, service_request, transformation_hook)
+
+            if service_request.request_state == 'finished'
+              @handle.log(:info, "Ansible playbook service request (id: #{service_request_id}) is finished.")
+              if transformation_hook == 'pre' && service_request.status == 'Error'
+                raise "Ansible playbook has failed (hook=#{transformation_hook})"
+              end
+            else
+              set_retry('Service request is not finished yet.', '15.seconds')
+            end
+          rescue => e
+            @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+            raise
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Transformation::Ansible::CheckPlaybookAsAService.new.main
+end

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -13,7 +13,7 @@ module ManageIQ
           def main
             transformation_hook = @handle.inputs['transformation_hook']
             task = @handle.root['service_template_transformation_plan_task']
-            service_request_id = task.get_option("#{transformation_hook}_ansible_playbook_service_request_id")
+            service_request_id = task.get_option("#{transformation_hook}_ansible_playbook_service_request_id".to_sym)
 
             if service_request_id.present?
               service_request = @handle.vmdb(:miq_request).find_by(:id => service_request_id)

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -24,7 +24,8 @@ module ManageIQ
               if service_request.request_state == 'finished'
                 @handle.log(:info, "Ansible playbook service request (id: #{service_request_id}) is finished.")
                 playbooks_status[transformation_hook][:job_status] = service_request.status
-                playbooks_status[transformation_hook][:job_id] = service_request.miq_request_tasks.first.destination.service_resource.first.id
+                playbooks_status[transformation_hook][:job_id] = service_request.miq_request_tasks.first.destination.service_resources.first.resource.id
+                task.set_option(:playbooks, playbooks_status)
                 if service_request.status == 'Error' && transformation_hook == 'pre'
                   raise "Ansible playbook has failed (hook=#{transformation_hook})"
                 end
@@ -33,6 +34,7 @@ module ManageIQ
                 @handle.root['ae_result'] = 'retry'
                 @handle.root['ae_retry_interval'] = '15.seconds'
               end
+              task.set_option(:playbooks, playbooks_status)
             end
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -18,7 +18,7 @@ module ManageIQ
 
             playbooks_status = task.get_option(:playbooks) || {}
             playbooks_status[transformation_hook] = { :job_state => service_request.request_state }
-            
+
             if service_request.request_state == 'finished'
               @handle.log(:info, "Ansible playbook service request (id: #{service_request_id}) is finished.")
               playbooks_status[transformation_hook][:job_status] = service_request.status
@@ -27,9 +27,9 @@ module ManageIQ
                 raise "Ansible playbook has failed (hook=#{transformation_hook})"
               end
             else
-            @handle.log(:info, "Playbook for #{transformation_hook} migration is not finished. Retrying.")
-            @handle.root['ae_result'] = 'retry'
-            @handle.root['ae_retry_interval'] = '15.seconds'
+              @handle.log(:info, "Playbook for #{transformation_hook} migration is not finished. Retrying.")
+              @handle.root['ae_result'] = 'retry'
+              @handle.root['ae_retry_interval'] = '15.seconds'
             end
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -8,50 +8,28 @@ module ManageIQ
           end
 
           def set_retry(message, interval = '1.minutes')
-            @handle.log(:info, "#{message}. Retrying.")
-            @handle.root['ae_result'] = 'retry'
-            @handle.root['ae_retry_interval'] = interval
-          end
-
-          def job_status(job)
-            { :job_id => job.id, :job_status => job.status }
-          end
-
-          def set_ansible_job(task, service_request, transformation_hook)
-            job = nil
-            service_request_task = service_request.miq_request_tasks.first
-            unless service_request_task.nil?
-              stack = service_request_task.destination.service_resources.first
-              job = stack.resource unless stack.nil?
-            end
-            playbooks_status = task.get_option(:playbooks) || {}
-
-            if playbooks_status[transformation_hook].nil?
-              if job.nil?
-                set_retry('Ansible job has not started yet.', '15.seconds')
-              else
-                playbooks_status[transformation_hook] = job_status(job)
-                task.set_option(:playbooks, playbooks_status)
-              end
-            end
           end
 
           def main
             transformation_hook = @handle.inputs['transformation_hook']
-
             task = @handle.root['service_template_transformation_plan_task']
             service_request_id = task.get_option("#{transformation_hook}_ansible_playbook_service_request_id")
             service_request = @handle.vmdb(:miq_request).find_by(:id => service_request_id)
 
-            set_ansible_job(task, service_request, transformation_hook)
-
+            playbooks_status = task.get_option(:playbooks) || {}
+            playbooks_status[transformation_hook] = { :job_state => service_request.request_state }
+            
             if service_request.request_state == 'finished'
               @handle.log(:info, "Ansible playbook service request (id: #{service_request_id}) is finished.")
-              if transformation_hook == 'pre' && service_request.status == 'Error'
+              playbooks_status[transformation_hook][:job_status] = service_request.status
+              playbooks_status[transformation_hook][:job_id] = service_request.miq_request_tasks.first.destination.service_resource.first.id
+              if service_request.status == 'Error' && transformation_hook == 'pre'
                 raise "Ansible playbook has failed (hook=#{transformation_hook})"
               end
             else
-              set_retry('Service request is not finished yet.', '15.seconds')
+            @handle.log(:info, "Playbook for #{transformation_hook} migration is not finished. Retrying.")
+            @handle.root['ae_result'] = 'retry'
+            @handle.root['ae_retry_interval'] = '15.seconds'
             end
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.yaml
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.yaml
@@ -1,0 +1,33 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: CheckPlaybookAsAService
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs:
+  - field:
+      aetype: 
+      name: transformation_hook
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: _
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -10,10 +10,10 @@ module ManageIQ
           def target_host(task, transformation_hook)
             target_host = nil
             case transformation_hook
-            when /^pre_/
+            when 'pre'
               target_host = task.source
-            when /^post_/
-              target_host = @handle.vmdb(:vm).find_by(:id => task.get_option('destination_vm_id'))
+            when 'post'
+              target_host = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
             end
             target_host
           end
@@ -26,7 +26,7 @@ module ManageIQ
               service_template = task.send("#{transformation_hook}_ansible_playbook_service_template")
               @handle.log(:info, "Service Template Id: #{service_template.id}")
               unless service_template.nil?
-                target_host = target_host(transformation_hook)
+                target_host = target_host(task, transformation_hook)
                 unless target_host.nil?
                   if target_host.power_state == 'on'
                     service_dialog_options = { :hosts => target_host.ipaddresses.first }

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -7,21 +7,19 @@ module ManageIQ
             @handle = handle
           end
 
-          def target_host(transformation_hook)
+          def target_host(task, transformation_hook)
             target_host = nil
             case transformation_hook
             when /^pre_/
-              target_host = source_vm
+              target_host = task.source
             when /^post_/
-              target_host = destination_vm
+              target_host = @handle.vmdb(:vm).find_by(:id => task.get_option('destination_vm_id'))
             end
             target_host
           end
 
           def main
             task = @handle.root['service_template_transformation_plan_task']
-            source_vm = task.source
-            destination_vm = @handle.vmdb(:vm).find_by(:id => task.get_option('destination_vm_id'))
             transformation_hook = @handle.inputs['transformation_hook']
 
             unless transformation_hook == '_'

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -25,16 +25,13 @@ module ManageIQ
             unless transformation_hook == '_'
               service_template = task.send("#{transformation_hook}_ansible_playbook_service_template")
               @handle.log(:info, "Service Template Id: #{service_template.id}")
-              unless service_template.nil?
-                target_host = target_host(task, transformation_hook)
-                unless target_host.nil?
-                  if target_host.power_state == 'on'
-                    service_dialog_options = { :hosts => target_host.ipaddresses.first }
-                    service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
-                    task.set_option("#{transformation_hook}_ansible_playbook_service_request_id", service_request.id)
-                  end
-                end
-              end
+              return if service_template.nil?
+              target_host = target_host(task, transformation_hook)
+              return if target_host.nil?
+              return unless target_host.power_state == 'on'
+              service_dialog_options = { :hosts => target_host.ipaddresses.first }
+              service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
+              task.set_option("#{transformation_hook}_ansible_playbook_service_request_id".to_sym, service_request.id)
             end
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -1,0 +1,53 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Ansible
+        class LaunchPlaybookAsAService
+          def initialize(handle = $evm)
+            @handle = handle
+          end
+
+          def target_host(transformation_hook)
+            target_host = nil
+            case transformation_hook
+            when /^pre_/
+              target_host = source_vm
+            when /^post_/
+              target_host = destination_vm
+            end
+            target_host
+          end
+
+          def main
+            task = @handle.root['service_template_transformation_plan_task']
+            source_vm = task.source
+            destination_vm = @handle.vmdb(:vm).find_by(:id => task.get_option('destination_vm_id'))
+            transformation_hook = @handle.inputs['transformation_hook']
+
+            unless transformation_hook == '_'
+              service_template = task.send("#{transformation_hook}_ansible_playbook_service_template")
+              @handle.log(:info, "Service Template Id: #{service_template.id}")
+              unless service_template.nil?
+                target_host = target_host(transformation_hook)
+                unless target_host.nil?
+                  if target_host.power_state == 'on'
+                    service_dialog_options = { :hosts => target_host.ipaddresses.first }
+                    service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
+                    task.set_option("#{transformation_hook}_ansible_playbook_service_request_id", service_request.id)
+                  end
+                end
+              end
+            end
+          rescue => e
+            @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+            raise
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService.new.main
+end

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.yaml
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.yaml
@@ -1,0 +1,33 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: LaunchPlaybookAsAService
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs:
+  - field:
+      aetype: 
+      name: transformation_hook
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: _
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/Ansible.class/_missing.yaml
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/_missing.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: "${#_missing_instance}"

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkpoweredon.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkpoweredon.rb
@@ -13,10 +13,7 @@ module ManageIQ
                 task = @handle.root['service_template_transformation_plan_task']
                 if task.get_option(:source_vm_power_state) == 'on'
                   destination_vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
-                  destination_ems = destination_vm.ext_management_system
-                  destination_vm_sdk = ManageIQ::Automate::Transformation::Infrastructure::VM::RedHat::Utils.new(destination_ems).vm_find_by_name(destination_vm.name)
-                  @handle.log(:info, "Status of VM '#{destination_vm.name}': #{destination_vm_sdk.status}")
-                  unless destination_vm_sdk.status == OvirtSDK4::VmStatus::UP
+                  unless destination_vm.power_state == 'on'
                     @handle.root["ae_result"] = "retry"
                     @handle.root["ae_retry_interval"] = "15.seconds"
                   end

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkpoweredon.yaml
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkpoweredon.yaml
@@ -9,7 +9,5 @@ object:
     scope: instance
     language: ruby
     location: inline
-    embedded_methods:
-    - "/Transformation/Infrastructure/VM/rhevm/Utils"
     options: {}
   inputs: []

--- a/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/__class__.yaml
@@ -1,0 +1,133 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Ansible
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: State1
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State2
+      display_name: 
+      datatype: 
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State3
+      display_name: 
+      datatype: 
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State4
+      display_name: 
+      datatype: 
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State5
+      display_name: 
+      datatype: 
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State6
+      display_name: 
+      datatype: 
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
@@ -10,18 +10,18 @@ object:
   fields:
   - State2:
       value: "/Transformation/Ansible/LaunchPlaybookAsAService"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
-        => "Launch ${#migration_hook} migration playbook", task_message => "Migrating")
-      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
-        => "Launch ${#migration_hook} migration playbook", task_message => "Migrating")
-      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
-        => "Launch ${#migration_hook} migration playbook", task_message => "Migrating")
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 20, description
+        => "Launch ${#transformation_hook} migration playbook", task_message => "Migrating")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 20, description
+        => "Launch ${#transformation_hook} migration playbook", task_message => "Migrating")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 20, description
+        => "Launch ${#transformation_hook} migration playbook", task_message => "Migrating")
   - State5:
       value: "/Transformation/Ansible/CheckPlaybookAsAService"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
-        => "Check ${#migration_hook} migration playbook", task_message => "Migrating")
-      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
-        => "Check ${#migration_hook} migration playbook", task_message => "Migrating")
-      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
-        => "Check ${#migration_hook} migration playbook", task_message => "Migrating")
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description
+        => "Check ${#transformation_hook} migration playbook", task_message => "Migrating")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description
+        => "Check ${#transformation_hook} migration playbook", task_message => "Migrating")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description
+        => "Check ${#transformation_hook} migration playbook", task_message => "Migrating")
       max_retries: '1500'

--- a/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
@@ -1,0 +1,27 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: TransformationPlaybook
+    inherits: 
+    description: 
+  fields:
+  - State2:
+      value: "/Transformation/Ansible/LaunchPlaybookAsAService"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
+        => "Launch ${#migration_hook} migration playbook", task_message => "Migrating")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
+        => "Launch ${#migration_hook} migration playbook", task_message => "Migrating")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
+        => "Launch ${#migration_hook} migration playbook", task_message => "Migrating")
+  - State5:
+      value: "/Transformation/Ansible/CheckPlaybookAsAService"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
+        => "Check ${#migration_hook} migration playbook", task_message => "Migrating")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
+        => "Check ${#migration_hook} migration playbook", task_message => "Migrating")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 4, description
+        => "Check ${#migration_hook} migration playbook", task_message => "Migrating")
+      max_retries: '1500'

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
@@ -25,7 +25,7 @@ object:
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Acquire Transformation Host", task_message => "Pre-migration")
   - State8:
-      value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?migration_hook=pre"
+      value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?transformation_hook=pre"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Run pre-migration playbook")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
@@ -57,7 +57,7 @@ object:
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 84, description
         => "Transform VM")
   - State20:
-      value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?migration_hook=post"
+      value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?transformation_hook=post"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Run post-migration playbook")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
@@ -24,6 +24,14 @@ object:
         => "Acquire Transformation Host", task_message => "Pre-migration")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Acquire Transformation Host", task_message => "Pre-migration")
+  - State8:
+      value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?migration_hook=pre"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Run pre-migration playbook")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Run pre-migration playbook")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Run pre-migration playbook")
   - State11:
       value: "/Transformation/Infrastructure/VM/Common/PowerOff"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
@@ -42,12 +50,20 @@ object:
         => "Collapse Snapshots", task_message => "Pre-migration")
   - State17:
       value: "/Transformation/StateMachines/VMTransformation/${state_var#transformation_type}_${state_var#transformation_method}?state_ancestry=${#state_ancestry}/${#ae_state}"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 94, description
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 84, description
         => "Transform VM")
-      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 94, description
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 84, description
         => "Transform VM")
-      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 94, description
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 84, description
         => "Transform VM")
+  - State20:
+      value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?migration_hook=post"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Run post-migration playbook")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Run post-migration playbook")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Run post-migration playbook")
   - State23:
       value: "/Transformation/Infrastructure/VM/Common/RestoreVmAttributes"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description


### PR DESCRIPTION
This PR adds support to call playbooks in pre and post migration phases. The implementation is generic to allow calling playbooks for other hooks. The backend provides methods to get the service template associated to pre and post hooks. The `LaunchPlaybookAsAService` method call `create_provision_request` and stores the request id in the task options hash. The `CheckPlaybookAsAService` method checks the status of the request. It gracefully fails if the playbook fails in post migration.

The `CheckPlaybookAsAService` method also updates the Ansible Tower job status in the task options hash, so that the UI can display it and also collect the job output.

Unfortunately, the test to check whether the destination VM is on was introduced inconsistency. It used the oVirt SDK gem to get the information from the provider. It was meant to be faster than wait for refresh. However, with targeted refresh, the power state is reported fast. So I changed the test to use `destination_vm.power_state == 'on'`. Without it the post migration playbook could be skipped due to race condition.

This PR adds add the following attributes to task options hash (example):

```
"pre_ansible_playbook_service_request_id" => 3,
:playbooks => {
    "pre": {
      :job_state => "finished",
      :job_status => "Ok",
      :job_id => 4
    },
    "post": {
      :job_state => "pending"
    }
}
```

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1564250