### PR TITLE
Add default cleanup state machine for VM transformation

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.rb
@@ -1,0 +1,29 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Common
+        class AssessTransformationCleanup
+          def initialize(handle = $evm)
+            @handle = handle
+          end
+
+          def main
+            task = @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
+            raise 'No task found. Exiting' if task.nil?
+            @handle.log(:info, "Task: #{task.inspect}") if @debug
+
+            destination_ems = @handle.vmdb(:ext_management_system).find_by(:id => task.get_option(:destination_ems_id))
+            @handle.set_state_var(:destination_ems_type, destination_ems.emstype)
+          rescue => e
+            @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+            raise
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Transformation::Common::AssessTransformationCleanup.new.main
+end

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.rb
@@ -5,6 +5,7 @@ module ManageIQ
         class AssessTransformationCleanup
           def initialize(handle = $evm)
             @handle = handle
+            @debug = false
           end
 
           def main

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.rb
@@ -12,7 +12,10 @@ module ManageIQ
             raise 'No task found. Exiting' if task.nil?
             @handle.log(:info, "Task: #{task.inspect}") if @debug
 
-            destination_ems = @handle.vmdb(:ext_management_system).find_by(:id => task.get_option(:destination_ems_id))
+            destination_ems_id = task.get_option(:destination_ems_id)
+            raise "'destination_ems_id' is not available" if destination_ems_id.blank?
+            destination_ems = @handle.vmdb(:ext_management_system).find_by(:id => destination_ems_id)
+            raise "Destination EMS with id '#{destination_ems_id}' doesn't exist." if destination_ems.blank?
             @handle.set_state_var(:destination_ems_type, destination_ems.emstype)
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.yaml
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformationcleanup.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: AssessTransformationCleanup
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
@@ -11,6 +11,7 @@ module ManageIQ
 
               def main
                 task = @handle.root['service_template_transformation_plan_task']
+                task ||= @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
                 if task.get_option(:source_vm_power_state) == 'on'
                   destination_vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
                   destination_vm.start

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
@@ -12,11 +12,12 @@ module ManageIQ
               def main
                 if @handle.root['service_template_transformation_plan_task'].blank?
                   task = @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
-                  vm = task.source
+                  vm = task.source if task.present?
                 else
                   task = @handle.root['service_template_transformation_plan_task']
-                  vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
+                  vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id)) if task.present?
                 end
+                return if vm.blank?
                 vm.start if task.get_option(:source_vm_power_state) == 'on'
               rescue => e
                 @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
@@ -10,12 +10,14 @@ module ManageIQ
               end
 
               def main
-                task = @handle.root['service_template_transformation_plan_task']
-                task ||= @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
-                if task.get_option(:source_vm_power_state) == 'on'
-                  destination_vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
-                  destination_vm.start
+                if @handle.root['service_template_transformation_plan_task'].blank?
+                  task = @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
+                  vm = task.source
+                else
+                  task = @handle.root['service_template_transformation_plan_task']
+                  vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
                 end
+                vm.start if task.get_option(:source_vm_power_state) == 'on'
               rescue => e
                 @handle.set_state_var(:ae_state_progress, 'message' => e.message)
                 raise

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkpoweredon.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkpoweredon.rb
@@ -11,6 +11,7 @@ module ManageIQ
 
               def main
                 task = @handle.root['service_template_transformation_plan_task']
+                task ||= @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
                 if task.get_option(:source_vm_power_state) == 'on'
                   destination_vm = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
                   unless destination_vm.power_state == 'on'

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
@@ -12,8 +12,8 @@ object:
     owner: 
   schema:
   - field:
-      aetype: state
-      name: State1
+      aetype: attribute
+      name: cleanup_state_machine
       display_name: 
       datatype: 
       priority: 1
@@ -33,7 +33,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State2
+      name: State1
       display_name: 
       datatype: 
       priority: 2
@@ -53,7 +53,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State3
+      name: State2
       display_name: 
       datatype: 
       priority: 3
@@ -73,7 +73,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State4
+      name: State3
       display_name: 
       datatype: 
       priority: 4
@@ -93,7 +93,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State5
+      name: State4
       display_name: 
       datatype: 
       priority: 5
@@ -113,7 +113,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State6
+      name: State5
       display_name: 
       datatype: 
       priority: 6
