### PR TITLE
Transformation throttling - Base components

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/acquiretransformationhost.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/acquiretransformationhost.rb
@@ -5,27 +5,14 @@ module ManageIQ
         class AcquireTransformationHost
           def initialize(handle = $evm)
             @handle = handle
+            @task = ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
           end
 
           def main
-            factory_config = @handle.get_state_var(:factory_config)
-            raise "No factory config found. Aborting." if factory_config.nil?
-
-            task = @handle.root['service_template_transformation_plan_task']
-            @handle.log(:info, "Task: #{task.inspect}")
-
-            transformation_host_type, transformation_host, transformation_method = ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.get_transformation_host(task, factory_config)
-            if transformation_host.nil?
-              @handle.log(:info, "No transformation host available. Retrying.")
+            if @task.get_option(:transformation_host_id).nil?
               @handle.root['ae_result'] = 'retry'
               @handle.root['ae_retry_server_affinity'] = true
-              @handle.root['ae_retry_interval'] = $evm.object['check_convert_interval'] || '1.minutes'
-            else
-              @handle.log(:info, "Transformation Host: #{transformation_host.name}.")
-              task.set_option(:transformation_host_id, transformation_host.id)
-              task.set_option(:transformation_host_name, transformation_host.name)
-              task.set_option(:transformation_host_type, transformation_host_type)
-              task.set_option(:transformation_method, transformation_method)
+              @handle.root['ae_retry_interval'] = 15.seconds
             end
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/content/automate/ManageIQ/Transformation/StateMachines/TransformationThrottler.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/TransformationThrottler.class/__class__.yaml
@@ -1,0 +1,193 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: TransformationThrottler
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: throttler_election_strategy
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: throttler_ttl
+      display_name: 
+      datatype: integer
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: throttler_type
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State1
+      display_name: 
+      datatype: 
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State2
+      display_name: 
+      datatype: 
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State3
+      display_name: 
+      datatype: 
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State4
+      display_name: 
+      datatype: 
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State5
+      display_name: 
+      datatype: 
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: State6
+      display_name: 
+      datatype: 
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/StateMachines/TransformationThrottler.class/default.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/TransformationThrottler.class/default.yaml
@@ -1,0 +1,13 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Default
+    inherits: 
+    description: 
+  fields:
+  - State1:
+      value: "/Transformation/TransformationThrottler/Throttle"
+      max_retries: '250'

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/posttransform.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/posttransform.yaml
@@ -10,24 +10,24 @@ object:
   fields:
   - State2:
       value: "/Transformation/Infrastructure/VM/${state_var#destination_ems_type}/SetDescription"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
-        => "Update description of VM", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 5, description => "Update description of VM", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Update description of VM", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Update description of VM", task_message => "Migrating")
   - State5:
       value: "/Transformation/Infrastructure/VM/Common/PowerOn"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
-        => "Power-on VM", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 5, description => "Power-on VM", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Power-on VM", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Power-on VM", task_message => "Migrating")
   - State8:
       value: "/Transformation/Infrastructure/VM/Common/CheckPoweredOn"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
-        => "Power-on VM", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 40, description => "Power-on VM", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
         => "Power-on VM", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
@@ -35,24 +35,24 @@ object:
       max_retries: '200'
   - State11:
       value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?transformation_hook=post"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description         =>
-        "Run post-migration playbook")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 40, description         => "Run post-migration playbook")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description         =>
         "Run post-migration playbook")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description         =>
         "Run post-migration playbook")
   - State14:
       value: "/Transformation/Infrastructure/VM/Common/RestoreVmAttributes"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
-        => "Restore VM Attributes", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 5, description => "Restore VM Attributes", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Restore VM Attributes", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Restore VM Attributes", task_message => "Migrating")
   - State17:
       value: "/Transformation/Infrastructure/VM/${state_var#source_ems_type}/SetMigrated"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
-        => "Mark source as migrated", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 5, description => "Mark source as migrated", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Mark source as migrated", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/pretransform.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/pretransform.yaml
@@ -10,16 +10,16 @@ object:
   fields:
   - State2:
       value: "/Transformation/StateMachines/Ansible/TransformationPlaybook?transformation_hook=pre"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 30, description         =>
