### PR TITLE
Refactor and add specs for Transformation - AssessTransformation

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -8,8 +8,8 @@ module ManageIQ
 
           def initialize(handle = $evm)
             @handle = handle
-            @task = ManageIQ::Automate::Transformation::Common::Utils.task
-            @source_vm = ManageIQ::Automate::Transformation::Common::Utils.source_vm
+            @task ||= ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
+            @source_vm ||= ManageIQ::Automate::Transformation::Common::Utils.source_vm(@handle)
           end
 
           def virtv2v_networks

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -44,35 +44,33 @@ module ManageIQ
 
           def source_cluster
             @source_cluster ||= @source_vm.ems_cluster.tap do |cluster|
-              raise "No source cluster for VM '#{@source_vm.name}'. Exiting." if cluster.nil?
+              raise "No source cluster for VM '#{@source_vm.name}'" if cluster.nil?
             end
           end
           
           def source_ems
             @source_ems ||= source_cluster.ext_management_system.tap do |ems|
-              raise "No source EMS for VM '#{@source_vm.name}'. Exiting." if ems.nil?
+              raise "No source EMS for VM '#{@source_vm.name}'" if ems.nil?
             end
           end
           
           def destination_cluster
             @destination_cluster ||= @task.transformation_destination(source_cluster).tap do |cluster|
-              raise "No destination cluster for '#{@source_vm.name}'. Exiting." if cluster.nil?
+              raise "No destination cluster for '#{@source_vm.name}'" if cluster.nil?
             end
           end
           
           def destination_ems
             @destination_ems ||= destination_cluster.ext_management_system.tap do |ems|
-              raise "No destination EMS for '#{@source_vm.name}'. Exiting." if ems.nil?
+              raise "No destination EMS for '#{@source_vm.name}'" if ems.nil?
             end
           end
 
           def transformation_type
             raise "Unsupported source EMS type: #{source_ems.emstype}." unless SUPPORTED_SOURCE_EMS_TYPES.include?(source_ems.emstype)
-            @handle.set_state_var(:source_ems_type, source_ems.emstype)
-
             raise "Unsupported destination EMS type: #{destination_ems.emstype}." unless SUPPORTED_DESTINATION_EMS_TYPES.include?(destination_ems.emstype)
+            @handle.set_state_var(:source_ems_type, source_ems.emstype)
             @handle.set_state_var(:destination_ems_type, destination_ems.emstype)
-            
             "#{source_ems.emstype}2#{destination_ems.emstype}"
           end
           

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -53,7 +53,6 @@ module ManageIQ
 
           def destination_cluster
             @destination_cluster ||= @task.transformation_destination(source_cluster).tap do |cluster|
-              #raise "No destination cluster for '#{@source_vm.name}'" if cluster.nil?
               raise "No destination cluster" if cluster.nil?
             end
           end

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -8,8 +8,8 @@ module ManageIQ
 
           def initialize(handle = $evm)
             @handle = handle
-            @task ||= ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
-            @source_vm ||= ManageIQ::Automate::Transformation::Common::Utils.source_vm(@handle)
+            @task = ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
+            @source_vm = ManageIQ::Automate::Transformation::Common::Utils.source_vm(@handle)
           end
 
           def virtv2v_networks

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -8,13 +8,10 @@ module ManageIQ
 
           def initialize(handle = $evm)
             @handle = handle
-          end
-
-          def task_and_vms
             @task = ManageIQ::Automate::Transformation::Common::Utils.task
             @source_vm = ManageIQ::Automate::Transformation::Common::Utils.source_vm
           end
-          
+
           def virtv2v_networks
             @source_vm.hardware.nics.select { |n| n.device_type == 'ethernet' }.collect do |nic|
               source_network = nic.lan
@@ -47,19 +44,19 @@ module ManageIQ
               raise "No source cluster for VM '#{@source_vm.name}'" if cluster.nil?
             end
           end
-          
+
           def source_ems
             @source_ems ||= source_cluster.ext_management_system.tap do |ems|
               raise "No source EMS for VM '#{@source_vm.name}'" if ems.nil?
             end
           end
-          
+
           def destination_cluster
             @destination_cluster ||= @task.transformation_destination(source_cluster).tap do |cluster|
               raise "No destination cluster for '#{@source_vm.name}'" if cluster.nil?
             end
           end
-          
+
           def destination_ems
             @destination_ems ||= destination_cluster.ext_management_system.tap do |ems|
               raise "No destination EMS for '#{@source_vm.name}'" if ems.nil?
@@ -73,7 +70,7 @@ module ManageIQ
             @handle.set_state_var(:destination_ems_type, destination_ems.emstype)
             "#{source_ems.emstype}2#{destination_ems.emstype}"
           end
-          
+
           def populate_task_options
             @task.set_option(:source_ems_id, source_ems.id)
             @task.set_option(:destination_ems_id, destination_ems.id)
@@ -92,9 +89,8 @@ module ManageIQ
             }
             @handle.set_state_var(:factory_config, factory_config)
           end
-          
+
           def main
-            task_and_vms
             populate_task_options
             force_factory_config
           rescue => e

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -41,25 +41,26 @@ module ManageIQ
 
           def source_cluster
             @source_cluster ||= @source_vm.ems_cluster.tap do |cluster|
-              raise "No source cluster for VM '#{@source_vm.name}'" if cluster.nil?
+              raise "No source cluster" if cluster.nil?
             end
           end
 
           def source_ems
-            @source_ems ||= source_cluster.ext_management_system.tap do |ems|
-              raise "No source EMS for VM '#{@source_vm.name}'" if ems.nil?
+            @source_ems ||= @source_vm.ext_management_system.tap do |ems|
+              raise "No source EMS" if ems.nil?
             end
           end
 
           def destination_cluster
             @destination_cluster ||= @task.transformation_destination(source_cluster).tap do |cluster|
-              raise "No destination cluster for '#{@source_vm.name}'" if cluster.nil?
+              #raise "No destination cluster for '#{@source_vm.name}'" if cluster.nil?
+              raise "No destination cluster" if cluster.nil?
             end
           end
 
           def destination_ems
             @destination_ems ||= destination_cluster.ext_management_system.tap do |ems|
-              raise "No destination EMS for '#{@source_vm.name}'" if ems.nil?
+              raise "No destination EMS" if ems.nil?
             end
           end
 
@@ -82,7 +83,7 @@ module ManageIQ
             @task.set_option(:power_off, true)
           end
 
-          def force_factory_config
+          def populate_factory_config
             factory_config = {
               'vmtransformation_check_interval' => @handle.object['vmtransformation_check_interval'] || '15.seconds',
               'vmpoweroff_check_interval'       => @handle.object['vmpoweroff_check_interval'] || '30.seconds'
@@ -91,8 +92,7 @@ module ManageIQ
           end
 
           def main
-            populate_task_options
-            force_factory_config
+            %w(task_options factory_config).each { |ci| send("populate_#{ci}") }
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)
             raise

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -5,19 +5,21 @@ module ManageIQ
         class AssessTransformation
           SUPPORTED_SOURCE_EMS_TYPES = ['vmwarews'].freeze
           SUPPORTED_DESTINATION_EMS_TYPES = ['rhevm'].freeze
-          REQUIRED_CUSTOM_ATTRIBUTES = {
-            'rhevm' => %i(rhv_export_domain_id rhv_cluster_id rhv_storage_domain_id)
-          }.freeze
 
           def initialize(handle = $evm)
             @handle = handle
           end
 
