### PR TITLE
Trigger targeted refresh for new Nuage entities

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_floatingip_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_floatingip_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_floatingip_create
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_floatingip_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_floatingip_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_floatingip_delete
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_floatingip_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_floatingip_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_floatingip_update
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_l2domain_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_l2domain_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_l2domain_create
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_l2domain_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_l2domain_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_l2domain_delete
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_l2domain_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_l2domain_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_l2domain_update
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_sharednetworkresource_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_sharednetworkresource_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_sharednetworkresource_create
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_sharednetworkresource_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_sharednetworkresource_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_sharednetworkresource_delete
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_sharednetworkresource_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_sharednetworkresource_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_sharednetworkresource_update
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_vport_create.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_vport_create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_vport_create
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_vport_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_vport_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_vport_delete
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_vport_update.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_vport_update.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_vport_update
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"


### PR DESCRIPTION
With this commit we provide default AE Instances that are responsible of triggering event-based targeted refresh on recently supported Nuage entities. Namely, we support:

- sharednetworkresource (aka CloudNetwork)
- l2domain (aka CloudSubnet::L2)
- floatingip (aka FloatingIp)
- vport (aka NetworkPort)

@miq-bot add_label enhancement
@miq-bot assign @gmcculloug 

/cc @Ladas @agrare 