-        "Run pre-migration playbook")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 30, description         => "Run pre-migration playbook")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 30, description         =>
         "Run pre-migration playbook")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 30, description         =>
         "Run pre-migration playbook")
   - State5:
       value: "/Transformation/Infrastructure/VM/Common/PowerOff"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
-        => "Power off", task_message => "Pre-migration")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 40, description => "Power off", task_message => "Pre-migration")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
         => "Power off", task_message => "Pre-migration")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
@@ -27,8 +27,8 @@ object:
       max_retries: '20'
   - State8:
       value: "/Transformation/Infrastructure/VM/${state_var#source_ems_type}/CollapseSnapshots"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
-        => "Collapse Snapshots", task_message => "Pre-migration")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 40, description => "Collapse Snapshots", task_message => "Pre-migration")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description
         => "Collapse Snapshots", task_message => "Pre-migration")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 40, description

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transform.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transform.yaml
@@ -10,16 +10,16 @@ object:
   fields:
   - State2:
       value: "/Transformation/TransformationHosts/Common/VMTransform"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
-        => "Convert disks", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 5, description => "Convert disks", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Convert disks", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 5, description
         => "Convert disks", task_message => "Migrating")
   - State5:
       value: "/Transformation/TransformationHosts/Common/VMCheckTransformed"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description
-        => "Convert disks", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 80, description => "Convert disks", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description
         => "Convert disks", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description
@@ -27,8 +27,8 @@ object:
       max_retries: '1500'
   - State8:
       value: "/Transformation/Infrastructure/VM/Common/CheckVmInInventory"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 15, description
-        => "Refresh inventory", task_message => "Migrating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 15, description => "Refresh inventory", task_message => "Migrating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 15, description
         => "Refresh inventory", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 15, description

--- a/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml
@@ -14,16 +14,16 @@ object:
       value: "/Transformation/StateMachines/VMTransformation/TransformationCleanup"
   - State2:
       value: "/Transformation/Common/AssessTransformation"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
-        => "Assess Migration", task_message => "Validating")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 1, description => "Assess Migration", task_message => "Validating")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Assess Migration", task_message => "Validating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Assess Migration", task_message => "Validating")
   - State5:
       value: "/Transformation/Common/AcquireTransformationHost"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
-        => "Acquire Transformation Host", task_message => "Pre-migration")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 1, description => "Acquire Transformation Host", task_message => "Pre-migration")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
         => "Acquire Transformation Host", task_message => "Pre-migration")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 1, description
@@ -31,24 +31,24 @@ object:
       max_retries: '86400'
   - State8:
       value: "/Transformation/StateMachines/VMTransformation/PreTransform?state_ancestry=${#state_ancestry}/${#ae_state}"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 2, description
-        => "Pre Transform VM")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 2, description => "Pre Transform VM")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 2, description
         => "Pre Transform VM")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 2, description
         => "Pre Transform VM")
   - State11:
       value: "/Transformation/StateMachines/VMTransformation/Transform?state_ancestry=${#state_ancestry}/${#ae_state}"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 85, description
-        => "Transform VM")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 85, description => "Transform VM")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 85, description
         => "Transform VM")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 85, description
         => "Transform VM")
   - State14:
       value: "/Transformation/StateMachines/VMTransformation/PostTransform?state_ancestry=${#state_ancestry}/${#ae_state}"
-      on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
-        => "Post Transform VM")
+      on_entry: /Transformation/TransformationThrottler.Watch ; /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight
+        => 10, description => "Post Transform VM")
       on_exit: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description
         => "Post Transform VM")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 10, description

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__class__.yaml
@@ -1,0 +1,33 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: TransformationThrottler
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: method
+      name: execute
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/throttle.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/throttle.rb
@@ -1,0 +1,22 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module TransformationThrottler
+        class Throttle
+          def initialize(handle = $evm)
+            @handle = handle
+          end
+
+          def main
+            return unless ManageIQ::Automate::Transformation::TransformationThrottler::Utils.elected_throttler?(@handle)
+            ManageIQ::Automate::Transformation::TransformationThrottler::Utils.schedule_tasks(@handle)
+            ManageIQ::Automate::Transformation::TransformationThrottler::Utils.adjust_limits(@handle)
+            ManageIQ::Automate::Transformation::TransformationThrottler::Utils.retry_or_die(@handle)
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::Transformation::TransformationThrottler::Throttle.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/throttle.yaml
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/throttle.yaml
@@ -3,13 +3,14 @@ object_type: method
 version: 1.0
 object:
   attributes:
