### PR TITLE
Changed ansible_tower_job instance to use AutomationManagement namespace.

### DIFF
--- a/content/automate/ManageIQ/System/Request.class/ansible_tower_job.yaml
+++ b/content/automate/ManageIQ/System/Request.class/ansible_tower_job.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job/default"
+      value: "/AutomationManagement/AnsibleTower/Operations/StateMachines/Job/default"


### PR DESCRIPTION
Changed System/Request ansible_tower_job instance to use AutomationManagement namespace.
ConfigurationManagement namespace has been Deprecated.