-          def network_mappings(task, vm)
-            vm.hardware.nics.select { |n| n.device_type == 'ethernet' }.collect do |nic|
+          def task_and_vms
+            @task = ManageIQ::Automate::Transformation::Common::Utils.task
+            @source_vm = ManageIQ::Automate::Transformation::Common::Utils.source_vm
+          end
+          
+          def virtv2v_networks
+            @source_vm.hardware.nics.select { |n| n.device_type == 'ethernet' }.collect do |nic|
               source_network = nic.lan
-              destination_network = task.transformation_destination(source_network)
-              raise "[#{vm.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping. Aborting." if destination_network.nil?
+              destination_network = @task.transformation_destination(source_network)
+              raise "[#{@source_vm.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping. Aborting." if destination_network.nil?
               {
                 :source      => source_network.name,
                 :destination => destination_network.name,
@@ -26,65 +28,77 @@ module ManageIQ
             end
           end
 
-          def storage_mappings(task, vm)
-            vm.hardware.disks.select { |d| d.device_type == 'disk' }.collect do |disk|
+          def virtv2v_disks
+            @source_vm.hardware.disks.select { |d| d.device_type == 'disk' }.collect do |disk|
               source_storage = disk.storage
-              destination_storage = task.transformation_destination(disk.storage)
-              raise "[#{vm.name}] Disk #{disk.device_name} [#{source_storage.name}] has no mapping. Aborting." if destination_storage.nil?
+              destination_storage = @task.transformation_destination(disk.storage)
+              raise "[#{@source_vm.name}] Disk #{disk.device_name} [#{source_storage.name}] has no mapping. Aborting." if destination_storage.nil?
               {
                 :path    => disk.filename,
                 :size    => disk.size,
                 :percent => 0,
-                :weight  => disk.size.to_f / vm.allocated_disk_storage.to_f * 100
+                :weight  => disk.size.to_f / @source_vm.allocated_disk_storage.to_f * 100
               }
             end
           end
 
-          def main
-            task = @handle.root['service_template_transformation_plan_task']
-            raise 'No task found. Exiting' if task.nil?
-            @handle.log(:info, "Task: #{task.inspect}") if @debug
+          def source_cluster
+            @source_cluster ||= @source_vm.ems_cluster.tap do |cluster|
+              raise "No source cluster for VM '#{@source_vm.name}'. Exiting." if cluster.nil?
+            end
+          end
+          
+          def source_ems
+            @source_ems ||= source_cluster.ext_management_system.tap do |ems|
+              raise "No source EMS for VM '#{@source_vm.name}'. Exiting." if ems.nil?
+            end
+          end
+          
+          def destination_cluster
+            @destination_cluster ||= @task.transformation_destination(source_cluster).tap do |cluster|
+              raise "No destination cluster for '#{@source_vm.name}'. Exiting." if cluster.nil?
+            end
+          end
+          
+          def destination_ems
+            @destination_ems ||= destination_cluster.ext_management_system.tap do |ems|
+              raise "No destination EMS for '#{@source_vm.name}'. Exiting." if ems.nil?
+            end
+          end
 
-            source_vm ||= task.source
-            raise 'No VM found. Exiting' if source_vm.nil?
-
-            source_cluster = source_vm.ems_cluster
-            destination_cluster = task.transformation_destination(source_cluster)
-            raise "No destination cluster for '#{source_vm.name}'. Exiting." if destination_cluster.nil?
-
-            source_ems = source_vm.ext_management_system
-            task.set_option(:source_ems_id, source_ems.id)
-            destination_ems = destination_cluster.ext_management_system
-            task.set_option(:destination_ems_id, destination_ems.id)
-
-            virtv2v_networks = network_mappings(task, source_vm)
-            @handle.log(:info, "Network mappings: #{virtv2v_networks}")
-            task.set_option(:virtv2v_networks, virtv2v_networks)
-
-            virtv2v_disks = storage_mappings(task, source_vm)
-            @handle.log(:info, "Source VM Disks #{virtv2v_disks}")
-            task.set_option(:virtv2v_disks, virtv2v_disks)
-
+          def transformation_type
             raise "Unsupported source EMS type: #{source_ems.emstype}." unless SUPPORTED_SOURCE_EMS_TYPES.include?(source_ems.emstype)
             @handle.set_state_var(:source_ems_type, source_ems.emstype)
 
             raise "Unsupported destination EMS type: #{destination_ems.emstype}." unless SUPPORTED_DESTINATION_EMS_TYPES.include?(destination_ems.emstype)
             @handle.set_state_var(:destination_ems_type, destination_ems.emstype)
+            
+            "#{source_ems.emstype}2#{destination_ems.emstype}"
+          end
+          
+          def populate_task_options
+            @task.set_option(:source_ems_id, source_ems.id)
+            @task.set_option(:destination_ems_id, destination_ems.id)
+            @task.set_option(:virtv2v_networks, virtv2v_networks)
+            @task.set_option(:virtv2v_disks, virtv2v_disks)
+            @task.set_option(:transformation_type, transformation_type)
+            @task.set_option(:source_vm_power_state, @source_vm.power_state)
+            @task.set_option(:collapse_snapshots, true)
+            @task.set_option(:power_off, true)
+          end
 
-            task.set_option(:transformation_type, "#{source_ems.emstype}2#{destination_ems.emstype}")
-
+          def force_factory_config
             factory_config = {
               'vmtransformation_check_interval' => @handle.object['vmtransformation_check_interval'] || '15.seconds',
               'vmpoweroff_check_interval'       => @handle.object['vmpoweroff_check_interval'] || '30.seconds'
             }
             @handle.set_state_var(:factory_config, factory_config)
-
-            # Store source VM power state, as we will power it off
-            task.set_option(:source_vm_power_state, source_vm.power_state)
-
-            # Force VM shutdown and snapshots collapse by default
-            task.set_option(:collapse_snapshots, true)
-            task.set_option(:power_off, true)
+          end
+          
+          def main
+            task_and_vms
+            populate_task_options
+            force_factory_config
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)
             raise

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.yaml
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.yaml
@@ -9,5 +9,7 @@ object:
     scope: instance
     language: ruby
     location: inline
+    embedded_methods:
+    - "/Transformation/Common/Utils"
     options: {}
   inputs: []

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -1,4 +1,5 @@
 require_domain_file
+require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb')
 
 describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   let(:user) { FactoryGirl.create(:user_with_email_and_group) }
@@ -43,8 +44,8 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   let(:svc_model_nic_1) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_1) }
   let(:svc_model_nic_2) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_2) }
 