-    name: AcquireTransformationHost
+    name: Throttle
     display_name: 
     description: 
     scope: instance
     language: ruby
     location: inline
     embedded_methods:
-    - "/Transformation/Common/Utils"
+    - "/Transformation/TransformationThrottler/Utils"
+    - "/Transformation/TransformationHosts/Common/Utils"
     options: {}
   inputs: []

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.rb
@@ -67,7 +67,7 @@ module ManageIQ
                 :class_name    => CLASS_NAME,
                 :instance_name => throttler_type(handle),
                 :user_id       => 1,
-                :attrs         => { :ttl => throttler_ttl }
+                :attrs         => { :ttl => throttler_ttl(handle) }
               },
               'admin',
               true
@@ -75,10 +75,10 @@ module ManageIQ
           end
 
           def self.retry_or_die(handle = $evm)
-            return if current_throttler.created_on.utc + throttler_ttl < Time.now.utc
+            return if current_throttler(handle).created_on.utc + throttler_ttl(handle) < Time.now.utc
             return if active_transformation_tasks(handle).empty?
             handle.root['ae_result'] = 'retry'
-            handle.root['ae_retry_interval'] = (throttler_ttl / handle.root['ae_state_max_retries']).seconds
+            handle.root['ae_retry_interval'] = (throttler_ttl(handle) / handle.root['ae_state_max_retries']).seconds
           end
 
           def self.tasks_scheduling_policy(handle = $evm)

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.rb
@@ -1,0 +1,125 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module TransformationThrottler
+        class Utils
+          NAMESPACE = 'Transformation/StateMachines'.freeze
+          CLASS_NAME = 'TransformationThrottler'.freeze
+          DEFAULT_THROTTLER_ELECTION_POLICY = 'eldest_active'.freeze
+          DEFAULT_THROTTLER_TYPE = 'Default'.freeze
+          DEFAULT_THROTTLER_TTL = 3600
+          DEFAULT_TASKS_SCHEDULING_POLICY = 'fifo'.freeze
+          DEFAULT_LIMITS_ADJUSTMENT_POLICY = 'skip'.freeze
+
+          def self.log_and_raise(message, handle = $evm)
+            handle.log(:error, message)
+            raise "ERROR - #{message}"
+          end
+
+          def self.task(handle = $evm)
+            @task ||= handle.root['automation_task'].tap do |task|
+              log_and_raise('An automation_task is needed for this method to continue', handle) if task.nil?
+            end
+          end
+
+          def self.current_throttler(handle = $evm)
+            @current_throttler ||= task(handle).miq_request.tap do |request|
+              log_and_raise('A miq_request is needed for this method to continue', handle) if request.nil?
+            end
+          end
+
+          def self.active_throttlers(handle = $evm)
+            @active_throttlers ||= handle.vmdb(:miq_request).where(
+              :request_state => 'active',
+              :type          => 'AutomationRequest'
+            ).select do |request|
+              request.options[:namespace] == NAMESPACE &&
+                request.options[:class_name] == CLASS_NAME &&
+                request.options[:instance_name] == throttler_type(handle)
+            end
+          end
+
+          def self.throttler_election_policy(handle = $evm)
+            @throttler_election_policy ||= handle.root['throttler_election_policy'] || DEFAULT_THROTTLER_ELECTION_POLICY
+          end
+
+          def self.elected_throttler?(handle = $evm)
+            send("#{throttler_election_policy(handle)}_throttler?", handle)
+          end
+
+          def self.eldest_active_throttler?(handle = $evm)
+            active_throttlers(handle).select { |t| t.created_on < current_throttler(handle).created_on }.length.zero?
+          end
+
+          def self.throttler_ttl(handle = $evm)
+            @throttler_ttl ||= handle.root['throttler_ttl'] || DEFAULT_THROTTLER_TTL
+          end
+
+          def self.throttler_type(handle = $evm)
+            @throttler_type ||= handle.root['throttler_type'] || DEFAULT_THROTTLER_TYPE
+          end
+
+          def self.launch(handle = $evm)
+            handle.execute(
+              :create_automation_request,
+              {
+                :namespace     => NAMESPACE,
+                :class_name    => CLASS_NAME,
+                :instance_name => throttler_type(handle),
+                :user_id       => 1,
+                :attrs         => { :ttl => throttler_ttl }
+              },
+              'admin',
+              true
+            )
+          end
+
+          def self.retry_or_die(handle = $evm)
+            return if current_throttler.created_on.utc + throttler_ttl < Time.now.utc
+            return if active_transformation_tasks(handle).empty?
+            handle.root['ae_result'] = 'retry'
+            handle.root['ae_retry_interval'] = (throttler_ttl / handle.root['ae_state_max_retries']).seconds
+          end
+
+          def self.tasks_scheduling_policy(handle = $evm)
+            @tasks_scheduling_policy ||= handle.root['tasks_scheduling_policy'] || DEFAULT_TASKS_SCHEDULING_POLICY
+          end
+
+          def self.schedule_tasks(handle = $evm)
+            send("schedule_tasks_#{tasks_scheduling_policy(handle)}", handle)
+          end
+
+          def self.schedule_tasks_fifo(handle = $evm)
+            unassigned_transformation_tasks(handle).sort_by(&:created_on).each do |transformation_task|
+              transformation_host_type, transformation_host, transformation_method = ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.get_transformation_host(transformation_task, {})
+              break if transformation_host.nil?
+              transformation_task.set_option(:transformation_host_id, transformation_host.id)
+              transformation_task.set_option(:transformation_host_name, transformation_host.name)
+              transformation_task.set_option(:transformation_host_type, transformation_host_type)
+              transformation_task.set_option(:transformation_method, transformation_method)
+            end
+          end
+
+          def self.limits_adjustment_policy(handle = $evm)
+            @limits_adjustment_policy ||= handle.root['limits_adjustment_policy'] || DEFAULT_LIMITS_ADJUSTMENT_POLICY
+          end
+
+          def self.adjust_limits(handle = $evm)
+            send("adjust_limits_#{limits_adjustment_policy(handle)}", handle)
+          end
+
+          def self.adjust_limits_skip(handle = $evm)
+          end
+
+          def self.active_transformation_tasks(handle)
+            @active_transformation_tasks ||= handle.vmdb(:service_template_transformation_plan_task).where(:state => 'active')
+          end
+
+          def self.unassigned_transformation_tasks(handle)
+            active_transformation_tasks(handle).select { |transformation_task| transformation_task.get_option(:transformation_host_id).nil? }
+          end
+        end
+      end
+    end
+  end
+end

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.yaml
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.yaml
@@ -3,13 +3,13 @@ object_type: method
 version: 1.0
 object:
   attributes:
