### PR TITLE
Remove check on number of runners when converting VM

### DIFF
--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
@@ -9,12 +9,6 @@ module ManageIQ
               @handle = handle
             end
 
-            def set_retry(message = nil, interval = '1.minutes')
-              @handle.log(:info, message) if message.present?
-              @handle.root['ae_result'] = 'retry'
-              @handle.root['ae_retry_interval'] = interval
-            end
-
             def main
               require 'json'
 
@@ -31,31 +25,23 @@ module ManageIQ
 
               @handle.log(:info, "Transformation - Started On: #{start_timestamp}")
 
-              destination_ems = @handle.vmdb(:ext_management_system).find_by(:id => task.get_option(:destination_ems_id))
-              max_runners = Transformation::TransformationHosts::Common::Utils.ems_max_runners(destination_ems, factory_config)
-              if Transformation::TransformationHosts::Common::Utils.get_runners_count_by_ems(destination_ems, factory_config) >= max_runners
-                @handle.log(:info, "Too many transformations running [#{max_runners}]. Retrying.")
-              else
-                wrapper_options = ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.virtv2vwrapper_options(task)
+              wrapper_options = ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.virtv2vwrapper_options(task)
 
-                # WARNING: Enable at your own risk, as it may lead to sensitive data leak
-                # @handle.log(:info, "JSON Input:\n#{JSON.pretty_generate(wrapper_options)}") if @debug
+              # WARNING: Enable at your own risk, as it may lead to sensitive data leak
+              # @handle.log(:info, "JSON Input:\n#{JSON.pretty_generate(wrapper_options)}") if @debug
 
-                @handle.log(:info, "Connecting to #{transformation_host.name} as #{transformation_host.authentication_userid}") if @debug
-                @handle.log(:info, "Executing '/usr/bin/virt-v2v-wrapper.py'")
-                result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "/usr/bin/virt-v2v-wrapper.py", wrapper_options.to_json)
-                raise result[:stderr] unless result[:rc].zero?
+              @handle.log(:info, "Connecting to #{transformation_host.name} as #{transformation_host.authentication_userid}") if @debug
+              @handle.log(:info, "Executing '/usr/bin/virt-v2v-wrapper.py'")
+              result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "/usr/bin/virt-v2v-wrapper.py", wrapper_options.to_json)
+              raise result[:stderr] unless result[:rc].zero?
 
-                # Record the wrapper files path
-                @handle.log(:info, "Command stdout: #{result[:stdout]}") if @debug
-                task.set_option(:virtv2v_wrapper, JSON.parse(result[:stdout]))
+              # Record the wrapper files path
+              @handle.log(:info, "Command stdout: #{result[:stdout]}") if @debug
+              task.set_option(:virtv2v_wrapper, JSON.parse(result[:stdout]))
 
-                # Record the status in the task object
-                task.set_option(:virtv2v_started_on, start_timestamp)
-                task.set_option(:virtv2v_status, 'active')
-              end
-
-              set_retry if task.get_option(:virtv2v_started_on).nil?
+              # Record the status in the task object
+              task.set_option(:virtv2v_started_on, start_timestamp)
+              task.set_option(:virtv2v_status, 'active')
             rescue => e
               @handle.set_state_var(:ae_state_progress, 'message' => e.message)
               raise
@@ -67,4 +53,6 @@ module ManageIQ
   end
 end
 
-ManageIQ::Automate::Transformation::TransformationHost::Common::VMTransform.new.main
+if  == __FILE__
+  ManageIQ::Automate::Transformation::TransformationHost::Common::VMTransform.new.main
+end

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
@@ -53,6 +53,4 @@ module ManageIQ
   end
 end
 
-if  == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::Common::VMTransform.new.main
-end
+ManageIQ::Automate::Transformation::TransformationHost::Common::VMTransform.new.main


### PR DESCRIPTION
When launching the conversion of the VM with virt-v2v, we check that the number of runners is not above the max number of runners per provider. However this check has already been done when acquiring the conversion host, and it leads to pausing the last tasks (number defined by number of generic workers).

This PR removes this check, allowing the balancing to fill the pool of conversions.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1607368