-  let(:disk_1) { instance_double("disk", :device_name => "Hard disk 1", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm.vmdk", :size => 17179869184) }
-  let(:disk_2) { instance_double("disk", :device_name => "Hard disk 2", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm-2.vmdk", :size => 17179869184) }
+  let(:disk_1) { instance_double("disk", :device_name => "Hard disk 1", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm.vmdk", :size => 17_179_869_184) }
+  let(:disk_2) { instance_double("disk", :device_name => "Hard disk 2", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm-2.vmdk", :size => 17_179_869_184) }
 
   let(:virtv2v_networks) do
     [
@@ -167,7 +168,7 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   context "transformation_type" do
     let(:svc_model_src_vm) { svc_model_src_vm_vmware }
 
-    it  "transformation_type with invalid source ems" do
+    it "transformation_type with invalid source ems" do
       allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_dst_ems_redhat)
       errormsg = "Unsupported source EMS type: #{svc_model_dst_ems_redhat.emstype}."
       expect { described_class.new(ae_service).transformation_type }.to raise_error(errormsg)
@@ -212,7 +213,7 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
       expect(described_class.new(ae_service).virtv2v_disks).to eq(virtv2v_disks)
     end
 
-     it "source_vm has no nic" do
+    it "source_vm has no nic" do
       allow(svc_model_src_vm.hardware).to receive(:nics).and_return([])
       expect(described_class.new(ae_service).virtv2v_networks).to eq([])
     end
@@ -324,7 +325,7 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
       expect(ae_service.get_state_var(:factory_config)['vmtransformation_check_interval']).to eq('15.seconds')
       expect(ae_service.get_state_var(:factory_config)['vmpoweroff_check_interval']).to eq('30.seconds')
     end
-   end
+  end
 
   context "source is vmware and destination is redhat" do
     let(:svc_model_src_vm) { svc_model_src_vm_vmware }

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -1,0 +1,154 @@
+require_domain_file
+
+describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:group) { FactoryGirl.create(:miq_group) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:src_vm_vmware) { FactoryGirl.create(:vm_vmware) }
+  let(:src_cluster) { FactoryGirl.create(:ems_cluster) }
+  let(:src_ems_vmware) { FactoryGirl.create(:ems_vmware) }
+  let(:dst_cluster) { FactoryGirl.create(:ems_cluster) }
+  let(:dst_ems_redhat) { FactoryGirl.create(:ems_redhat) }
+  let(:dst_ems_openstack { FactoryGirl.create(:ems_openstack_infra) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_group) { MiqAeMethodService::MiqAeServiceMiqGroup.find(group.id) }
+  let(:svc_model_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }
+  let(:svc_model_src_vm_vmware) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(src_vm_vmware.id) }
+  let(:svc_model_src_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(src_cluster) }
+  let(:svc_model_src_ems_vmware) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(src_ems_vmware) }
+  let(:svc_model_dst_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(dst_cluster) }
+  let(:svc_model_dst_ems_redhat) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems_redhat) }
+  let(:svc_model_dst_ems_openstack) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems_openstack) }
+
+  let(:retirement_date) { Time.now.utc + 1.day }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current' => current_object,
+      'user'    => svc_model_user,
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object.parent = root
+      service.current_object = current_object
+    end
+  end
+
+  def set_vm_identity
+    svc_model_src_vm.add_to_service(svc_model_service)
+    src_vm.tag_with("prod", :ns => "/managed", :cat => "environment")
+    svc_model_src_vm.custom_set('attr', 'value')
+    svc_model_src_vm.owner = svc_model_user
+    svc_model_src_vm.group = svc_model_group
+    svc_model_src_vm.retires_on = retirement_date
+    svc_model_src_vm.retirement_warn = 7
+  end
+
+  shared_examples_for "validate task_and_vms" do
+    it "when task is absent" do
+      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
+      expect { described_class.new(ae_service).task_and_vms }.to raise_error(errormsg)
+    end
+
+    it "when source vm is absent" do
+      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
+      errormsg = 'ERROR - Source VM has not been defined in the task'
+      expect { described_class.new(ae_service).task_and_vms }.to raise_error(errormsg)
+    end
+
+    it "when task is present" do
+      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
+      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
+      described_class.new(ae_service).task_and_vms
+      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@task).id).to eq(svc_model_task.id)
+      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_vm).id).to eq(svc_model_src_vm.id)
+    end
+  end
+
+  context "validate task_and_vms when source is vmware" do
+    let(:src_vm) { src_vm_vmware }
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+
+    it_behaves_like "validate task_and_vms"
+  end
+
+  shared_examples_for "source and destination items" do
+    it "" do
+
+    end
+  end
+
+  context "source and destination items source vmware and destination redhat"
+    let(:src_vm) { src_vm_vmware }
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:src_ems) { src_ems_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:dst_ems) { dst_ems_redhat }
+    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
+
+    it_behaves_like "source and destination items"
+  end
+
+ context "source and destination items source vmware and destination openstack"
+    let(:src_vm) { src_vm_vmware }
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:src_ems) { src_ems_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:dst_ems) { dst_ems_openstack }
+    let(:svc_model_dst_ems) { svc_model_dst_ems_openstack }
+
+    it_behaves_like "source and destination items"
+  end
+
+  context "source and destination items with invalid source vmware and destination redhat"
+    let(:src_vm) { src_vm_vmware }
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:src_ems) { src_ems_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
+    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
+
+    it_behaves_like "source and destination items"
+  end
+
+   context "source and destination items source vmware and invalid destination"
+    let(:src_vm) { src_vm_vmware }
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:src_ems) { src_ems_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
+    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
+
+    it_behaves_like "source and destination items"
+  end
+
+  shared_examples_for "transformation_type" do
+    it "invalid source ems" do
+
+    end
+
+    it "invalid destination ems" do
+
+    end
+  end
+
+  context "transformation_type" do
+
+  end
+
+  context "catchall exception rescue" do
+    before do
+      allow(svc_model_task).to receive(:source).and_raise(StandardError.new('kaboom'))
+    end
+
+    it "forcefully raise" do
+      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
+      expect { described_class.new(ae_service).main }.to raise_error(errormsg)
+      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => errormsg)
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -1,5 +1,4 @@
 require_domain_file
-require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb')
 
 describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   let(:user) { FactoryGirl.create(:user_with_email_and_group) }
@@ -11,6 +10,16 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   let(:dst_cluster) { FactoryGirl.create(:ems_cluster) }
   let(:dst_ems_redhat) { FactoryGirl.create(:ems_redhat) }
   let(:dst_ems_openstack) { FactoryGirl.create(:ems_openstack_infra) }
+  let(:src_storage_1) { FactoryGirl.create(:storage) }
+  let(:src_storage_2) { FactoryGirl.create(:storage) }
+  let(:dst_storage) { FactoryGirl.create(:storage) }
+  let(:src_lan_1) { FactoryGirl.create(:lan) }
+  let(:src_lan_2) { FactoryGirl.create(:lan) }
+  let(:dst_lan_1) { FactoryGirl.create(:lan) }
+  let(:dst_lan_2) { FactoryGirl.create(:lan) }
+  let(:hardware) { FactoryGirl.create(:hardware) }
+  let(:nic_1) { FactoryGirl.create(:guest_device_nic) }
+  let(:nic_2) { FactoryGirl.create(:guest_device_nic) }
 
   let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
   let(:svc_model_group) { MiqAeMethodService::MiqAeServiceMiqGroup.find(group.id) }
@@ -21,6 +30,35 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   let(:svc_model_dst_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(dst_cluster) }
   let(:svc_model_dst_ems_redhat) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems_redhat) }
   let(:svc_model_dst_ems_openstack) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems_openstack) }