-    name: AcquireTransformationHost
+    name: Utils
     display_name: 
     description: 
     scope: instance
     language: ruby
     location: inline
     embedded_methods:
-    - "/Transformation/Common/Utils"
+    - "/Transformation/TransformationHosts/Common/Utils"
     options: {}
   inputs: []

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/watch.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/watch.rb
@@ -1,0 +1,20 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module TransformationThrottler
+        class Watch
+          def initialize(handle = $evm)
+            @handle = handle
+            @active_throttlers = ManageIQ::Automate::Transformation::TransformationThrottler::Utils.active_throttlers(@handle)
+          end
+
+          def main
+            ManageIQ::Automate::Transformation::TransformationThrottler::Utils.launch(@handle) if @active_throttlers.empty?
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::Transformation::TransformationThrottler::Watch.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/watch.yaml
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/watch.yaml
@@ -3,13 +3,13 @@ object_type: method
 version: 1.0
 object:
   attributes:
-    name: AcquireTransformationHost
+    name: Watch
     display_name: 
     description: 
     scope: instance
     language: ruby
     location: inline
     embedded_methods:
-    - "/Transformation/Common/Utils"
+    - "/Transformation/TransformationThrottler/Utils"
     options: {}
   inputs: []

--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/_missing.yaml
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/_missing.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: "${#_missing_instance}"

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/acquiretransformationhost_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/acquiretransformationhost_spec.rb
@@ -1,0 +1,64 @@
+require_domain_file
+require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb')
+
+describe ManageIQ::Automate::Transformation::Common::AcquireTransformationHost do
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:host) { FactoryGirl.create(:host) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }
+  let(:svc_model_host) { MiqAeMethodService::MiqAeServiceHost.find(host.id) }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current'             => current_object,
+      'user'                => svc_model_user,
+      'state_machine_phase' => 'transformation'
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root
+      service.object = current_object
+    end
+  end
+
+  before do
+    allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).and_return(svc_model_task)
+  end
+
+  context "#main" do
+    it "without transformation host" do
+      allow(svc_model_task).to receive(:get_option).with(:transformation_host_id).and_return(nil)
+      described_class.new(ae_service).main
+      expect(ae_service.root['ae_result']).to eq('retry')
+      expect(ae_service.root['ae_retry_server_affinity']).to eq(true)
+      expect(ae_service.root['ae_retry_interval']).to eq(15.seconds)
+    end
+
+    it "with transformation host" do
+      allow(svc_model_task).to receive(:get_option).with(:transformation_host_id).and_return(svc_model_host.id)
+      described_class.new(ae_service).main
+      expect(ae_service.root['ae_result']).to be_nil
+      expect(ae_service.root['ae_retry_server_affinity']).to be_nil
+      expect(ae_service.root['ae_retry_interval']).to be_nil
+    end
+  end
+
+  context "catchall exception rescue" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+
+    before do
+      allow(svc_model_task).to receive(:get_option).with(:transformation_host_id).and_raise(StandardError, 'kaboom')
+    end
+
+    it "forcefully raise" do
+      expect { described_class.new(ae_service).main }.to raise_error('kaboom')
+      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => 'kaboom')
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
@@ -1,5 +1,5 @@
 require_domain_file
