### PR TITLE
Actually rename AE Instances, not just fixture filename

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_domain_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_domain_create.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: domain_create
+    name: nuage_domain_create
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_domain_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_domain_delete.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: domain_delete
+    name: nuage_domain_delete
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_domain_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_domain_update.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: domain_update
+    name: nuage_domain_update
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_enterprise_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_enterprise_create.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: enterprise_create
+    name: nuage_enterprise_create
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_enterprise_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_enterprise_delete.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: enterprise_delete
+    name: nuage_enterprise_delete
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_enterprise_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_enterprise_update.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: enterprise_update
+    name: nuage_enterprise_update
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_policygroup_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_policygroup_create.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: policygroup_create
+    name: nuage_policygroup_create
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_policygroup_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_policygroup_delete.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: policygroup_delete
+    name: nuage_policygroup_delete
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_policygroup_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_policygroup_update.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: policygroup_update
+    name: nuage_policygroup_update
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnet_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnet_create.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: subnet_create
+    name: nuage_subnet_create
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnet_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnet_delete.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: subnet_delete
+    name: nuage_subnet_delete
     inherits: 
     description: 
   fields:

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnet_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnet_update.yaml
@@ -4,7 +4,7 @@ version: 1.0
 object:
   attributes:
     display_name: 
-    name: subnet_update
+    name: nuage_subnet_update
     inherits: 
     description: 
   fields:


### PR DESCRIPTION
With previouse commit we accidently only updated filenames leaving actual AE Instance names without the `nuage_` prefix. Fixed.

Followup for: https://github.com/ManageIQ/manageiq-content/pull/363

@miq-bot add_label enhancement
@miq-bot assign @gmcculloug 

/cc @agrare @Ladas 