### PR TITLE
Options hash should not store Active Record objects

### DIFF
--- a/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
+++ b/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
@@ -20,7 +20,7 @@ describe "FilterByDialogParameters Automate Method" do
              "middle"     => {:type    => 'composite', :children => ['vm_service']},
              "vm_service" => {:type    => 'atomic',
                               :request => {:target_name => "fred", :src_vm_id => @src_vm.id,
-                                           :number_of_vms => 1, :requester => @user}
+                                           :number_of_vms => 1, :requester_id => @user.id}
                              }
             }
     build_service_template_tree(model)


### PR DESCRIPTION
This spec was passing the user object and storing it in the
options hash, pass the id instead.

Related to https://github.com/ManageIQ/manageiq/pull/17783