### PR TITLE
Refactor set retry for pre/post migration playbooks

### DIFF
--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -7,7 +7,10 @@ module ManageIQ
             @handle = handle
           end
 
-          def set_retry(message, interval = '1.minutes')
+	  def set_retry(message = nil, interval = '1.minutes')
+            @handle.log(:info, message) if message.present?
+            @handle.root['ae_result'] = 'retry'
+            @handle.root['ae_retry_interval'] = interval
           end
 
           def main
@@ -30,9 +33,7 @@ module ManageIQ
                   raise "Ansible playbook has failed (hook=#{transformation_hook})"
                 end
               else
-                @handle.log(:info, "Playbook for #{transformation_hook} migration is not finished. Retrying.")
-                @handle.root['ae_result'] = 'retry'
-                @handle.root['ae_retry_interval'] = '15.seconds'
+                set_retry("Playbook for #{transformation_hook} migration is not finished. Retrying.", '15.seconds')
               end
               task.set_option(:playbooks, playbooks_status)
             end

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -7,7 +7,7 @@ module ManageIQ
             @handle = handle
           end
 
-	  def set_retry(message = nil, interval = '1.minutes')
+          def set_retry(message = nil, interval = '1.minutes')
             @handle.log(:info, message) if message.present?
             @handle.root['ae_result'] = 'retry'
             @handle.root['ae_retry_interval'] = interval


### PR DESCRIPTION
As suggested by @mkanoor in another PR, this one separates the retry logic from the main code for pre-post-migration playbooks.

Associated RHBZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1564250