### PR TITLE
Prevent AR validation failure

### DIFF
--- a/spec/automation/unit/method_validation/dialog_parser_spec.rb
+++ b/spec/automation/unit/method_validation/dialog_parser_spec.rb
@@ -2,7 +2,7 @@ describe "DialogParser Automate Method" do
   include Spec::Support::ServiceTemplateHelper
 
   before(:each) do
-    @root_stp = FactoryGirl.create(:miq_request_task, :type => 'ServiceTemplateProvisionTask')
+    @root_stp = FactoryGirl.create(:service_template_provision_task)
     @user = FactoryGirl.create(:user_with_group)
   end
 


### PR DESCRIPTION
without request_type setting to 'clone_to_service', the save! validation will fail

It fixes the build failures in master and Gaprindashvili branch