+  let(:svc_model_src_storage_1) { MiqAeMethodService::MiqAeServiceStorage.find(src_storage_1) }
+  let(:svc_model_src_storage_2) { MiqAeMethodService::MiqAeServiceStorage.find(src_storage_2) }
+  let(:svc_model_dst_storage) { MiqAeMethodService::MiqAeServiceStorage.find(dst_storage) }
+  let(:svc_model_src_lan_1) { MiqAeMethodService::MiqAeServiceLan.find(src_lan_1) }
+  let(:svc_model_src_lan_2) { MiqAeMethodService::MiqAeServiceLan.find(src_lan_2) }
+  let(:svc_model_dst_lan_1) { MiqAeMethodService::MiqAeServiceLan.find(dst_lan_1) }
+  let(:svc_model_dst_lan_2) { MiqAeMethodService::MiqAeServiceLan.find(dst_lan_2) }
+  let(:svc_model_hardware) { MiqAeMethodService::MiqAeServiceHardware.find(hardware) }
+  let(:svc_model_guest_device_1) { MiqAeMethodService::MiqAeServiceGuestDevice.find(guest_device_1) }
+  let(:svc_model_guest_device_2) { MiqAeMethodService::MiqAeServiceGuestDevice.find(guest_device_2) }
+  let(:svc_model_nic_1) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_1) }
+  let(:svc_model_nic_2) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_2) }
+
+  let(:disk_1) { instance_double("disk", :device_name => "Hard disk 1", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm.vmdk", :size => 17179869184) }
+  let(:disk_2) { instance_double("disk", :device_name => "Hard disk 2", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm-2.vmdk", :size => 17179869184) }
+
+  let(:virtv2v_networks) do
+    [
+      { :source => svc_model_src_lan_1.name, :destination => svc_model_dst_lan_1.name, :mac_address => svc_model_nic_1.address },
+      { :source => svc_model_src_lan_2.name, :destination => svc_model_dst_lan_2.name, :mac_address => svc_model_nic_2.address },
+    ]
+  end
+
+  let(:virtv2v_disks) do
+    [
+      { :path => disk_1.filename, :size => disk_1.size, :percent => 0, :weight  => 50.0 },
+      { :path => disk_2.filename, :size => disk_2.size, :percent => 0, :weight  => 50.0 }
+    ]
+  end
 
   let(:root) do
     Spec::Support::MiqAeMockObject.new(
@@ -33,14 +71,21 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   let(:current_object) { Spec::Support::MiqAeMockObject.new }
   let(:ae_service) do
     Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
       current_object.parent = root
-      service.current_object = current_object
+      service.object = current_object
     end
   end
 
   before do
     allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
     allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
+
+    allow(svc_model_src_vm).to receive(:hardware).and_return(svc_model_hardware)
+    allow(disk_1).to receive(:storage).and_return(svc_model_src_storage_1)
+    allow(disk_2).to receive(:storage).and_return(svc_model_src_storage_2)
+    allow(svc_model_nic_1).to receive(:lan).and_return(svc_model_src_lan_1)
+    allow(svc_model_nic_2).to receive(:lan).and_return(svc_model_src_lan_2)
   end
 
   before(:each) do
@@ -50,168 +95,252 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, nil)
   end
 
-#  shared_examples_for "validate task_and_vms" do
-#    it "when task is absent" do
-#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(nil)
-#      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
-#      expect { described_class.new(ae_service) }.to raise_error(errormsg)
-#    end
-#
-#    it "when task is present and source vm is absent" do
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@task, svc_model_task)
-#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).with(ae_service).and_return(svc_model_task)
-#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).with(ae_service).and_return(nil)
-#      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
-#      errormsg = 'ERROR - Source VM has not been defined in the task'
-#      expect { described_class.new(ae_service) }.to raise_error(errormsg)
-#    end
-#
-#    it "when task and source vm are present" do
-#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
-#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
-#      described_class.new(ae_service)
-#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@task).id).to eq(svc_model_task.id)
-#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_vm).id).to eq(svc_model_src_vm.id)
-#    end
-#  end
-#
-#  context "validate task_and_vms when source is vmware" do
-#    let(:src_vm) { src_vm_vmware }
-#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-#
-#    it_behaves_like "validate task_and_vms"
-#  end
-
-  shared_examples_for "source and destination exceptions" do
+  shared_examples_for "source and destination items" do
     it "source_cluster without cluster" do
       allow(svc_model_src_vm).to receive(:ems_cluster).and_return(nil)
-      errormsg = "No source cluster for VM '#{svc_model_src_vm.name}'"
+      errormsg = "No source cluster"
       expect { described_class.new(ae_service).source_cluster }.to raise_error(errormsg)
     end
 
-#    it "source_cluster with cluster" do
-#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-#      byebug
-#      described_class.new(ae_service).source_cluster
-#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_cluster).id).to eq(svc_model_src_cluster.id)
-#    end
+    it "source_cluster with cluster" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      expect(described_class.new(ae_service).source_cluster.id).to eq(svc_model_src_cluster.id)
+    end
 
     it "source_ems without ems" do
       allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
       allow(svc_model_src_cluster).to receive(:ext_management_system).and_return(nil)
-      errormsg = "No source EMS for VM '#{svc_model_src_vm.name}'"
+      errormsg = "No source EMS"
       expect { described_class.new(ae_service).source_ems }.to raise_error(errormsg)
     end
 
-#    it "source_ems with cluster" do
-#      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems)
-#      described_class.new(ae_service).source_ems
-#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_ems).id).to eq(svc_model_src_ems.id)
-#    end
+    it "source_ems with ems" do
+      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems)
+      expect(described_class.new(ae_service).source_ems.id).to eq(svc_model_src_ems.id)
+    end
 
     it "destination_cluster without cluster" do
       allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
       allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(nil)
-#      errormsg = "No destination cluster for VM '#{svc_model_src_vm.name}'"
-      errorrex = /No destination cluster for VM/
-#      expect { byebug ; described_class.new(ae_service).destination_cluster }.to raise_error(errormsg)
-      expect { byebug ; described_class.new(ae_service).destination_cluster }.to raise_error(RuntimeError, errorrex)
+      errormsg = "No destination cluster"
+      expect { described_class.new(ae_service).destination_cluster }.to raise_error(errormsg)
     end
 
-#    it "destination_cluster with cluster" do
-#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
-#      described_class.new(ae_service).destination_cluster
-#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_cluster).id).to eq(svc_model_dst_cluster.id)
-#    end
+    it "destination_cluster with cluster" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+      expect(described_class.new(ae_service).destination_cluster.id).to eq(svc_model_dst_cluster.id)
+    end
 
     it "destination_ems without ems" do
       allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
       allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
       allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(nil)
-      errormsg = "No destination EMS for VM '#{svc_model_src_vm.name}'"
-      expect { byebug ; described_class.new(ae_service).destination_ems }.to raise_error(errormsg)
+      errormsg = "No destination EMS"
+      expect { described_class.new(ae_service).destination_ems }.to raise_error(errormsg)
     end
 
-#    it "source_cluster with cluster" do
-#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
-#      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_dst_ems)
-#      described_class.new(ae_service).destination_ems
-#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_ems).id).to eq(svc_model_dst_ems.id)
-#    end
+    it "destination_ems with ems" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(svc_model_dst_ems)
+      expect(described_class.new(ae_service).destination_ems.id).to eq(svc_model_dst_ems.id)
+    end
   end
 
   context "source and destination items source vmware and destination redhat" do
-    let(:src_vm) { src_vm_vmware }
     let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-    let(:src_ems) { src_ems_vmware }
     let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-    let(:dst_ems) { dst_ems_redhat }
     let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
 
-    it_behaves_like "source and destination exceptions"
+    it_behaves_like "source and destination items"
   end
 
-#  context "source and destination items source vmware and destination openstack" do
-#    let(:src_vm) { src_vm_vmware }
-#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-#    let(:src_ems) { src_ems_vmware }
-#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-#    let(:dst_ems) { dst_ems_openstack }
-#    let(:svc_model_dst_ems) { svc_model_dst_ems_openstack }
-#
-#    it_behaves_like "source and destination items"
-#  end
-#
-#  context "source and destination items with invalid source vmware and destination redhat" do
-#    let(:src_vm) { src_vm_vmware }
-#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-#    let(:src_ems) { src_ems_vmware }
-#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-#    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
-#    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
-#
-#    it_behaves_like "source and destination items"
-#  end
-#
-#  context "source and destination items source vmware and invalid destination" do
-#    let(:src_vm) { src_vm_vmware }
-#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-#    let(:src_ems) { src_ems_vmware }
-#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-#    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
-#    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
-#
-#    it_behaves_like "source and destination items"
-#  end
-#
-#  context "transformation_type" do
-#    it  "transformation_type with invalid source ems" do
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_dst_ems_redhat)
-#      errormsg = "Unsupported source EMS type: #{svc_model_dst_ems_redhat.emstype}."
-#      expect { described_class.new(ae_service).transformation_type }.to raise_error(errormsg)
-#    end
-#
-#    it "transformation_type with invalid destination ems" do
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_src_ems_vmware)
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, svc_model_src_ems_vmware)
-#      errormsg = "Unsupported destination EMS type: #{svc_model_src_ems_vmware.emstype}."
-#      expect { described_class.new(ae_service).transformation_type }.to raise_error(errormsg)
-#    end
-#
-#    it "transformation_type with valid source and destination ems" do
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_src_ems_vmware)
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, svc_model_dst_ems_redhat)
-#      expect(described_class.new(ae_service).transformation_type).to eq("#{svc_model_src_ems_vmware.emstype}2#{svc_model_dst_ems_redhat.emstype}")
-#    end
-#  end
+  context "source and destination items source vmware and destination openstack" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:svc_model_dst_ems) { svc_model_dst_ems_openstack }
 
