### PR TITLE
Fix computation of currently running conversions by host

### DIFF
--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -13,7 +13,7 @@ module ManageIQ
             end
 
             def self.get_runners_count_by_host(host, handle = $evm)
-              handle.vmdb(:service_template_transformation_plan_task).where(:state => 'active').select { |task| task.get_option(:transformation_host) == host }.size
+              handle.vmdb(:service_template_transformation_plan_task).where(:state => 'active').select { |task| task.get_option(:transformation_host_id) == host.id }.size
             end
 
             def self.transformation_hosts(ems, method, factory_config)
@@ -24,7 +24,7 @@ module ManageIQ
                   :host    => host,
                   :runners => {
                     :current => get_runners_count_by_host(host),
-                    :maximum => host.custom_get('Max Transformation Runners') || factory_config['transformation_host_max_runners'] || 1
+                    :maximum => host.custom_get('Max Transformation Runners') || factory_config['transformation_host_max_runners'] || 10
                   }
                 }
               end

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/vmtransform_vmwarews2rhevm_vddk.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/vmtransform_vmwarews2rhevm_vddk.rb
@@ -34,7 +34,7 @@ module ManageIQ
 
               max_runners = destination_ems.custom_get('Max Transformation Runners') || factory_config['max_transformation_runners_by_ems'] || 1
               if Transformation::TransformationHosts::Common::Utils.get_runners_count_by_ems(destination_ems, @handle.get_state_var(:transformation_method), factory_config) >= max_runners
-                @handle.log("Too many transformations running: (#{max_runners}). Retrying.")
+                @handle.log(":info, Too many transformations running: (#{max_runners}). Retrying.")
               else
                 # Collect the VMware connection information
                 vmware_uri = "vpx://"


### PR DESCRIPTION
The number of currently running conversions per host was based on task option named `transformation_host` which doesn't exist. We only store the transformation host id and name, as it is thinner than storing the host object. However, the method was not updated after this change.

The PR also sets the default max number of conversions per host to 10, which is the recommendation of oVirt.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1600152