-require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb')
+require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb')
 
 describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
   let(:user) { FactoryGirl.create(:user_with_email_and_group) }
@@ -7,12 +7,18 @@ describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
   let(:automation_request_1) { FactoryGirl.create(:automation_request) }
   let(:automation_request_2) { FactoryGirl.create(:automation_request) }
   let(:automation_request_3) { FactoryGirl.create(:automation_request) }
+  let(:transformation_task_1) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:transformation_task_2) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:host) { FactoryGirl.create(:host) }
 
   let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
   let(:svc_model_automation_task) { MiqAeMethodService::MiqAeServiceAutomationTask.find(automation_task.id) }
   let(:svc_model_automation_request_1) { MiqAeMethodService::MiqAeServiceAutomationRequest.find(automation_request_1.id) }
   let(:svc_model_automation_request_2) { MiqAeMethodService::MiqAeServiceAutomationRequest.find(automation_request_2.id) }
   let(:svc_model_automation_request_3) { MiqAeMethodService::MiqAeServiceAutomationRequest.find(automation_request_3.id) }
+  let(:svc_model_transformation_task_1) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(transformation_task_1.id) }
+  let(:svc_model_transformation_task_2) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(transformation_task_2.id) }
+  let(:svc_model_host) { MiqAeMethodService::MiqAeServiceHost.find(host.id) }
 
   let(:root) do
     Spec::Support::MiqAeMockObject.new(
@@ -46,6 +52,13 @@ describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
   before(:each) do
     ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@task, nil)
     ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@current_throttler, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@active_throttlers, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_election_policy, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_type, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_ttl, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@tasks_scheduling_policy, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@limits_adjustment_policy, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@active_transformation_tasks, nil)
   end
 
   context "#task" do
@@ -78,11 +91,203 @@ describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
   context "#active_throttlers" do
     let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceAutomationRequest }
 
-    it "eliminate invalid request" do
+    it "filter out invalid request" do
       allow(ae_service).to receive(:vmdb).with(:miq_request).and_return(svc_vmdb_handle)
       allow(svc_vmdb_handle).to receive(:where).with(:request_state => 'active', :type => 'AutomationRequest').and_return([svc_model_automation_request_1, svc_model_automation_request_3])
       expect(described_class.active_throttlers(ae_service).length).to eq(1)
       expect(described_class.active_throttlers(ae_service).first.id).to eq(svc_model_automation_request_1.id)