-#  context "catchall exception rescue" do
-#    it "forcefully raise" do
-#      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
-#      expect { described_class.new(ae_service).main }.to raise_error(errormsg)
-#      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => errormsg)
-#    end
-#  end
+    it_behaves_like "source and destination items"
+  end
+
+  context "transformation_type" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+
+    it  "transformation_type with invalid source ems" do
+      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_dst_ems_redhat)
+      errormsg = "Unsupported source EMS type: #{svc_model_dst_ems_redhat.emstype}."
+      expect { described_class.new(ae_service).transformation_type }.to raise_error(errormsg)
+    end
+
+    it "transformation_type with invalid destination ems" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems_vmware)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(svc_model_src_ems_vmware)
+      errormsg = "Unsupported destination EMS type: #{svc_model_src_ems_vmware.emstype}."
+      expect { described_class.new(ae_service).transformation_type }.to raise_error(errormsg)
+    end
+
+    it "transformation_type with valid source and destination ems" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems_vmware)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(svc_model_dst_ems_redhat)
+      expect(described_class.new(ae_service).transformation_type).to eq("#{svc_model_src_ems_vmware.emstype}2#{svc_model_dst_ems_redhat.emstype}")
+    end
+  end
+
+  shared_examples_for "virtv2v hardware" do
+    it "source_vm has no disk" do
+      allow(svc_model_src_vm.hardware).to receive(:disks).and_return([])
+      expect(described_class.new(ae_service).virtv2v_disks).to eq([])
+    end
+
+    it "source_vm has disks, but src_storage_1 has no mapping" do
+      allow(svc_model_hardware).to receive(:disks).and_return([disk_1, disk_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_storage_1).and_return(nil)
+      errormsg = "[#{svc_model_src_vm.name}] Disk #{disk_1.device_name} [#{svc_model_src_storage_1.name}] has no mapping. Aborting."
+      expect { described_class.new(ae_service).virtv2v_disks }.to raise_error(errormsg)
+    end
+
+    it "source_vm has disks and storages have mapping" do
+      allow(svc_model_hardware).to receive(:disks).and_return([disk_1, disk_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_storage_1).and_return(svc_model_dst_storage)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_storage_2).and_return(svc_model_dst_storage)
+      allow(svc_model_src_vm).to receive(:allocated_disk_storage).and_return(disk_1.size + disk_2.size)
+      expect(described_class.new(ae_service).virtv2v_disks).to eq(virtv2v_disks)
+    end
+
+     it "source_vm has no nic" do
+      allow(svc_model_src_vm.hardware).to receive(:nics).and_return([])
+      expect(described_class.new(ae_service).virtv2v_networks).to eq([])
+    end
+
+    it "source_vm has nics, but src_lan_1 has no mapping" do
+      allow(svc_model_hardware).to receive(:nics).and_return([svc_model_nic_1, svc_model_nic_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_lan_1).and_return(nil)
+      errormsg = "[#{svc_model_src_vm.name}] NIC #{svc_model_nic_1.device_name} [#{svc_model_src_lan_1.name}] has no mapping. Aborting."
+      expect { described_class.new(ae_service).virtv2v_networks }.to raise_error(errormsg)
+    end
+
+    it "source_vm has nicss and lans have mapping" do
+      allow(svc_model_hardware).to receive(:nics).and_return([svc_model_nic_1, svc_model_nic_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_lan_1).and_return(svc_model_dst_lan_1)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_lan_2).and_return(svc_model_dst_lan_2)
+      expect(described_class.new(ae_service).virtv2v_networks).to eq(virtv2v_networks)
+    end
+  end
+
+  context "source vm is vmware" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+
+    it_behaves_like "virtv2v hardware"
+  end
+
+  shared_examples_for "populate task options" do
+    it "task options" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(svc_model_dst_ems)
+      allow(svc_model_hardware).to receive(:disks).and_return([disk_1, disk_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_storage_1).and_return(svc_model_dst_storage)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_storage_2).and_return(svc_model_dst_storage)
+      allow(svc_model_src_vm).to receive(:allocated_disk_storage).and_return(disk_1.size + disk_2.size)
+      allow(svc_model_hardware).to receive(:nics).and_return([svc_model_nic_1, svc_model_nic_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_lan_1).and_return(svc_model_dst_lan_1)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_lan_2).and_return(svc_model_dst_lan_2)
+      allow(svc_model_src_vm).to receive(:power_state).and_return("on")
+      described_class.new(ae_service).populate_task_options
+      expect(svc_model_task.get_option(:source_ems_id)).to eq(svc_model_src_ems.id)
+      expect(svc_model_task.get_option(:destination_ems_id)).to eq(svc_model_dst_ems.id)
+      expect(svc_model_task[:options][:virtv2v_networks]).to eq(virtv2v_networks)
+      expect(svc_model_task[:options][:virtv2v_disks]).to eq(virtv2v_disks)
+      expect(svc_model_task.get_option(:transformation_type)).to eq("#{svc_model_src_ems.emstype}2#{svc_model_dst_ems.emstype}")
+      expect(svc_model_task.get_option(:source_vm_power_state)).to eq("on")
+      expect(svc_model_task.get_option(:collapse_snapshots)).to be true
+      expect(svc_model_task.get_option(:power_off)).to be true
+    end
+  end
+
+  context "source is vmware and destination is redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
+
+    it_behaves_like "populate task options"
+  end
+
+  context "populate factory config" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+
+    it "without vmtransformation_check_interval" do
+      described_class.new(ae_service).populate_factory_config
+      expect(ae_service.get_state_var(:factory_config)['vmtransformation_check_interval']).to eq('15.seconds')
+    end
+
+    it "with vmtransformation_check_interval" do
+      ae_service.object['vmtransformation_check_interval'] = '30.seconds'
+      described_class.new(ae_service).populate_factory_config
+      expect(ae_service.get_state_var(:factory_config)['vmtransformation_check_interval']).to eq('30.seconds')
+    end
+
+    it "without vmpoweroff_check_interval" do
+      described_class.new(ae_service).populate_factory_config
+      expect(ae_service.get_state_var(:factory_config)['vmpoweroff_check_interval']).to eq('30.seconds')
+    end
+
+    it "with vmpoweroff_check_interval" do
+      ae_service.object['vmpoweroff_check_interval'] = '1.minutes'
+      described_class.new(ae_service).populate_factory_config
+      expect(ae_service.get_state_var(:factory_config)['vmpoweroff_check_interval']).to eq('1.minutes')
+    end
+  end
+
+  shared_examples_for "main" do
+    it "global summary test" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(svc_model_dst_ems)
+      allow(svc_model_hardware).to receive(:disks).and_return([disk_1, disk_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_storage_1).and_return(svc_model_dst_storage)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_storage_2).and_return(svc_model_dst_storage)
+      allow(svc_model_src_vm).to receive(:allocated_disk_storage).and_return(disk_1.size + disk_2.size)
+      allow(svc_model_hardware).to receive(:nics).and_return([svc_model_nic_1, svc_model_nic_2])
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_lan_1).and_return(svc_model_dst_lan_1)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_lan_2).and_return(svc_model_dst_lan_2)
+      allow(svc_model_src_vm).to receive(:power_state).and_return("on")
+      described_class.new(ae_service).main
+      expect(svc_model_task.get_option(:source_ems_id)).to eq(svc_model_src_ems.id)
+      expect(svc_model_task.get_option(:destination_ems_id)).to eq(svc_model_dst_ems.id)
+      expect(svc_model_task[:options][:virtv2v_networks]).to eq(virtv2v_networks)
+      expect(svc_model_task[:options][:virtv2v_disks]).to eq(virtv2v_disks)
+      expect(svc_model_task.get_option(:transformation_type)).to eq("#{svc_model_src_ems.emstype}2#{svc_model_dst_ems.emstype}")
+      expect(svc_model_task.get_option(:source_vm_power_state)).to eq("on")
+      expect(svc_model_task.get_option(:collapse_snapshots)).to be true
+      expect(svc_model_task.get_option(:power_off)).to be true
+      expect(ae_service.get_state_var(:factory_config)['vmtransformation_check_interval']).to eq('15.seconds')
+      expect(ae_service.get_state_var(:factory_config)['vmpoweroff_check_interval']).to eq('30.seconds')
+    end
+   end
+
+  context "source is vmware and destination is redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
+
+    it_behaves_like "main"
+  end
+
+  context "catchall exception rescue" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+
+    it "forcefully raise" do
+      errormsg = 'No source EMS'
+      expect { described_class.new(ae_service).main }.to raise_error(errormsg)
+      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => errormsg)
+    end
+  end
 end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -38,103 +38,101 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
     end
   end
 
