### PR TITLE
Fix cleanup state machine path build

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -34,6 +34,7 @@ module ManageIQ
               if sm_uri.present? && task.get_option(:cleanup_request_id).blank?
                 options = {}
                 sm_uri_array = sm_uri.split('/')
+                sm_uri_array.shift
                 options[:instance_name] = sm_uri_array.pop
                 options[:class_name] = sm_uri_array.pop
                 options[:namespace] = sm_uri_array.join('/')


### PR DESCRIPTION
The current build method for the cleanup state machine path leaves a leading `/` in the namespace name, which leads to path resolving failure. This PR removes it.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1599997