### PR TITLE
Use targeted refresh during transformation

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/vm_import_from_configuration_executed_successfully.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/vm_import_from_configuration_executed_successfully.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: VM_IMPORT_FROM_CONFIGURATION_EXECUTED_SUCCESSFULLY
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh_new_target?target=src_vm"

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkvmininventory.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkvmininventory.rb
@@ -16,7 +16,7 @@ module ManageIQ
                 destination_vm = ManageIQ::Automate::Transformation::Infrastructure::VM::RedHat::Utils.new(destination_ems).vm_find_by_name(source_vm.name)
                 raise "VM #{source_vm.name} not found in destination provider #{destination_ems.name}" if destination_vm.nil?
 
-                destination_vm_vmdb = @handle.vmdb(:vm).where(["ems_ref = ?", destination_vm.href.gsub(/^\/ovirt-engine/, '')]).first
+                destination_vm_vmdb = @handle.vmdb(:vm).find_by(:ems_ref => destination_vm.href.gsub(/^\/ovirt-engine/, ''))
                 if destination_vm_vmdb.blank?
                   @handle.root['ae_result'] = 'retry'
                   @handle.root['ae_retry_interval'] = '15.seconds'

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkvmininventory.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkvmininventory.rb
@@ -16,27 +16,13 @@ module ManageIQ
                 destination_vm = ManageIQ::Automate::Transformation::Infrastructure::VM::RedHat::Utils.new(destination_ems).vm_find_by_name(source_vm.name)
                 raise "VM #{source_vm.name} not found in destination provider #{destination_ems.name}" if destination_vm.nil?
 
-                finished = false
-
                 destination_vm_vmdb = @handle.vmdb(:vm).where(["ems_ref = ?", destination_vm.href.gsub(/^\/ovirt-engine/, '')]).first
                 if destination_vm_vmdb.blank?
-                  @handle.log(:info, "VM '#{source_vm.name}' not found in VMDB.")
-                  if @handle.state_var_exist?(:ems_refresh_in_progress)
-                    @handle.log(:info, "Refresh of '#{destination_ems.name}' is in progress. Nothing to do.")
-                  else
-                    @handle.log(:info, "Forcing refresh of provider '#{destination_ems.name}'")
-                    destination_ems.refresh
-                    @handle.set_state_var(:ems_refresh_in_progress, true)
-                  end
+                  @handle.root['ae_result'] = 'retry'
+                  @handle.root['ae_retry_interval'] = '15.seconds'
                 else
                   @handle.log(:info, "VM '#{source_vm.name}' found in VMDB with id '#{destination_vm_vmdb.id}'")
                   task.set_option(:destination_vm_id, destination_vm_vmdb.id)
-                  finished = true
-                end
-
-                unless finished
-                  @handle.root['ae_result'] = 'retry'
-                  @handle.root['ae_retry_interval'] = '15.seconds'
                 end
               rescue => e
                 @handle.set_state_var(:ae_state_progress, 'message' => e.message)


### PR DESCRIPTION
Previously, during transformation, we triggered a full refresh to be sure that the VM was in the inventory for the post migration steps. But, this consumed a lot of resources compared to the single VM we want to track. And on a huge inventory with thousands of VMs, triggering a full refresh for each migration can soon be problematic.

This PR adds a new instance in the event switchboard that triggers a targeted refresh for the associated VM. The event is named `VM_IMPORT_FROM_CONFIGURATION_EXECUTED_SUCCESSFULLY`.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1607368