### PR TITLE
Added log_and_exit utility method

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object.rb
@@ -8,6 +8,16 @@ module ManageIQ
       module CommonMethods
         module Utils
           class LogObject
+            # If you want to log a message and exit without specifying a handle using the global $evm
+            #    ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_exit(msg, code)
+            #
+            # If you want to log a message and exit using a specific handle
+            #    ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_exit(msg, code, handle)
+            #
+            def self.log_and_exit(msg, exit_code, handle = $evm)
+              handle.log('info', "Script ending #{msg} code : #{exit_code}")
+              exit(exit_code)
+            end
             # If you want to log the root MiqAeObject and use the global $evm
             #    ManageIQ::Automate::System::CommonMethods::Utils::LogObject.root
             #

--- a/spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb
+++ b/spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb
@@ -60,6 +60,18 @@ describe ManageIQ::Automate::System::CommonMethods::Utils::LogObject do
     ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log(root, 'My Object', ae_service)
   end
 
+  it '.log_and_exit' do
+    exit_msg = "Ta Ta for now"
+    exit_code = 7
+    expect(ae_service).to receive(:log).with('info', "Script ending #{exit_msg} code : #{exit_code}").exactly(1).times
+
+    expect do
+      ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_exit(exit_msg, exit_code, ae_service)
+    end.to raise_error(SystemExit) do |error|
+      expect(error.status).to eq(exit_code)
+    end
+  end
+
   context 'log ar_objects' do
     let(:ar_object) { svc_model_vm1 }
 


### PR DESCRIPTION
This utility method allows a user to log and exit with a single method call.
It also tests the exit call from a spec