### PR TITLE
Updated requested method to fix vm_reconfigure via rest-api.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -158,7 +158,7 @@ def requested_storage(args_hash)
     end
     if args_hash[:resource].options[:disk_remove]
       args_hash[:resource].options[:disk_remove].each do |disk|
-        disk_num = disk[:disk_name].match(/_(\d).vmdk/)
+        disk_num = disk['disk_name'].match(/_(\d).vmdk/)
         next unless disk_num
         $evm.log(:info, "Reconfigure Disk Removal: #{disk.inspect}")
         disk_n_number = "disk_#{disk_num[1].succ}_size"

--- a/spec/automation/unit/method_validation/requested_spec.rb
+++ b/spec/automation/unit/method_validation/requested_spec.rb
@@ -240,6 +240,15 @@ describe "Quota Validation" do
       check_results(ws.root['quota_requested'], 10.megabytes, 2, 1, 4096.megabytes)
     end
 
+    it "removes a disk " do
+      setup_model("vmware_reconfigure")
+      @reconfigure_request.update_attributes(:options => {:src_ids => [@vm_vmware.id], :request_type => :vm_reconfigure,\
+      :disk_remove => [{"disk_name" => "freds disk", "persistent" => true, "thin_provisioned" => false,\
+      "dependent" => true, "bootable" => false}]})
+      ws = run_automate_method(reconfigure_attrs)
+      check_results(ws.root['quota_requested'], 0, 0, 1, 0.megabytes)
+    end
+
     it "minus 1 cpu and minus 2048 memory" do
       setup_model("vmware_reconfigure")
       @reconfigure_request.update_attributes(:options => {:src_ids => [@vm_vmware.id], :cores_per_socket => 1,\


### PR DESCRIPTION
Issuing a vm_reconfigure disk_remove via rest-api was failing.
Very minor change (:disk_name was changed to 'disk_name')

```disk_num = disk['disk_name'].match(/_(\d).vmdk/)"```

https://bugzilla.redhat.com/show_bug.cgi?id=1620161

The rest-api call for vm_reconfigure uses the ```options[:disk_remove]``` hash which contains a string key of ```'disk_name'```.  The quota requested method failed since it was expecting disk_name as a symbol. 

The UI also uses the ```options[:disk_remove]``` hash with a string key of ```'disk_name'```, which doesn't fail the same way in quota because the hash type is HashWithIndifferentAccess. So, the method wasn't able to find the correct value (nil), but didn't fail. Although this ticket is specifically about quota, the actual vm_reconfigure works when initiated by the UI, but does not work properly when initiated by the rest-api.
Will open a new ticket to track the vm_configure rest-api issue.
