### PR TITLE
Fix hook string passing for pre/post-migration playbooks

### DIFF
--- a/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
@@ -9,7 +9,7 @@ object:
     description: 
   fields:
   - State2:
-      value: "/Transformation/Ansible/LaunchPlaybookAsAService"
+      value: "/Transformation/Ansible/LaunchPlaybookAsAService?transformation_hook=${#transformation_hook}"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 20, description
         => "Launch ${#transformation_hook} migration playbook", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 20, description
@@ -17,7 +17,7 @@ object:
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 20, description
         => "Launch ${#transformation_hook} migration playbook", task_message => "Migrating")
   - State5:
-      value: "/Transformation/Ansible/CheckPlaybookAsAService"
+      value: "/Transformation/Ansible/CheckPlaybookAsAService?transformation_hook=${#transformation_hook}"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description
         => "Check ${#transformation_hook} migration playbook", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description


### PR DESCRIPTION
The transformation hook is not passed from the parent state machine, so we have to force it. Somehow it was missing in https://github.com/ManageIQ/manageiq-content/pull/355.

Associated RHBZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1564250