### PR TITLE
Transformation - Refactor task and vm collection

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
@@ -23,7 +23,7 @@ module ManageIQ
             handle.vmdb(:service_template_transformation_plan_task).find_by(:id => handle.root['service_template_transformation_plan_task_id'])
           end
 
-          def self.vm_at_source(task, handle = $evm)
+          def self.vm_at_source(task, _)
             task.source
           end
 

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
@@ -10,8 +10,8 @@ module ManageIQ
           end
 
           def self.task_and_vm(vm_type, handle = $evm)
-            task = send("task_in_#{migration_phase}")
-            vm = send("vm_at_#{vm_type}", task) if task.present?
+            task = send("task_in_#{migration_phase(handle)}", handle)
+            vm = send("vm_at_#{vm_type}", task, handle) if task.present?
             return task, vm
           end
 

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
@@ -3,7 +3,7 @@ module ManageIQ
     module Transformation
       module Common
         class Utils
-          STATE_MACHINE_PHASES=%(transformation cleanup)
+          STATE_MACHINE_PHASES = %w(transformation cleanup).freeze
 
           def self.log_and_raise(message, handle = $evm)
             handle.log(:error, message)

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
@@ -11,7 +11,7 @@ module ManageIQ
           end
 
           def self.transformation_phase(handle = $evm)
-            @transformation_phase = handle.root['state_machine_phase'].tap do |phase|
+            @transformation_phase ||= handle.root['state_machine_phase'].tap do |phase|
               log_and_raise('Transformation phase is not valid', handle) if STATE_MACHINE_PHASES.exclude?(phase)
             end
           end
@@ -31,7 +31,7 @@ module ManageIQ
           end
 
           def self.cleanup_task(handle = $evm)
-            log_and_raise('service_template_transformation_plan_task_id is not defined') if handle.root['service_template_transformation_plan_task_id'].nil?
+            log_and_raise('service_template_transformation_plan_task_id is not defined', handle) if handle.root['service_template_transformation_plan_task_id'].nil?
             @task ||= handle.vmdb(:service_template_transformation_plan_task).find_by(:id => handle.root['service_template_transformation_plan_task_id']).tap do |task|
               log_and_raise('A service_template_transformation_plan_task is needed for this method to continue', handle) if task.nil?
             end
@@ -44,8 +44,11 @@ module ManageIQ
           end
 
           def self.destination_vm(handle = $evm)
-            return if task(handle).get_option(:destination_vm_id).nil?
-            @destination_vm ||= handle.vmdb(:vm).find_by(:id => task(handle).get_option(:destination_vm_id))
+            destination_vm_id = task(handle).get_option(:destination_vm_id)
+            return if destination_vm_id.nil?
+            @destination_vm ||= handle.vmdb(:vm).find_by(:id => destination_vm_id).tap do |vm|
+              log_and_raise("No match for destination_vm_id in VMDB", handle) if vm.nil?
+            end
           end
         end
       end

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
@@ -1,0 +1,38 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Common
+        class Utils
+          def self.migration_phase(handle = $evm)
+            return 'migration' if handle.root['service_template_transformation_plan_task'].present?
+            return 'cleanup' if handle.root['service_template_transformation_plan_task_id'].present?
+            raise 'Migration phase is not valid'
+          end
+
+          def self.task_and_vm(vm_type, handle = $evm)
+            task = send("task_in_#{migration_phase}")
+            vm = send("vm_at_#{vm_type}", task) if task.present?
+            return task, vm
+          end
+
+          def self.task_in_migration(handle = $evm)
+            handle.root['service_template_transformation_plan_task']
+          end
+
+          def self.task_in_cleanup(handle = $evm)
+            handle.vmdb(:service_template_transformation_plan_task).find_by(:id => handle.root['service_template_transformation_plan_task_id'])
+          end
+
+          def self.vm_at_source(task, handle = $evm)
+            task.source
+          end
+
+          def self.vm_at_destination(task, handle = $evm)
+            return if task.get_option(:destination_vm_id).nil?
+            handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
+          end
+        end
+      end
+    end
+  end
+end

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.yaml
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Utils
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
@@ -1,7 +1,6 @@
 require domain_file
 
 describe ManageIQ::Automate::Transformation::Common::Utils do
