### PR TITLE
Fix quota requested cloud_volume calculations.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -264,7 +264,7 @@ def cloud_storage(args_hash)
               flavor.root_disk_size.to_i + flavor.ephemeral_disk_size.to_i + flavor.swap_disk_size.to_i
             end
 
-  storage += cloud_volume_storage(args_hash) if @reconfigure_request
+  storage += cloud_volume_storage(args_hash)
   $evm.log(:info, "Retrieving cloud storage #{storage}")
   default_option(storage, args_hash[:options_array])
 end

--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -186,6 +186,17 @@ describe "Quota Validation" do
     end
   end
 
+  context "VM Cloud provisioning with cloud volumes" do
+    it "google calculate_requested number of vms 3, cloud volumes 3 gig " do
+      setup_model("google")
+      @miq_provision_request.options[:volumes] = [{:name => "Fred", :size => '1'}, {:name => "Wilma", :size => '2'}]
+      @miq_provision_request.options[:number_of_vms] = 3
+      @miq_provision_request.save
+      ws = run_automate_method(vm_attrs)
+      check_results(ws.root['quota_requested'], 39.gigabytes, 12, 3, 3.kilobytes)
+    end
+  end
+
   context "VM provisioning quota" do
     it "vmware calculate_requested" do
       setup_model("vmware")


### PR DESCRIPTION
Add spec test for google cloud volumes and check for cloud_volumes unconditionally.

The quota requested method was checking for cloud_volumes only on a reconfigure request. We should be checking for cloud_volumes all cloud provisioning requests.