### PR TITLE
Add support to apply right-size recommendation during transformation

### DIFF
--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize.rb
@@ -24,8 +24,8 @@ module ManageIQ
 
               def main
                 RIGHT_SIZE_ITEMS.each do |item|
-                  next unless @task.get_option("right_size_strategy_#{item}".to_sym)
-                  send("apply_right_size_#{item}", @task.get_option("right_size_strategy_#{item}".to_sym))
+                  right_size_strategy = @task.get_option("right_size_strategy_#{item}".to_sym)
+                  send("apply_right_size_#{item}", right_size_strategy) if right_size_strategy
                 end
               rescue => e
                 @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize.rb
@@ -1,0 +1,42 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Infrastructure
+        module VM
+          module Common
+            class ApplyRightSize
+              RIGHT_SIZE_ITEMS = %i(cpu memory).freeze
+
+              def initialize(handle = $evm)
+                @handle = handle
+                @task = ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
+                @source_vm = ManageIQ::Automate::Transformation::Common::Utils.source_vm(@handle)
+                @destination_vm = ManageIQ::Automate::Transformation::Common::Utils.destination_vm(@handle)
+              end
+
+              def apply_right_size_cpu(strategy)
+                @destination_vm.set_number_of_cpus(@source_vm.send("#{strategy}_recommended_vcpus"), :sync => true)
+              end
+
+              def apply_right_size_memory(strategy)
+                @destination_vm.set_memory(@source_vm.send("#{strategy}_recommended_mem"), :sync => true)
+              end
+
+              def main
+                RIGHT_SIZE_ITEMS.each do |item|
+                  next unless @task.get_option("right_size_strategy_#{item}".to_sym)
+                  send("apply_right_size_#{item}", @task.get_option("right_size_strategy_#{item}".to_sym))
+                end
+              rescue => e
+                @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+                raise
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::Transformation::Infrastructure::VM::Common::ApplyRightSize.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize.yaml
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize.yaml
@@ -1,0 +1,15 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ApplyRightSize
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    embedded_methods:
+    - "/Transformation/Common/Utils"
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/__class__.yaml
@@ -451,3 +451,23 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: state
+      name: State21
+      display_name: 
+      datatype: 
+      priority: 23
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/posttransform.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/posttransform.yaml
@@ -9,6 +9,14 @@ object:
     description: 
   fields:
   - State2:
+      value: "/Transformation/Infrastructure/VM/Common/ApplyRightSize"
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 5, description => "Apply Right-Size Recommendation", task_message => "Migrating")
+      on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Apply Right-Size Recommendation", task_message => "Migrating")
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
+        => "Apply Right-Size Recommendation", task_message => "Migrating")
+  - State5:
       value: "/Transformation/Infrastructure/VM/${state_var#destination_ems_type}/SetDescription"
       on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
         => 5, description => "Update description of VM", task_message => "Migrating")
@@ -16,7 +24,7 @@ object:
         => "Update description of VM", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Update description of VM", task_message => "Migrating")
-  - State5:
+  - State8:
       value: "/Transformation/Infrastructure/VM/Common/PowerOn"
       on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
         => 5, description => "Power-on VM", task_message => "Migrating")
@@ -24,16 +32,16 @@ object:
         => "Power-on VM", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Power-on VM", task_message => "Migrating")
-  - State8:
+  - State11:
       value: "/Transformation/Infrastructure/VM/Common/CheckPoweredOn"
       on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
         => 40, description => "Power-on VM", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
         => "Power-on VM", task_message => "Migrating")
-      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
+      on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 35, description
         => "Power-on VM", task_message => "Migrating")
       max_retries: '200'
-  - State11:
+  - State14:
       value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?transformation_hook=post"
       on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
         => 40, description         => "Run post-migration playbook")
@@ -41,7 +49,7 @@ object:
         "Run post-migration playbook")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description         =>
         "Run post-migration playbook")
-  - State14:
+  - State17:
       value: "/Transformation/Infrastructure/VM/Common/RestoreVmAttributes"
       on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
         => 5, description => "Restore VM Attributes", task_message => "Migrating")
@@ -49,7 +57,7 @@ object:
         => "Restore VM Attributes", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Restore VM Attributes", task_message => "Migrating")