-
   let(:user) { FactoryGirl.create(:user_with_email_and_group) }
   let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
   let(:src_vm_vmware) { FactoryGirl.create(:vm_vmware) }

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
@@ -1,0 +1,189 @@
+require domain_file
+require 'byebug'
+
+describe ManageIQ::Automate::Transformation::Common::Utils do
+  
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:src_vm_vmware) { FactoryGirl.create(:vm_vmware) }
+  let(:dst_vm_redhat) { FactoryGirl.create(:vm_redhat) }
+  let(:dst_vm_openstack) { FactoryGirl.create(:vm_openstack) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }
+  let(:svc_model_src_vm_vmware) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(src_vm_vmware.id) }
+  let(:svc_model_dst_vm_redhat) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager_Vm.find(dst_vm_redhat.id) }
+  let(:svc_model_dst_vm_openstack) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm.find(dst_vm_openstack.id) }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current' => current_object,
+      'user'    => svc_model_user,
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object.parent = root
+      service.current_object = current_object
+    end
+  end
+
+  context "migration phase" do
+    it "with task" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      expect(described_class.migration_phase(ae_service)).to eq('migration')     
+    end
+
+    it "with task_id" do
+      ae_service.root['service_template_transformation_plan_task_id'] = svc_model_task.id
+      expect(described_class.migration_phase(ae_service)).to eq('cleanup')     
+    end
+
+    it "failure" do
+      expect { described_class.migration_phase(ae_service) }.to raise_error(StandardError, 'Migration phase is not valid')
+    end
+  end
+
+
+  shared_examples_for "task_in_migration" do
+    it "with task" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      expect(described_class.task_in_migration(ae_service).id).to eq(svc_model_task.id)
+    end
+
+    it "without task" do
+      expect(described_class.task_in_migration(ae_service)).to be_nil
+    end
+  end
+
+  context "task_in_migration vmware to redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+
+    it_behaves_like "task_in_migration"
+  end
+
+  context "task_in_migration vmware to openstack" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+
+    it_behaves_like "task_in_migration"
+  end
+
+
+  shared_examples_for "task_in_cleanup" do
+    it "with task_id" do
+      ae_service.root['service_template_transformation_plan_task_id'] = svc_model_task.id
+      expect(described_class.task_in_cleanup(ae_service).id).to eq(svc_model_task.id)
+    end
+
+    it "without task_id" do
+      expect(described_class.task_in_cleanup(ae_service)).to be_nil
+    end
+  end
+
+  context "task_in_cleanup vmware to redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+
+    it_behaves_like "task_in_cleanup"
+  end
+
+  context "task_in_cleanup vmware to openstack" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+
+    it_behaves_like "task_in_cleanup"
+  end
+
+
+  shared_examples_for "vm_at_source" do
+    before do
+      allow(svc_model_task).to receive(:source) { svc_model_src_vm }
+    end
+
+    it "vm" do
+      expect(described_class.vm_at_source(svc_model_task, ae_service).id).to eq(svc_model_src_vm.id)
+    end
+  end
+
+  context "vm_at_source vmware" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    it_behaves_like "vm_at_source"
+  end
+
+
+  shared_examples_for "vm_at_destination" do
+    before do
+      allow(svc_model_task).to receive(:get_option).with(:destination_vm_id).and_return(svc_model_dst_vm.id)
+    end
+
+    it "vm" do
+      expect(described_class.vm_at_destination(svc_model_task, ae_service).id).to eq(svc_model_dst_vm.id)
+    end
+  end
+
+  context "vm_at_source vmware to redhat" do
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+    it_behaves_like "vm_at_destination"
+  end
+
+  context "vm_at_source vmware to openstack" do
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+    it_behaves_like "vm_at_destination"
+  end
+
+
+
+  shared_examples_for "task_and_vm" do
+    before do
+      allow(svc_model_task).to receive(:source) { svc_model_src_vm }
+      allow(svc_model_task).to receive(:get_option).with(:destination_vm_id).and_return(svc_model_dst_vm.id)
+    end
+
+    it "task_and_vm in migration at source" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      byebug
+      r_task, r_vm = described_class.task_and_vm('source', ae_service)
+      expect(r_task.id).to eq(svc_model_task.id)
+      expect(r_vm.id).to eq(svc_model_src_vm.id)
+    end
+
+    it "task_and_vm in migration at destination" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      r_task, r_vm = described_class.task_and_vm('destination', ae_service)
+      expect(r_task.id).to eq(svc_model_task.id)
+      expect(r_vm.id).to eq(svc_model_dst_vm.id)
+    end
+
+    it "task_and_vm_in cleanup at source" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      r_task, r_vm = described_class.task_and_vm('source', ae_service)
+      expect(r_task.id).to eq(svc_model_task.id)
+      expect(r_vm.id).to eq(svc_model_dst_vm.id)
+    end
+
+    it "task_and_vm_in cleanup at destination" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      r_task, r_vm = described_class.task_and_vm('destination', ae_service)
+      expect(r_task.id).to eq(svc_model_task.id)
+      expect(r_vm.id).to eq(svc_model_dst_vm.id)
+    end
+  end
+
+  context "task_and_vm migration vmware to redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+
+    it_behaves_like "task_and_vm"
+  end
+
+  context "task_and_vm migration vmware to openstack" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+
+    it_behaves_like "task_and_vm"
+  end
+end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
@@ -1,8 +1,7 @@
 require domain_file
