### PR TITLE
Transformation - Fix virt-v2v success check

### DIFF
--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmchecktransformed.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmchecktransformed.rb
@@ -50,12 +50,12 @@ module ManageIQ
                 end
               else
                 task.set_option(:virtv2v_finished_on, Time.now.utc.strftime('%Y%m%d_%H%M'))
-                if virtv2v_state['return_code'].zero?
+                if virtv2v_state['failed']
+                  @handle.set_state_var(:ae_state_progress, 'message' => 'Disks transformation failed.')
+                  raise "Disks transformation failed."
+                else
                   virtv2v_disks.each { |d| d[:percent] = 100 }
                   @handle.set_state_var(:ae_state_progress, 'message' => 'Disks transformation succeeded.', 'percent' => 100)
-                else
-                  @handle.set_state_var(:ae_state_progress, 'message' => 'Disks transformation succeeded.')
-                  raise "Disks transformation failed."
                 end
               end
 


### PR DESCRIPTION
The current approach checks the `return_code` attribute of the virt-v2v-wrapper state file. However, if the wrapper failed to launch virt-v2v, there no return code. Nonetheless, the `failed` attribute is a boolean that we can use to properly raise the exception. This PR implements this new method.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1564251