### PR TITLE
Escape username of VMware host

### DIFF
--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -86,7 +86,7 @@ module ManageIQ
               destination_storage = task.transformation_destination(source_vm.hardware.disks.select { |d| d.device_type == 'disk' }.first.storage)
 
               vmware_uri = "esx://"
-              vmware_uri += "root@#{source_vm.host.ipaddress}/"
+              vmware_uri += "#{URI.escape(source_vm.host.authentication_userid)}@#{source_vm.host.ipaddress}/"
               vmware_uri += "?no_verify=1"
 
               {

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -86,7 +86,7 @@ module ManageIQ
               destination_storage = task.transformation_destination(source_vm.hardware.disks.select { |d| d.device_type == 'disk' }.first.storage)
 
               vmware_uri = "esx://"
-              vmware_uri += "#{URI.escape(source_vm.host.authentication_userid)}@#{source_vm.host.ipaddress}/"
+              vmware_uri += "#{CGI.escape(source_vm.host.authentication_userid)}@#{source_vm.host.ipaddress}/"
               vmware_uri += "?no_verify=1"
 
               {


### PR DESCRIPTION
During migration, if using a non root user to connect to ESX host, we have to escape its userid as it may contain special characters, such as `\` and `@`. This PR implements this change.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1616385