+  before do
+    allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
+    allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
+  end
+
   before(:each) do
-    ManageIQ::Automate::Transformation::Common::Utils.instance_variable_set(:@task, nil)
-    ManageIQ::Automate::Transformation::Common::Utils.instance_variable_set(:@source_vm, nil)
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@task, nil)
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_vm, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_cluster, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_cluster, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, nil)
   end
 
-  shared_examples_for "validate task_and_vms" do
-    it "when task is absent" do
-      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(nil)
-      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
-      expect { described_class.new(ae_service) }.to raise_error(errormsg)
-    end
-
-    it "when task is present and source vm is absent" do
-      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
-      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(nil)
-      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
-      errormsg = 'ERROR - Source VM has not been defined in the task'
-      expect { described_class.new(ae_service) }.to raise_error(errormsg)
-    end
-
-    it "when task and source vm are present" do
-      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
-      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
-      described_class.new(ae_service)
-      expect (ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@task).id).to eq(svc_model_task.id)
-      expect (ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_vm).id).to eq(svc_model_src_vm.id)
-    end
-  end
-
-  context "validate task_and_vms when source is vmware" do
-    let(:src_vm) { src_vm_vmware }
-    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-
-    it_behaves_like "validate task_and_vms"
-  end
-
-#  shared_examples_for "source and destination items" do
-#    before(:each) do
+#  shared_examples_for "validate task_and_vms" do
+#    it "when task is absent" do
+#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(nil)
+#      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
+#      expect { described_class.new(ae_service) }.to raise_error(errormsg)
+#    end
+#
+#    it "when task is present and source vm is absent" do
 #      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@task, svc_model_task)
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_vm, svc_model_src_vm)
+#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).with(ae_service).and_return(svc_model_task)
+#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).with(ae_service).and_return(nil)
+#      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+#      errormsg = 'ERROR - Source VM has not been defined in the task'
+#      expect { described_class.new(ae_service) }.to raise_error(errormsg)
 #    end
 #
-#    it "source_cluster without cluster" do
-#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(nil)
-#      errormsg = "No source cluster for VM '#{svc_model_src_vm.name}'"
-#      expect { described_class.new(ae_service).source_cluster }.to raise_error(errormsg)
+#    it "when task and source vm are present" do
+#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
+#      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
+#      described_class.new(ae_service)
+#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@task).id).to eq(svc_model_task.id)
+#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_vm).id).to eq(svc_model_src_vm.id)
 #    end
+#  end
 #
+#  context "validate task_and_vms when source is vmware" do
+#    let(:src_vm) { src_vm_vmware }
+#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+#
+#    it_behaves_like "validate task_and_vms"
+#  end
+
+  shared_examples_for "source and destination exceptions" do
+    it "source_cluster without cluster" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(nil)
+      errormsg = "No source cluster for VM '#{svc_model_src_vm.name}'"
+      expect { described_class.new(ae_service).source_cluster }.to raise_error(errormsg)
+    end
+
 #    it "source_cluster with cluster" do
-#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_vm, svc_model_src_vm)
-#      @source_vm = svc_model_src_vm
 #      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
 #      byebug
 #      described_class.new(ae_service).source_cluster
 #      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_cluster).id).to eq(svc_model_src_cluster.id)
 #    end
-#
-#    it "source_ems without ems" do
-#      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(nil)
-#      errormsg = "No source EMS for VM '#{svc_model_src_vm.name}'"
-#      expect { described_class.new(ae_service).source_ems }.to raise_error(errormsg)
-#    end
-#
-#    it "source_cluster with cluster" do
+
+    it "source_ems without ems" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_src_cluster).to receive(:ext_management_system).and_return(nil)
+      errormsg = "No source EMS for VM '#{svc_model_src_vm.name}'"
+      expect { described_class.new(ae_service).source_ems }.to raise_error(errormsg)
+    end
+
+#    it "source_ems with cluster" do
 #      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems)
 #      described_class.new(ae_service).source_ems
 #      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_ems).id).to eq(svc_model_src_ems.id)
 #    end
