### PR TITLE
Fix transformation host selection

### DIFF
--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -43,9 +43,9 @@ module ManageIQ
 
             def self.get_transformation_host(task, factory_config, handle = $evm)
               ems = handle.vmdb(:ext_management_system).find_by(:id => task.get_option(:destination_ems_id))
-              ems_max_runners = ems.custom_get('Max Transformation Runners').to_i || factory_config['ems_max_runners'] || 1
+              ems_max_runners = ems.custom_get('Max Transformation Runners') || factory_config['ems_max_runners'] || 10
               ems_cur_runners = get_runners_count_by_ems(ems, factory_config)
-              transformation_host_hash = ems_cur_runners < ems_max_runners ? eligible_transformation_hosts(ems, factory_config).first : {}
+              transformation_host_hash = ems_cur_runners < ems_max_runners.to_i ? eligible_transformation_hosts(ems, factory_config).first : {}
               return transformation_host_hash[:type], transformation_host_hash[:host], transformation_host_hash[:transformation_method]
             end
 

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -7,14 +7,6 @@ module ManageIQ
             DEFAULT_EMS_MAX_RUNNERS = 10
             DEFAULT_HOST_MAX_RUNNERS = 10
 
-            def initialize(handle = $evm)
-              @debug = true
-              @handle = handle
-            end
-
-            def main
-            end
-
             def self.get_runners_count_by_host(host, handle = $evm)
               handle.vmdb(:service_template_transformation_plan_task).where(:state => 'active').select { |task| task.get_option(:transformation_host_id) == host.id }.size
             end
@@ -145,8 +137,4 @@ module ManageIQ
       end
     end
   end
-end
-
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.new.main
 end

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -19,7 +19,7 @@ module ManageIQ
               handle.vmdb(:service_template_transformation_plan_task).where(:state => 'active').select { |task| task.get_option(:transformation_host_id) == host.id }.size
             end
 
-            def self.host_max_runners(host, factory_config, handle = $evm)
+            def self.host_max_runners(host, factory_config, max_runners = DEFAULT_HOST_MAX_RUNNERS, handle = $evm)
               if host.custom_get('Max Transformation Runners')
                 handle.log(:info, "Using max transformation runners from host custom attribute: #{host.custom_get('Max Transformation Runners')}")
                 host.custom_get('Max Transformation Runners').to_i
@@ -27,8 +27,8 @@ module ManageIQ
                 handle.log(:info, "Using max transformation runners from factory config: #{factory_config['transformation_host_max_runners']}")
                 factory_config['transformation_host_max_runners'].to_i
               else
-                handle.log(:info, "Using default max transformation runners: #{DEFAULT_HOST_MAX_RUNNERS}")
-                DEFAULT_HOST_MAX_RUNNERS
+                handle.log(:info, "Using default max transformation runners: #{max_runners}")
+                max_runners
               end
             end
 
@@ -57,7 +57,7 @@ module ManageIQ
               transformation_hosts(ems, factory_config).inject(0) { |sum, thost| sum + thost[:runners][:current] }
             end
 
-            def self.ems_max_runners(ems, factory_config, handle = $evm)
+            def self.ems_max_runners(ems, factory_config, max_runners = DEFAULT_EMS_MAX_RUNNERS, handle = $evm)
               if ems.custom_get('Max Transformation Runners')
                 handle.log(:info, "Using max transformation runners from EMS custom attribute: #{ems.custom_get('Max Transformation Runners')}")
                 ems.custom_get('Max Transformation Runners').to_i
@@ -65,8 +65,8 @@ module ManageIQ
                 handle.log(:info, "Using max transformation runners from factory config: #{factory_config['ems_max_runners']}")
                 factory_config['ems_max_runners'].to_i
               else
-                handle.log(:info, "Using default max transformation runners: #{DEFAULT_EMS_MAX_RUNNERS}")
-                DEFAULT_EMS_MAX_RUNNERS
+                handle.log(:info, "Using default max transformation runners: #{max_runners}")
+                max_runners
               end
             end
 

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -4,6 +4,8 @@ module ManageIQ
       module TransformationHosts
         module Common
           class Utils