@@ -133,7 +133,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State7
+      name: State6
       display_name: 
       datatype: 
       priority: 7
@@ -153,7 +153,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State8
+      name: State7
       display_name: 
       datatype: 
       priority: 8
@@ -173,7 +173,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State9
+      name: State8
       display_name: 
       datatype: 
       priority: 9
@@ -193,7 +193,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State10
+      name: State9
       display_name: 
       datatype: 
       priority: 10
@@ -213,7 +213,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State11
+      name: State10
       display_name: 
       datatype: 
       priority: 11
@@ -233,7 +233,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State12
+      name: State11
       display_name: 
       datatype: 
       priority: 12
@@ -253,7 +253,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State13
+      name: State12
       display_name: 
       datatype: 
       priority: 13
@@ -273,7 +273,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State14
+      name: State13
       display_name: 
       datatype: 
       priority: 14
@@ -293,7 +293,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State15
+      name: State14
       display_name: 
       datatype: 
       priority: 15
@@ -313,7 +313,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State16
+      name: State15
       display_name: 
       datatype: 
       priority: 16
@@ -333,7 +333,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State17
+      name: State16
       display_name: 
       datatype: 
       priority: 17
@@ -353,7 +353,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State18
+      name: State17
       display_name: 
       datatype: 
       priority: 18
@@ -373,7 +373,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State19
+      name: State18
       display_name: 
       datatype: 
       priority: 19
@@ -393,10 +393,30 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State20
+      name: State19
       display_name: 
       datatype: 
       priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State20
+      display_name: 
+      datatype: 
+      priority: 21
       owner: 
       default_value: 
       substitute: true

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: 
   fields:
+  - cleanup_state_machine:
+      value: "/Transformation/StateMachines/VMTransformation/TransformationCleanup"
   - State2:
       value: "/Transformation/Common/AssessTransformation"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformationcleanup.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformationcleanup.yaml
@@ -1,0 +1,43 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: TransformationCleanup
+    inherits: 
+    description: 
+  fields:
+  - State2:
+      value: "/Transformation/Common/AssessTransformationCleanup"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
+        => "Assess Migration Cleanup", task_message => "Cleanup")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
+        => "Assess Migration Cleanup", task_message => "Cleanup")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
+        => "Assess Migration Cleanup", task_message => "Cleanup")
+  - State5:
+      value: "/Transformation/TransformationHosts/Common/KillVirtV2V"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
+        => "Interrupt virt-v2v", task_message => "Cleanup")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
+        => "Interrupt virt-v2v", task_message => "Cleanup")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
+        => "Interrupt virt-v2v", task_message => "Cleanup")
+  - State8:
+      value: "/Transformation/Infrastructure/VM/Common/PowerOn"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
+        => "Power-on VM", task_message => "Cleanup")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
+        => "Power-on VM", task_message => "Cleanup")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
+        => "Power-on VM", task_message => "Cleanup")
+  - State11:
+      value: "/Transformation/Infrastructure/VM/${state_var#destination_ems_type}/CheckPoweredOn"
+      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
+        => "Power-on VM", task_message => "Cleanup")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
+        => "Power-on VM", task_message => "Cleanup")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
+        => "Power-on VM", task_message => "Cleanup")
+      max_retries: '200'

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -3,9 +3,8 @@ module ManageIQ
     module Transformation
       module TransformationHost
         module Common
-          class VMCheckTransformed
+          class KillVirtV2V
             def initialize(handle = $evm)
-              @debug = true
               @handle = handle
             end
 
@@ -36,5 +35,5 @@ module ManageIQ
 end
 
 if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::Common::VMCheckTransformed.new.main
+  ManageIQ::Automate::Transformation::TransformationHost::Common::KillVirtV2V.new.main
 end

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -18,7 +18,7 @@ module ManageIQ
               transformation_host = @handle.vmdb(:host).find_by(:id => task.get_option(:transformation_host_id))
 
               # Skip if virtv2v has not started yet or is already finished
-              return if task.get_option(:virtv2v_started_on).blank? || !task.get_option(:virtv2v_finished_on).blank?
+              return if task.get_option(:virtv2v_started_on).blank? || task.get_option(:virtv2v_finished_on).present?
               # Skip if virtv2v wrapper information is not available
               return if task.get_option(:virtv2v_wrapper).blank?
               # Get the state of virtv2v from the conversion host
