### PR TITLE
Add state_machine_phase attribute to transformation state machines

### DIFF
--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
@@ -13,7 +13,7 @@ object:
   schema:
   - field:
       aetype: attribute
-      name: cleanup_state_machine
+      name: state_machine_phase
       display_name: 
       datatype: 
       priority: 1
@@ -32,8 +32,8 @@ object:
       max_retries: 
       max_time: 
   - field:
-      aetype: state
-      name: State1
+      aetype: attribute
+      name: cleanup_state_machine
       display_name: 
       datatype: 
       priority: 2
@@ -53,7 +53,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State2
+      name: State1
       display_name: 
       datatype: 
       priority: 3
@@ -73,7 +73,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State3
+      name: State2
       display_name: 
       datatype: 
       priority: 4
@@ -93,7 +93,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State4
+      name: State3
       display_name: 
       datatype: 
       priority: 5
@@ -113,7 +113,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State5
+      name: State4
       display_name: 
       datatype: 
       priority: 6
@@ -133,7 +133,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State6
+      name: State5
       display_name: 
       datatype: 
       priority: 7
@@ -153,7 +153,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State7
+      name: State6
       display_name: 
       datatype: 
       priority: 8
@@ -173,7 +173,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State8
+      name: State7
       display_name: 
       datatype: 
       priority: 9
@@ -193,7 +193,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State9
+      name: State8
       display_name: 
       datatype: 
       priority: 10
@@ -213,7 +213,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State10
+      name: State9
       display_name: 
       datatype: 
       priority: 11
@@ -233,7 +233,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State11
+      name: State10
       display_name: 
       datatype: 
       priority: 12
@@ -253,7 +253,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State12
+      name: State11
       display_name: 
       datatype: 
       priority: 13
@@ -273,7 +273,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State13
+      name: State12
       display_name: 
       datatype: 
       priority: 14
@@ -293,7 +293,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State14
+      name: State13
       display_name: 
       datatype: 
       priority: 15
@@ -313,7 +313,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State15
+      name: State14
       display_name: 
       datatype: 
       priority: 16
@@ -333,7 +333,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State16
+      name: State15
       display_name: 
       datatype: 
       priority: 17
@@ -353,7 +353,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State17
+      name: State16
       display_name: 
       datatype: 
       priority: 18
@@ -373,7 +373,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State18
+      name: State17
       display_name: 
       datatype: 
       priority: 19
@@ -393,7 +393,7 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State19
+      name: State18
       display_name: 
       datatype: 
       priority: 20
@@ -413,10 +413,30 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: State20
+      name: State19
       display_name: 
       datatype: 
       priority: 21
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State20
+      display_name: 
+      datatype: 
+      priority: 22
       owner: 
       default_value: 
       substitute: true

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: 
   fields:
+  - state_machine_phase:
+      value: transformation
   - cleanup_state_machine:
       value: "/Transformation/StateMachines/VMTransformation/TransformationCleanup"
   - State2:

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformationcleanup.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformationcleanup.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: 
   fields:
+  - state_machine_phase:
+      value: cleanup
   - State2:
       value: "/Transformation/TransformationHosts/Common/KillVirtV2V"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description


### PR DESCRIPTION
When refactoring _Transformation - PowerOn_ method, we made it generic by checking in which phase we are: either transformation, or cleanup. We do it by checking whether we have `service_template_transformation_plan_task` or `service_template_plan_task_id` as attribute of `$evm.root`. However, both attributes are really close in spelling and the check doesn't express the intent.

This PR adds an attribute to the transformation state machines to explicitly state that it is a `transformation` or `cleanup` state machine. This eases the check in methods that can be used in both phases.