+            DEFAULT_EMS_MAX_RUNNERS = 10
+
             def initialize(handle = $evm)
               @debug = true
               @handle = handle
@@ -41,11 +43,23 @@ module ManageIQ
               transformation_hosts(ems, factory_config).inject(0) { |sum, thost| sum + thost[:runners][:current] }
             end
 
+            def self.ems_max_runners(ems, factory_config, handle = $evm)
+              if ems.custom_get('Max Transformation Runners')
+                handle.log(:info, "Using max transformation runners from EMS custom attribute: #{ems.custom_get('Max Transformation Runners')}")
+                ems.custom_get('Max Transformation Runners').to_i
+              elsif factory_config['ems_max_runners']
+                handle.log(:info, "Using max transformation runners from factory config: #{factory_config['ems_max_runners']}")
+                factory_config['ems_max_runners'].to_i
+              else
+                handle.log(:info, "Using default max transformation runners: #{DEFAULT_EMS_MAX_RUNNERS}")
+                DEFAULT_EMS_MAX_RUNNERS
+              end
+            end
+
             def self.get_transformation_host(task, factory_config, handle = $evm)
               ems = handle.vmdb(:ext_management_system).find_by(:id => task.get_option(:destination_ems_id))
-              ems_max_runners = ems.custom_get('Max Transformation Runners') || factory_config['ems_max_runners'] || 10
               ems_cur_runners = get_runners_count_by_ems(ems, factory_config)
-              transformation_host_hash = ems_cur_runners < ems_max_runners.to_i ? eligible_transformation_hosts(ems, factory_config).first : {}
+              transformation_host_hash = ems_cur_runners < ems_max_runners(ems, factory_config) ? eligible_transformation_hosts(ems, factory_config).first : {}
               return transformation_host_hash[:type], transformation_host_hash[:host], transformation_host_hash[:transformation_method]
             end
 

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
@@ -32,8 +32,8 @@ module ManageIQ
               @handle.log(:info, "Transformation - Started On: #{start_timestamp}")
 
               destination_ems = @handle.vmdb(:ext_management_system).find_by(:id => task.get_option(:destination_ems_id))
-              max_runners = destination_ems.custom_get('Max Transformation Runners') || factory_config['max_transformation_runners_by_ems'] || 10
-              if Transformation::TransformationHosts::Common::Utils.get_runners_count_by_ems(destination_ems, factory_config) >= max_runners.to_i
+              max_runners = Transformation::TransformationHosts::Common::Utils.ems_max_runners(destination_ems, factory_config)
+              if Transformation::TransformationHosts::Common::Utils.get_runners_count_by_ems(destination_ems, factory_config) >= max_runners
                 @handle.log(:info, "Too many transformations running [#{max_runners}]. Retrying.")
               else
                 wrapper_options = ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.virtv2vwrapper_options(task)

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
@@ -32,8 +32,8 @@ module ManageIQ
               @handle.log(:info, "Transformation - Started On: #{start_timestamp}")
 
               destination_ems = @handle.vmdb(:ext_management_system).find_by(:id => task.get_option(:destination_ems_id))
-              max_runners = destination_ems.custom_get('Max Transformation Runners').to_i || factory_config['max_transformation_runners_by_ems'] || 10
-              if Transformation::TransformationHosts::Common::Utils.get_runners_count_by_ems(destination_ems, factory_config) >= max_runners
+              max_runners = destination_ems.custom_get('Max Transformation Runners') || factory_config['max_transformation_runners_by_ems'] || 10
+              if Transformation::TransformationHosts::Common::Utils.get_runners_count_by_ems(destination_ems, factory_config) >= max_runners.to_i
                 @handle.log(:info, "Too many transformations running [#{max_runners}]. Retrying.")
               else
                 wrapper_options = ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.virtv2vwrapper_options(task)


### PR DESCRIPTION
The comparison fails because `nil.to_i` equals to 0. This leads to endless loop on the AcquireTransformationHost and VMTransform states.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1600152