### PR TITLE
Change VMware URI to connect directly to ESXi

### DIFF
--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/vmwarews.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/vmwarews.class/__methods__/utils.rb
@@ -26,12 +26,10 @@ module ManageIQ
                 vim.serviceInstance.content.searchIndex.FindByUuid(:datacenter => dc, :uuid => vm.uid_ems, :vmSearch => true, :instanceUuid => false)
               end
 
-              def self.get_vcenter_fingerprint(ems, handle = $evm)
-                command = "openssl s_client -connect #{ems.hostname}:443 2>\/dev\/null | openssl x509 -noout -fingerprint -sha1"
+              def self.host_fingerprint(host)
+                command = "openssl s_client -connect #{host.ipaddress}:443 2>\/dev\/null | openssl x509 -noout -fingerprint -sha1"
                 ssl_fingerprint = `#{command}`
-                fingerprint = ssl_fingerprint[17..ssl_fingerprint.size - 2]
-                handle.log(:info, "vCenter fingerprint: #{fingerprint}")
-                fingerprint
+                ssl_fingerprint[17..ssl_fingerprint.size - 2]
               end
 
               def self.vm_rename(vm, new_name, handle = $evm)

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -79,24 +79,23 @@ module ManageIQ
 
             def self.virtv2vwrapper_options_vmwarews2rhevm_vddk(task)
               source_vm = task.source
-              source_ems = source_vm.ext_management_system
               source_cluster = source_vm.ems_cluster
 
               destination_cluster = task.transformation_destination(source_cluster)
               destination_ems = destination_cluster.ext_management_system
               destination_storage = task.transformation_destination(source_vm.hardware.disks.select { |d| d.device_type == 'disk' }.first.storage)
 
-              vmware_uri = "vpx://"
-              vmware_uri += "#{source_ems.authentication_userid.gsub('@', '%40')}@#{source_ems.hostname}/"
+              vmware_uri = "esx://"
+              vmware_uri += "root@#{source_vm.host.ipaddress}/"
               vmware_uri += "#{source_cluster.v_parent_datacenter.gsub(' ', '%20')}/#{source_cluster.name.gsub(' ', '%20')}/#{source_vm.host.uid_ems}"
               vmware_uri += "?no_verify=1"
 
               {
                 :vm_name             => source_vm.name,
                 :transport_method    => 'vddk',
-                :vmware_fingerprint  => ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::Utils.get_vcenter_fingerprint(source_ems),
+                :vmware_fingerprint  => ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::Utils.host_fingerprint(source_vm.host),
                 :vmware_uri          => vmware_uri,
-                :vmware_password     => source_ems.authentication_password,
+                :vmware_password     => source_vm.host.authentication_password,
                 :rhv_url             => "https://#{destination_ems.hostname}/ovirt-engine/api",
                 :rhv_cluster         => destination_cluster.name,
                 :rhv_storage         => destination_storage.name,

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -87,7 +87,6 @@ module ManageIQ
 
               vmware_uri = "esx://"
               vmware_uri += "root@#{source_vm.host.ipaddress}/"
-              vmware_uri += "#{source_cluster.v_parent_datacenter.gsub(' ', '%20')}/#{source_cluster.name.gsub(' ', '%20')}/#{source_vm.host.uid_ems}"
               vmware_uri += "?no_verify=1"
 
               {


### PR DESCRIPTION
While investigating issues with large transformations in parallel, it was identified that vCenter is a bottleneck for VM transformation. The solution is to connect directly to the ESXi host. This PR provides the necessary changes to Automate, in order to connect to the ESXi host.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1618717