-require 'byebug'
 
 describe ManageIQ::Automate::Transformation::Common::Utils do
-  
+
   let(:user) { FactoryGirl.create(:user_with_email_and_group) }
   let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
   let(:src_vm_vmware) { FactoryGirl.create(:vm_vmware) }
@@ -33,19 +32,18 @@ describe ManageIQ::Automate::Transformation::Common::Utils do
   context "migration phase" do
     it "with task" do
       ae_service.root['service_template_transformation_plan_task'] = svc_model_task
-      expect(described_class.migration_phase(ae_service)).to eq('migration')     
+      expect(described_class.migration_phase(ae_service)).to eq('migration')
     end
 
     it "with task_id" do
       ae_service.root['service_template_transformation_plan_task_id'] = svc_model_task.id
-      expect(described_class.migration_phase(ae_service)).to eq('cleanup')     
+      expect(described_class.migration_phase(ae_service)).to eq('cleanup')
     end
 
     it "failure" do
       expect { described_class.migration_phase(ae_service) }.to raise_error(StandardError, 'Migration phase is not valid')
     end
   end
-
 
   shared_examples_for "task_in_migration" do
     it "with task" do
@@ -72,7 +70,6 @@ describe ManageIQ::Automate::Transformation::Common::Utils do
     it_behaves_like "task_in_migration"
   end
 
-
   shared_examples_for "task_in_cleanup" do
     it "with task_id" do
       ae_service.root['service_template_transformation_plan_task_id'] = svc_model_task.id
@@ -98,7 +95,6 @@ describe ManageIQ::Automate::Transformation::Common::Utils do
     it_behaves_like "task_in_cleanup"
   end
 
-
   shared_examples_for "vm_at_source" do
     before do
       allow(svc_model_task).to receive(:source) { svc_model_src_vm }
@@ -113,7 +109,6 @@ describe ManageIQ::Automate::Transformation::Common::Utils do
     let(:svc_model_src_vm) { svc_model_src_vm_vmware }
     it_behaves_like "vm_at_source"
   end
-
 
   shared_examples_for "vm_at_destination" do
     before do
@@ -135,8 +130,6 @@ describe ManageIQ::Automate::Transformation::Common::Utils do
     it_behaves_like "vm_at_destination"
   end
 
-
-
   shared_examples_for "task_and_vm" do
     before do
       allow(svc_model_task).to receive(:source) { svc_model_src_vm }
@@ -145,7 +138,6 @@ describe ManageIQ::Automate::Transformation::Common::Utils do
 
     it "task_and_vm in migration at source" do
       ae_service.root['service_template_transformation_plan_task'] = svc_model_task
-      byebug
       r_task, r_vm = described_class.task_and_vm('source', ae_service)
       expect(r_task.id).to eq(svc_model_task.id)
       expect(r_vm.id).to eq(svc_model_src_vm.id)
@@ -162,7 +154,7 @@ describe ManageIQ::Automate::Transformation::Common::Utils do
       ae_service.root['service_template_transformation_plan_task'] = svc_model_task
       r_task, r_vm = described_class.task_and_vm('source', ae_service)
       expect(r_task.id).to eq(svc_model_task.id)
-      expect(r_vm.id).to eq(svc_model_dst_vm.id)
+      expect(r_vm.id).to eq(svc_model_src_vm.id)
     end
 
     it "task_and_vm_in cleanup at destination" do


### PR DESCRIPTION
In [PR#382](https://github.com/ManageIQ/manageiq-content/pull/382), @gmcculloug proposed to refactor the way we collect the task and vm at the beginning of our method. This PR provides a implementation of this proposal, as a utility method that can be embedded. This will allow refactoring all the Transformation code to use it.