### PR TITLE
Update WeightedUpdateStatus to handle task cancellation and cleanup

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -137,7 +137,6 @@ module ManageIQ
                   if @handle.root['ae_state_step'] == 'on_error'
                     task.message = 'Failed'
                     create_cleanup_request(task)
-                    task.set_option('cleanup_request_id', cleanup_request.id) unless cleanup_request.nil?
                   elsif task.get_option('cancel_requested')
                     task.message = 'Cancelled'
                     create_cleanup_request(task)

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -137,7 +137,7 @@ module ManageIQ
                   if @handle.root['ae_state_step'] == 'on_error'
                     task.message = 'Failed'
                     create_cleanup_request(task)
-                  elsif task.get_option('cancel_requested')
+                  elsif task.get_option('cancel_requested') && task.get_option(:cleanup_request_id).absent?
                     task.message = 'Canceled'
                     create_cleanup_request(task)
                     raise "Task cancellation requested."

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -31,7 +31,7 @@ module ManageIQ
 
             def create_cleanup_request
               sm_uri = @handle.object['cleanup_state_machine']
-              unless sm_uri.blank?
+              if sm_uri.present?
                 options = {}
                 sm_uri_array = sm_uri.split('/')
                 options[:instance_name] = sm_uri_array.pop

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -138,7 +138,7 @@ module ManageIQ
                     task.message = 'Failed'
                     create_cleanup_request(task)
                   elsif task.get_option('cancel_requested')
-                    task.message = 'Cancelled'
+                    task.message = 'Canceled'
                     create_cleanup_request(task)
                     raise "Task cancellation requested."
                   else

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -38,7 +38,7 @@ module ManageIQ
                 options[:class_name] = sm_uri_array.pop
                 options[:namespace] = sm_uri_array.join('/')
                 options[:user_id] = @handle.root['user_id']
-                request = @handle.execute("create_automation_request", options, 'admin', true)
+                request = @handle.execute("create_automation_request", options, @handle.root['user'].userid, true)
                 task.set_option(:cleanup_request_id, request.id) unless request.nil?
               end
             end

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -39,8 +39,8 @@ module ManageIQ
                 options[:namespace] = sm_uri_array.join('/')
                 options[:user_id] = @handle.root['user_id']
                 request = @handle.execute("create_automation_request", options, 'admin', true)
+                task.set_option(:cleanup_request_id, request.id) unless request.nil?
               end
-              task.set_option(:cleanup_request_id, request.id) unless request.nil?
             end
 
             def on_entry(state_hash, _, _, state_weight, state_description)

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -29,6 +29,20 @@ module ManageIQ
               percent
             end
 
+            def create_cleanup_request
+              sm_uri = @handle.object['cleanup_state_machine']
+              unless sm_uri.blank?
+                options = {}
+                sm_uri_array = sm_uri.split('/')
+                options[:instance_name] = sm_uri_array.pop
+                options[:class_name] = sm_uri_array.pop
+                options[:namespace] = sm_uri_array.join('/')
+                options[:user_id] = @handle.root['user_id']
+                request = @handle.execute("create_automation_request", options, 'admin', true).id
+              end
+              request
+            end
+
             def on_entry(state_hash, _, _, state_weight, state_description)
               # Initiate the state hash if it doesn't exist yet
               state_hash ||= { 'status' => 'active', 'weight' => state_weight, 'description' => state_description, 'message' => state_description }
@@ -122,6 +136,11 @@ module ManageIQ
                   # We set the task message.
                   if @handle.root['ae_state_step'] == 'on_error'
                     task.message = 'Failed'
+                    task.set_option('cleanup_request_id', create_cleanup_request.id)
+                  elsif task.get_option('cancel_requested')
+                    task.message = 'Cancelled'
+                    task.set_option('cleanup_request_id', create_cleanup_request.id)
+                    raise "Task cancellation requested."
                   else
                     task.message = @handle.inputs['task_message'] unless @handle.inputs['task_message'] == '_'
                   end


### PR DESCRIPTION
This PR implements task cancellation and cleanup. @bzwei has started implementing task cancellation on the backend: https://github.com/ManageIQ/manageiq/pull/17687/files. It adds an entry in task options hash called `cancel_requested` with value `true`. So we check if this entry exists and if yes we trigger the cleanup state machine and raise to abort the current state machine.

The method has also been changed to trigger the cleanup state machine when the migration is failed, i.e. the state exits `on_error`. The cleanup state machine is the same for failure and cancellation, as cancellation can be seen as a manual failure.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1599997