-#
-#    it "destination_cluster without cluster" do
-#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(nil)
+
+    it "destination_cluster without cluster" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(nil)
 #      errormsg = "No destination cluster for VM '#{svc_model_src_vm.name}'"
-#      expect { described_class.new(ae_service).destination_cluster }.to raise_error(errormsg)
-#    end
-#
+      errorrex = /No destination cluster for VM/
+#      expect { byebug ; described_class.new(ae_service).destination_cluster }.to raise_error(errormsg)
+      expect { byebug ; described_class.new(ae_service).destination_cluster }.to raise_error(RuntimeError, errorrex)
+    end
+
 #    it "destination_cluster with cluster" do
 #      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
 #      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
 #      described_class.new(ae_service).destination_cluster
 #      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_cluster).id).to eq(svc_model_dst_cluster.id)
 #    end
-#
-#    it "destination_ems without ems" do
-#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
-#      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(nil)
-#      errormsg = "No destination EMS for VM '#{svc_model_src_vm.name}'"
-#      expect { described_class.new(ae_service).destination_ems }.to raise_error(errormsg)
-#    end
-#
+
+    it "destination_ems without ems" do
+      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(nil)
+      errormsg = "No destination EMS for VM '#{svc_model_src_vm.name}'"
+      expect { byebug ; described_class.new(ae_service).destination_ems }.to raise_error(errormsg)
+    end
+
 #    it "source_cluster with cluster" do
 #      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
 #      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
@@ -142,18 +140,18 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
 #      described_class.new(ae_service).destination_ems
 #      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_ems).id).to eq(svc_model_dst_ems.id)
 #    end
-#  end
-#
-#  context "source and destination items source vmware and destination redhat" do
-#    let(:src_vm) { src_vm_vmware }
-#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-#    let(:src_ems) { src_ems_vmware }
-#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-#    let(:dst_ems) { dst_ems_redhat }
-#    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
-#
-#    it_behaves_like "source and destination items"
-#  end
+  end
+
+  context "source and destination items source vmware and destination redhat" do
+    let(:src_vm) { src_vm_vmware }
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:src_ems) { src_ems_vmware }
+    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+    let(:dst_ems) { dst_ems_redhat }
+    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
+
+    it_behaves_like "source and destination exceptions"
+  end
 
 #  context "source and destination items source vmware and destination openstack" do
 #    let(:src_vm) { src_vm_vmware }

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -24,8 +24,9 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
 
   let(:root) do
     Spec::Support::MiqAeMockObject.new(
-      'current' => current_object,
-      'user'    => svc_model_user,
+      'current'             => current_object,
+      'user'                => svc_model_user,
+      'state_machine_phase' => 'transformation'
     )
   end
 
@@ -38,42 +39,37 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   end
 
   before(:each) do
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@task, svc_model_task)
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_vm, svc_model_src_vm)
+    ManageIQ::Automate::Transformation::Common::Utils.instance_variable_set(:@task, nil)
+    ManageIQ::Automate::Transformation::Common::Utils.instance_variable_set(:@source_vm, nil)
+    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@task, nil)
+    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_vm, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_cluster, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_cluster, nil)
     ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, nil)
   end
 
-  def set_vm_identity
-    svc_model_src_vm.add_to_service(svc_model_service)
-    src_vm.tag_with("prod", :ns => "/managed", :cat => "environment")
-    svc_model_src_vm.custom_set('attr', 'value')
-    svc_model_src_vm.owner = svc_model_user
-    svc_model_src_vm.group = svc_model_group
-    svc_model_src_vm.retires_on = retirement_date
-    svc_model_src_vm.retirement_warn = 7
-  end
-
   shared_examples_for "validate task_and_vms" do
     it "when task is absent" do
+      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(nil)
       errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
-      expect { described_class.new(ae_service).task_and_vms }.to raise_error(errormsg)
+      expect { described_class.new(ae_service) }.to raise_error(errormsg)
     end
 
-    it "when source vm is absent" do
+    it "when task is present and source vm is absent" do
       allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
+      allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(nil)
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
       errormsg = 'ERROR - Source VM has not been defined in the task'
-      expect { described_class.new(ae_service).new.task_and_vms }.to raise_error(errormsg)
+      expect { described_class.new(ae_service) }.to raise_error(errormsg)
     end
 
-    it "when task is present" do
+    it "when task and source vm are present" do
       allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
       allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
-      described_class.new(ae_service).new.task_and_vms
-      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@task).id).to eq(svc_model_task.id)
-      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_vm).id).to eq(svc_model_src_vm.id)
+      described_class.new(ae_service)
+      expect (ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@task).id).to eq(svc_model_task.id)
+      expect (ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_vm).id).to eq(svc_model_src_vm.id)
     end
   end
 
@@ -84,135 +80,140 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
     it_behaves_like "validate task_and_vms"
   end
 
-  shared_examples_for "source and destination items" do
-    it "source_cluster without cluster" do
-      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(nil)
-      errormsg = "No source cluster for VM '#{svc_model_src_vm.name}'"
-      expect { described_class.new.source_cluster }.to raise_error(errormsg)
-    end
+#  shared_examples_for "source and destination items" do
+#    before(:each) do
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@task, svc_model_task)
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_vm, svc_model_src_vm)
+#    end
+#
+#    it "source_cluster without cluster" do
+#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(nil)
+#      errormsg = "No source cluster for VM '#{svc_model_src_vm.name}'"
+#      expect { described_class.new(ae_service).source_cluster }.to raise_error(errormsg)
+#    end
+#
+#    it "source_cluster with cluster" do
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_vm, svc_model_src_vm)
+#      @source_vm = svc_model_src_vm
+#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+#      byebug
+#      described_class.new(ae_service).source_cluster
+#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_cluster).id).to eq(svc_model_src_cluster.id)
+#    end
+#
+#    it "source_ems without ems" do
+#      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(nil)
+#      errormsg = "No source EMS for VM '#{svc_model_src_vm.name}'"
+#      expect { described_class.new(ae_service).source_ems }.to raise_error(errormsg)
+#    end
+#
+#    it "source_cluster with cluster" do
+#      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems)
+#      described_class.new(ae_service).source_ems
+#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_ems).id).to eq(svc_model_src_ems.id)
+#    end
+#
+#    it "destination_cluster without cluster" do
+#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(nil)
+#      errormsg = "No destination cluster for VM '#{svc_model_src_vm.name}'"
+#      expect { described_class.new(ae_service).destination_cluster }.to raise_error(errormsg)
+#    end
+#
+#    it "destination_cluster with cluster" do
+#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+#      described_class.new(ae_service).destination_cluster
+#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_cluster).id).to eq(svc_model_dst_cluster.id)
+#    end
+#
+#    it "destination_ems without ems" do
+#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+#      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(nil)
+#      errormsg = "No destination EMS for VM '#{svc_model_src_vm.name}'"
+#      expect { described_class.new(ae_service).destination_ems }.to raise_error(errormsg)
+#    end
+#
+#    it "source_cluster with cluster" do
+#      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+#      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
+#      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_dst_ems)
+#      described_class.new(ae_service).destination_ems
+#      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_ems).id).to eq(svc_model_dst_ems.id)
+#    end
+#  end
+#
+#  context "source and destination items source vmware and destination redhat" do
+#    let(:src_vm) { src_vm_vmware }
+#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+#    let(:src_ems) { src_ems_vmware }
+#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+#    let(:dst_ems) { dst_ems_redhat }
+#    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
+#
+#    it_behaves_like "source and destination items"
+#  end
 