@@ -28,7 +28,7 @@ module ManageIQ
               virtv2v_state = JSON.parse(result[:stdout])
               @handle.log(:info, "VirtV2V State: #{virtv2v_state.inspect}")
               # Kill virt-v2v process
-              result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "kill -9 #{virtv2v_state['pid']}")
+              Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "kill -9 #{virtv2v_state['pid']}")
             rescue => e
               @handle.set_state_var(:ae_state_progress, 'message' => e.message)
               raise

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -9,26 +9,21 @@ module ManageIQ
               @handle = handle
             end
 
-            def main
+            def task_virtv2v_state(task, transformation_host)
               require 'json'
-
-              task = @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
-
-              # Retrieve transformation host
-              transformation_host = @handle.vmdb(:host).find_by(:id => task.get_option(:transformation_host_id))
-
-              # Skip if virtv2v has not started yet or is already finished
               return if task.get_option(:virtv2v_started_on).blank? || task.get_option(:virtv2v_finished_on).present?
-              # Skip if virtv2v wrapper information is not available
               return if task.get_option(:virtv2v_wrapper).blank?
-              # Get the state of virtv2v from the conversion host
               result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "cat '#{task.get_option(:virtv2v_wrapper)['state_file']}'")
-              # Skip if no information is available
               return if !result[:success] || result[:stdout].empty?
               virtv2v_state = JSON.parse(result[:stdout])
+            end
+
+            def main
+              task = @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
+              transformation_host = @handle.vmdb(:host).find_by(:id => task.get_option(:transformation_host_id))
+              virtv2v_state = task_virtv2v_state(task, transformation_host)
               @handle.log(:info, "VirtV2V State: #{virtv2v_state.inspect}")
-              # Kill virt-v2v process
-              Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "kill -9 #{virtv2v_state['pid']}")
+              Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "kill -9 #{virtv2v_state['pid']}") if virtv2v_state.present?
             rescue => e
               @handle.set_state_var(:ae_state_progress, 'message' => e.message)
               raise

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -1,0 +1,41 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module TransformationHost
+        module Common
+          class VMCheckTransformed
+            def initialize(handle = $evm)
+              @debug = true
+              @handle = handle
+            end
+
+            def main
+              require 'json'
+
+              task = @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
+
+              # Retrieve transformation host
+              transformation_host = @handle.vmdb(:host).find_by(:id => task.get_option(:transformation_host_id))
+
+              # Retrieve state of virt-v2v
+              result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "cat '#{task.get_option(:virtv2v_wrapper)['state_file']}'")
+              if result[:success] && !result[:stdout].empty?
+                virtv2v_state = JSON.parse(result[:stdout])
+                @handle.log(:info, "VirtV2V State: #{virtv2v_state.inspect}")
+                result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "kill -9 #{virtv2v_state['pid']}")
+                raise result[:stderr] unless result[:success]
+              end
+            rescue => e
+              @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+              raise
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ManageIQ::Automate::Transformation::TransformationHost::Common::VMCheckTransformed.new.main
+end

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -15,7 +15,7 @@ module ManageIQ
               return if task.get_option(:virtv2v_wrapper).blank?
               result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "cat '#{task.get_option(:virtv2v_wrapper)['state_file']}'")
               return if !result[:success] || result[:stdout].empty?
-              virtv2v_state = JSON.parse(result[:stdout])
+              JSON.parse(result[:stdout])
             end
 
             def main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.yaml
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.yaml
@@ -1,0 +1,16 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: KillVirtV2V
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    embedded_methods:
+    - "/Transformation/TransformationHosts/Common/Utils"
+    - "/Transformation/TransformationHosts/ovirt_host/Utils"
+    options: {}
+  inputs: []


### PR DESCRIPTION
This PR provides the default state machine for VM transformation cleanup. The state machine is triggered from an automate request, as designed in https://github.com/ManageIQ/manageiq-content/pull/357. The request creation passes a variable in `$evm.root`: `service_template_transformation_plan_task_id`.

The process is as follow:

1. Assess the transformation cleanup. It basically sets the required state vars.
2. Kill virt-v2v. The PID of the process and the transformation host information is available in the task. It simply needs a remote command execution to kill the process. `virt-v2v-wrapper` handles cleaning up the destination provider when the virt-v2v command fails, so nothing to do on ManageIQ side.
3. Power on the VM if it was powered on when the migration started.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1599997