### PR TITLE
Allow running playbook against powered off VM

### DIFF
--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -26,7 +26,7 @@ module ManageIQ
             service_template = task.send("#{transformation_hook}_ansible_playbook_service_template")
             return if service_template.nil?
             target_host = target_host(task, transformation_hook)
-            return if target_host.nil? || target_host.power_state != 'on'
+            return if target_host.nil?
             service_dialog_options = { :hosts => target_host.ipaddresses.first }
             service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
             task.set_option("#{transformation_hook}_ansible_playbook_service_request_id".to_sym, service_request.id)

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -26,7 +26,7 @@ module ManageIQ
             service_template = task.send("#{transformation_hook}_ansible_playbook_service_template")
             return if service_template.nil?
             target_host = target_host(task, transformation_hook)
-            return if target_host.nil?
+            return if target_host.blank?
             service_dialog_options = { :hosts => target_host.ipaddresses.first }
             service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
             task.set_option("#{transformation_hook}_ansible_playbook_service_request_id".to_sym, service_request.id)


### PR DESCRIPTION
It has been decided that pre/post-migration playbooks should be executed even if the VM is powered off. This allows to act on external system on behalf of the VM, using `delegate_to` statements. As the pre-migration playbook failure implies migration failure, it's the responsibility of the user to write playbook that don't fail if the VM is down.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1564250