+    end
+  end
+
+  context "#throttler_election_policy" do
+    it "without policy" do
+      expect(described_class.throttler_election_policy(ae_service)).to eq('eldest_active')
+    end
+
+    it "with policy" do
+      ae_service.root['throttler_election_policy'] = 'smarter'
+      expect(described_class.throttler_election_policy(ae_service)).to eq('smarter')
+    end
+  end
+
+  context "#elected_throttler?" do
+    it "check send correct method" do
+      expect(described_class).to receive(:eldest_active_throttler?).with(ae_service)
+      described_class.elected_throttler?(ae_service)
+    end
+  end
+
+  context "#eldest_active_throttler?" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceAutomationRequest }
+
+    before do
+      ae_service.root['automation_task'] = svc_model_automation_task
+      allow(ae_service).to receive(:vmdb).with(:miq_request).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:request_state => 'active', :type => 'AutomationRequest').and_return([svc_model_automation_request_1, svc_model_automation_request_2])
+    end
+
+    it "is not eldest active throttler" do
+      allow(svc_model_automation_task).to receive(:miq_request).and_return(svc_model_automation_request_2)
+      expect(described_class.eldest_active_throttler?(ae_service)).to eq(false)
+    end
+
+    it "is eldest active throttler" do
+      allow(svc_model_automation_task).to receive(:miq_request).and_return(svc_model_automation_request_1)
+      expect(described_class.eldest_active_throttler?(ae_service)).to eq(true)
+    end
+  end
+
+  context "#throttler_ttl" do
+    it "without ttl" do
+      expect(described_class.throttler_ttl(ae_service)).to eq(3600)
+    end
+
+    it "with type" do
+      ae_service.root['throttler_ttl'] = 86_400
+      expect(described_class.throttler_ttl(ae_service)).to eq(86_400)
+    end
+  end
+
+  context "#throttler_type" do
+    it "without type" do
+      expect(described_class.throttler_type(ae_service)).to eq('Default')
+    end
+
+    it "with type" do
+      ae_service.root['throttler_type'] = 'Custom'
+      expect(described_class.throttler_type(ae_service)).to eq('Custom')
+    end
+  end
+
+  context "#launch" do
+    it "with default values" do
+      expect(ae_service).to receive(:execute).with(
+        :create_automation_request,
+        {
+          :namespace     => 'Transformation/StateMachines',
+          :class_name    => 'TransformationThrottler',
+          :instance_name => 'Default',
+          :user_id       => 1,
+          :attrs         => { :ttl => 3600 }
+        },
+        'admin',
+        true
+      )
+      described_class.launch(ae_service)
+    end
+  end
+
+  context "#retry_or_die" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask }
+
+    before do
+      ae_service.root['automation_task'] = svc_model_automation_task
+      allow(svc_model_automation_task).to receive(:miq_request).and_return(svc_model_automation_request_1)
+    end
+
+    it "ttl reached" do
+      allow(svc_model_automation_request_1).to receive(:created_on).and_return(Time.now.utc + 60)
+      described_class.retry_or_die(ae_service)
+      expect(ae_service.root['ae_result']).to be_nil
+    end
+
+    it "without active transformation task" do
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:state => 'active').and_return([])
+      described_class.retry_or_die(ae_service)
+      expect(ae_service.root['ae_result']).to be_nil
+    end
+
+    it "with active transformation task" do
+      ae_service.root['ae_state_max_retries'] = 60
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:state => 'active').and_return([svc_model_transformation_task_1])
+      described_class.retry_or_die(ae_service)
+      expect(ae_service.root['ae_result']).to eq('retry')
+      expect(ae_service.root['ae_retry_interval']).to eq(60.seconds)
+    end
+  end
+
+  context "#tasks_scheduling_policy" do
+    it "without policy" do
+      expect(described_class.tasks_scheduling_policy(ae_service)).to eq('fifo')
+    end
+
+    it "with policy" do
+      ae_service.root['tasks_scheduling_policy'] = 'smarter'
+      expect(described_class.tasks_scheduling_policy(ae_service)).to eq('smarter')
+    end
+  end
+
+  context "#schedule_tasks" do
+    it "check send correct method" do
+      expect(described_class).to receive(:schedule_tasks_fifo).with(ae_service)
+      described_class.schedule_tasks(ae_service)
+    end
+  end
+
+  context "#schedule_tasks_fifo" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask }
+
+    it "only one slot available" do
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:state => 'active').and_return([svc_model_transformation_task_1, svc_model_transformation_task_2])
+      allow(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:get_transformation_host).and_return(['OVirtHost', svc_model_host, 'vddk'], [nil, nil, nil])
+      described_class.schedule_tasks_fifo(ae_service)
+      expect(svc_model_transformation_task_1.get_option(:transformation_host_id)).to eq(svc_model_host.id)
+      expect(svc_model_transformation_task_1.get_option(:transformation_host_name)).to eq(svc_model_host.name)
+      expect(svc_model_transformation_task_1.get_option(:transformation_host_type)).to eq('OVirtHost')
+      expect(svc_model_transformation_task_1.get_option(:transformation_method)).to eq('vddk')
+      expect(svc_model_transformation_task_2.get_option(:transformation_host_id)).to be_nil
+      expect(svc_model_transformation_task_2.get_option(:transformation_host_name)).to be_nil
+      expect(svc_model_transformation_task_2.get_option(:transformation_host_type)).to be_nil
+      expect(svc_model_transformation_task_2.get_option(:transformation_method)).to be_nil
+    end
+  end
+
+  context "#limits_adjustment_policy" do
+    it "without policy" do
+      expect(described_class.limits_adjustment_policy(ae_service)).to eq('skip')
+    end
+
+    it "with policy" do
+      ae_service.root['limits_adjustment_policy'] = 'smarter'
+      expect(described_class.limits_adjustment_policy(ae_service)).to eq('smarter')
+    end
+  end
+
+  context "#adjust_limits" do
+    it "check send correct method" do
+      expect(described_class).to receive(:adjust_limits_skip).with(ae_service)
+      described_class.adjust_limits(ae_service)
+    end
+  end
+
+  context "#active_transformation_tasks" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask }
+
+    it "without active transformation task" do
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:state => 'active').and_return([])
+      expect(described_class.active_transformation_tasks(ae_service)).to eq([])
+    end
+
+    it "with active transformation task" do
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:state => 'active').and_return([svc_model_transformation_task_1])
+      expect(described_class.active_transformation_tasks(ae_service).first.id).to eq(svc_model_transformation_task_1.id)
+    end
+  end
+
+  context "#unassigned_transformation_tasks" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask }
+
+    it "filter out assigned transformation task" do
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:state => 'active').and_return([svc_model_transformation_task_1, svc_model_transformation_task_2])
+      allow(svc_model_transformation_task_1).to receive(:get_option).with(:transformation_host_id).and_return(svc_model_host.id)
+      expect(described_class.unassigned_transformation_tasks(ae_service).length).to eq(1)
+      expect(described_class.unassigned_transformation_tasks(ae_service).first.id).to eq(svc_model_transformation_task_2.id)
     end
   end
 end

