### PR TITLE
Trigger Nuage targeted refresh more often

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnettemplate_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_subnettemplate_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_subnettemplate_delete
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_zone_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_zone_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_zone_delete
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_zonetemplate_delete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/NUAGE.class/nuage_zonetemplate_delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: nuage_zonetemplate_delete
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"


### PR DESCRIPTION
With this commit we add three new entrypoints to Nuage targeted refresh to handle some Nuage problems with missing events:

- nuage_subnettemplate_delete
- nuage_zonetemplate_delete
- nuage_zone_delete

Targeted refresh was extended here:
- https://github.com/ManageIQ/manageiq-providers-nuage/pull/128
- https://github.com/ManageIQ/manageiq-providers-nuage/pull/134

@miq-bot add_label enhancement
@miq-bot assign @gmcculloug 

/cc @Ladas 