-    it "source_cluster with cluster" do
-      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-      described_class.new.source_cluster
-      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_cluster).id).to eq(svc_model_src_cluster.id)
-    end
+#  context "source and destination items source vmware and destination openstack" do
+#    let(:src_vm) { src_vm_vmware }
+#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+#    let(:src_ems) { src_ems_vmware }
+#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+#    let(:dst_ems) { dst_ems_openstack }
+#    let(:svc_model_dst_ems) { svc_model_dst_ems_openstack }
+#
+#    it_behaves_like "source and destination items"
+#  end
+#
+#  context "source and destination items with invalid source vmware and destination redhat" do
+#    let(:src_vm) { src_vm_vmware }
+#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+#    let(:src_ems) { src_ems_vmware }
+#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+#    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
+#    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
+#
+#    it_behaves_like "source and destination items"
+#  end
+#
+#  context "source and destination items source vmware and invalid destination" do
+#    let(:src_vm) { src_vm_vmware }
+#    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+#    let(:src_ems) { src_ems_vmware }
+#    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
+#    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
+#    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
+#
+#    it_behaves_like "source and destination items"
+#  end
+#
+#  context "transformation_type" do
+#    it  "transformation_type with invalid source ems" do
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_dst_ems_redhat)
+#      errormsg = "Unsupported source EMS type: #{svc_model_dst_ems_redhat.emstype}."
+#      expect { described_class.new(ae_service).transformation_type }.to raise_error(errormsg)
+#    end
+#
+#    it "transformation_type with invalid destination ems" do
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_src_ems_vmware)
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, svc_model_src_ems_vmware)
+#      errormsg = "Unsupported destination EMS type: #{svc_model_src_ems_vmware.emstype}."
+#      expect { described_class.new(ae_service).transformation_type }.to raise_error(errormsg)
+#    end
+#
+#    it "transformation_type with valid source and destination ems" do
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_src_ems_vmware)
+#      ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, svc_model_dst_ems_redhat)
+#      expect(described_class.new(ae_service).transformation_type).to eq("#{svc_model_src_ems_vmware.emstype}2#{svc_model_dst_ems_redhat.emstype}")
+#    end
+#  end
 
-    it "source_ems without ems" do
-      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(nil)
-      errormsg = "No source EMS for VM '#{svc_model_src_vm.name}'"
-      expect { described_class.new.source_ems }.to raise_error(errormsg)
-    end
-
-    it "source_cluster with cluster" do
-      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_src_ems)
-      described_class.new.source_ems
-      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@source_ems).id).to eq(svc_model_src_ems.id)
-    end
-
-    it "destination_cluster without cluster" do
-      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(nil)
-      errormsg = "No destination cluster for VM '#{svc_model_src_vm.name}'"
-      expect { described_class.new.destination_cluster }.to raise_error(errormsg)
-    end
-
-    it "destination_cluster with cluster" do
-      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
-      described_class.new.destination_cluster
-      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_cluster).id).to eq(svc_model_dst_cluster.id)
-    end
-
-    it "destination_ems without ems" do
-      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
-      allow(svc_model_dst_cluster).to receive(:ext_management_system).and_return(nil)
-      errormsg = "No destination EMS for VM '#{svc_model_src_vm.name}'"
-      expect { described_class.new.destination_ems }.to raise_error(errormsg)
-    end
-
-    it "source_cluster with cluster" do
-      allow(svc_model_src_vm).to receive(:ems_cluster).and_return(svc_model_src_cluster)
-      allow(svc_model_task).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cluster)
-      allow(svc_model_src_vm).to receive(:ext_management_system).and_return(svc_model_dst_ems)
-      described_class.new.destination_ems
-      expect(ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_get(:@destination_ems).id).to eq(svc_model_dst_ems.id)
-    end
-
-  end
-
-  context "source and destination items source vmware and destination redhat" do
-    let(:src_vm) { src_vm_vmware }
-    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-    let(:src_ems) { src_ems_vmware }
-    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-    let(:dst_ems) { dst_ems_redhat }
-    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
-
-    it_behaves_like "source and destination items"
-  end
-
- context "source and destination items source vmware and destination openstack" do
-    let(:src_vm) { src_vm_vmware }
-    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-    let(:src_ems) { src_ems_vmware }
-    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-    let(:dst_ems) { dst_ems_openstack }
-    let(:svc_model_dst_ems) { svc_model_dst_ems_openstack }
-
-    it_behaves_like "source and destination items"
-  end
-
-  context "source and destination items with invalid source vmware and destination redhat" do
-    let(:src_vm) { src_vm_vmware }
-    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-    let(:src_ems) { src_ems_vmware }
-    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
-    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
-
-    it_behaves_like "source and destination items"
-  end
-
-   context "source and destination items source vmware and invalid destination" do
-    let(:src_vm) { src_vm_vmware }
-    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
-    let(:src_ems) { src_ems_vmware }
-    let(:svc_model_src_ems) { svc_model_src_ems_vmware }
-    let(:dst_ems) { FactoryGirl.create(:ems_vmware) }
-    let(:svc_model_dst_ems) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems) }
-
-    it_behaves_like "source and destination items"
-  end
-
-  context "transformation_type with invalid source ems" do
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_dst_ems_redhat)
-    errormsg = "Unsupported source EMS type: #{svc_model_dst_ems_redhat.emstype}."
-    expect { described_class.new.transformation_type }.to raise_error(errormsg)
-  end
-
-  context "transformation_type with invalid destination ems" do
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_src_ems_vmware)
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, svc_model_src_ems_vmware)
-    errormsg = "Unsupported destination EMS type: #{svc_model_src_ems_vmware.emstype}."
-    expect { described_class.new.transformation_type }.to raise_error(errormsg)
-  end
-
-  context "transformation_type with valid source and destination ems" do
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@source_ems, svc_model_src_ems_vmware)
-    ManageIQ::Automate::Transformation::Common::AssessTransformation.instance_variable_set(:@destination_ems, svc_model_dst_ems_redhat)
-    expect(described_class.new(ae_service).transformation_type).to eq("#{svc_model_src_ems_vmware.emstype}2#{svc_model_dst_ems_redhat.emstype}")
-  end
-
-  context "catchall exception rescue" do
-    before do
-      allow(svc_model_task).to receive(:source).and_raise(StandardError.new('kaboom'))
-    end
-
-    it "forcefully raise" do
-      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
-      expect { described_class.new(ae_service).main }.to raise_error(errormsg)
-      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => errormsg)
-    end
-  end
+#  context "catchall exception rescue" do
+#    it "forcefully raise" do
+#      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
+#      expect { described_class.new(ae_service).main }.to raise_error(errormsg)
+#      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => errormsg)
+#    end
+#  end
 end


### PR DESCRIPTION
Now that [PR#391](https://github.com/ManageIQ/manageiq-content/pull/391) is merged, this PR refactors the transformation assessment to split the code in max-5-lines-ish methods and adds the associated tests.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1600870