--- a/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
@@ -1,0 +1,88 @@
+require_domain_file
+require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb')
+
+describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:automation_task) { FactoryGirl.create(:automation_task) }
+  let(:automation_request_1) { FactoryGirl.create(:automation_request) }
+  let(:automation_request_2) { FactoryGirl.create(:automation_request) }
+  let(:automation_request_3) { FactoryGirl.create(:automation_request) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_automation_task) { MiqAeMethodService::MiqAeServiceAutomationTask.find(automation_task.id) }
+  let(:svc_model_automation_request_1) { MiqAeMethodService::MiqAeServiceAutomationRequest.find(automation_request_1.id) }
+  let(:svc_model_automation_request_2) { MiqAeMethodService::MiqAeServiceAutomationRequest.find(automation_request_2.id) }
+  let(:svc_model_automation_request_3) { MiqAeMethodService::MiqAeServiceAutomationRequest.find(automation_request_3.id) }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current' => current_object,
+      'user'    => svc_model_user,
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object.parent = root
+      service.current_object = current_object
+    end
+  end
+
+  before do
+    svc_model_automation_request_1.set_option(:namespace, 'Transformation/StateMachines')
+    svc_model_automation_request_1.set_option(:class_name, 'TransformationThrottler')
+    svc_model_automation_request_1.set_option(:instance_name, 'Default')
+
+    svc_model_automation_request_2.set_option(:namespace, 'Transformation/StateMachines')
+    svc_model_automation_request_2.set_option(:class_name, 'TransformationThrottler')
+    svc_model_automation_request_2.set_option(:instance_name, 'Default')
+
+    svc_model_automation_request_3.set_option(:namespace, 'Transformation/StateMachines')
+    svc_model_automation_request_3.set_option(:class_name, 'TransformationThrottler')
+    svc_model_automation_request_3.set_option(:instance_name, 'Invalid')
+  end
+
+  before(:each) do
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@task, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@current_throttler, nil)
+  end
+
+  context "#task" do
+    it "without task" do
+      errormsg = 'ERROR - An automation_task is needed for this method to continue'
+      expect { described_class.task(ae_service) }.to raise_error(errormsg)
+    end
+
+    it "with task" do
+      ae_service.root['automation_task'] = svc_model_automation_task
+      expect(described_class.task(ae_service).id).to eq(svc_model_automation_task.id)
+    end
+  end
+
+  context "#current_throttler" do
+    it "without request" do
+      ae_service.root['automation_task'] = svc_model_automation_task
+      allow(svc_model_automation_task).to receive(:miq_request).and_return(nil)
+      errormsg = 'ERROR - A miq_request is needed for this method to continue'
+      expect { described_class.current_throttler(ae_service) }.to raise_error(errormsg)
+    end
+
+    it "with request" do
+      ae_service.root['automation_task'] = svc_model_automation_task
+      allow(svc_model_automation_task).to receive(:miq_request).and_return(svc_model_automation_request_1)
+      expect(described_class.current_throttler(ae_service).id).to eq(svc_model_automation_request_1.id)
+    end
+  end
+
+  context "#active_throttlers" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceAutomationRequest }
+
+    it "eliminate invalid request" do
+      allow(ae_service).to receive(:vmdb).with(:miq_request).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:where).with(:request_state => 'active', :type => 'AutomationRequest').and_return([svc_model_automation_request_1, svc_model_automation_request_3])
+      expect(described_class.active_throttlers(ae_service).length).to eq(1)
+      expect(described_class.active_throttlers(ae_service).first.id).to eq(svc_model_automation_request_1.id)
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
@@ -35,7 +35,17 @@ describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
     end
   end
 