-  - State17:
+  - State20:
       value: "/Transformation/Infrastructure/VM/${state_var#source_ems_type}/SetMigrated"
       on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
         => 5, description => "Mark source as migrated", task_message => "Migrating")

--- a/spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize_spec.rb
@@ -1,0 +1,95 @@
+require_domain_file
+require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb')
+
+describe ManageIQ::Automate::Transformation::Infrastructure::VM::Common::ApplyRightSize do
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:group) { FactoryGirl.create(:miq_group) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:src_vm_vmware) { FactoryGirl.create(:vm_vmware) }
+  let(:dst_vm_redhat) { FactoryGirl.create(:vm_redhat) }
+  let(:dst_ems_redhat) { FactoryGirl.create(:ems_redhat) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_group) { MiqAeMethodService::MiqAeServiceMiqGroup.find(group.id) }
+  let(:svc_model_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }
+  let(:svc_model_src_vm_vmware) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(src_vm_vmware.id) }
+  let(:svc_model_dst_vm_redhat) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager_Vm.find(dst_vm_redhat.id) }
+  let(:svc_model_dst_ems_redhat) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems_redhat.id) }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current'                                   => current_object,
+      'user'                                      => svc_model_user,
+      'service_template_transformation_plan_task' => svc_model_task
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object.parent = root
+      service.current_object = current_object
+    end
+  end
+
+  before do
+    allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
+    allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:source_vm).and_return(svc_model_src_vm)
+    allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:destination_vm).and_return(svc_model_dst_vm)
+
+    allow(svc_model_src_vm).to receive(:aggressive_recommended_vcpus).and_return(1)
+    allow(svc_model_src_vm).to receive(:conservative_recommended_mem).and_return(1024)
+    allow(svc_model_dst_vm).to receive(:set_number_of_cpus)
+    allow(svc_model_dst_vm).to receive(:set_memory)
+  end
+
+  shared_examples_for "apply right size" do
+    it "#apply_right_size_cpu" do
+      allow(svc_model_task).to receive(:get_option).with(:right_size_strategy_cpu).and_return('aggressive')
+      expect(svc_model_dst_vm).to receive(:set_number_of_cpus).with(1, :sync => true)
+      described_class.new(ae_service).apply_right_size_cpu('aggressive')
+    end
+
+    it "#apply_right_size_memory" do
+      allow(svc_model_task).to receive(:get_option).with(:right_size_strategy_memory).and_return('conservative')
+      expect(svc_model_dst_vm).to receive(:set_memory).with(1024, :sync => true)
+      described_class.new(ae_service).apply_right_size_memory('conservative')
+    end
+
+    it "#main without strategies" do
+      expect(svc_model_dst_vm).not_to receive(:set_number_of_cpus)
+      expect(svc_model_dst_vm).not_to receive(:set_memory)
+      described_class.new(ae_service).main
+    end
+
+    it "# main with strategies" do
+      allow(svc_model_task).to receive(:get_option).with(:right_size_strategy_cpu).and_return('aggressive')
+      allow(svc_model_task).to receive(:get_option).with(:right_size_strategy_memory).and_return('conservative')
+      expect(svc_model_dst_vm).to receive(:set_number_of_cpus).with(1, :sync => true)
+      expect(svc_model_dst_vm).to receive(:set_memory).with(1024, :sync => true)
+      described_class.new(ae_service).main
+    end
+  end
+
+  context "apply_right_size_cpu with source vmware and destination redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+
+    it_behaves_like "apply right size"
+  end
+
+  context "catchall exception rescue" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+    let(:svc_model_dst_ems) { svc_model_dst_ems_redhat }
+
+    before do
+      allow(svc_model_task).to receive(:get_option).with(:right_size_strategy_cpu).and_raise(StandardError, 'kaboom')
+    end
+
+    it "forcefully raise" do
+      expect { described_class.new(ae_service).main }.to raise_error('kaboom')
+      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => 'kaboom')
+    end
+  end
+end


### PR DESCRIPTION
When migrating a virtual machine, we have the opportunity to apply right-size recommendation as it is shutdown  in the migration process. This brings the additional ability to shrink the target environment and lower the TCO.

Depends on: https://github.com/ManageIQ/manageiq-automation_engine/pull/216
Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1623072