-  before do
+  before(:each) do
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@task, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@current_throttler, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@active_throttlers, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_election_policy, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_type, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_ttl, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@tasks_scheduling_policy, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@limits_adjustment_policy, nil)
+    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@active_transformation_tasks, nil)
+
     svc_model_automation_request_1.set_option(:namespace, 'Transformation/StateMachines')
     svc_model_automation_request_1.set_option(:class_name, 'TransformationThrottler')
     svc_model_automation_request_1.set_option(:instance_name, 'Default')
@@ -47,18 +57,6 @@ describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
     svc_model_automation_request_3.set_option(:namespace, 'Transformation/StateMachines')
     svc_model_automation_request_3.set_option(:class_name, 'TransformationThrottler')
     svc_model_automation_request_3.set_option(:instance_name, 'Invalid')
-  end
-
-  before(:each) do
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@task, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@current_throttler, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@active_throttlers, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_election_policy, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_type, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@throttler_ttl, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@tasks_scheduling_policy, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@limits_adjustment_policy, nil)
-    ManageIQ::Automate::Transformation::TransformationThrottler::Utils.instance_variable_set(:@active_transformation_tasks, nil)
   end
 
   context "#task" do


### PR DESCRIPTION
This PR is the first part of the throttling mechanism. Instead of using a transformation task as the scheduler / throttler, we use a dedicated automation request/task. The throttler creation logic is in a method called in `on_entry`, separately from WeightedUpdateStatus. This acts as a watchdog and creates a new throttler if needed. The throttler is a generic automation task with it's own state machine, so instantiating it is be done using `$evm.execute(:create_automation_request)`.

The state machine associated to the throttler task loops until no transformation task is left, or reaching its TTL. It is be responsible to adjust the limits of all the running tasks, but this PR doesn't implement the logic. The conversion host selection logic has also been moved to this task as it would solves the collisions issue. The idea of the TTL is to prevent never ending tasks: the throttler reads the existing state from the transformation task, so the next one can take over with no loss.

To ensure it acts as a *singleton*, We check in the throttler code that no other throttler is alive, i.e. `request_state == 'active'. If more than one is alive, only the eldest (`created_on`) continues, the others stop.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1594196