### PR TITLE
Adding log_and_notify method into log_object embedded method.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object.rb
@@ -1,6 +1,7 @@
 #
 # Description: Display Log messages for object attributes for root, current or desired object.
 # Added InspectMe functionality
+# Added log_and_notify
 
 module ManageIQ
   module Automate
@@ -8,6 +9,12 @@ module ManageIQ
       module CommonMethods
         module Utils
           class LogObject
+            NOTIFY_LEVEL_TO_LOG_LEVEL = {
+              'info'    => 'info',
+              'warning' => 'warn',
+              'error'   => 'error',
+              'success' => 'info'
+            }.freeze
             # If you want to log a message and exit without specifying a handle using the global $evm
             #    ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_exit(msg, code)
             #
@@ -18,6 +25,20 @@ module ManageIQ
               handle.log('info', "Script ending #{msg} code : #{exit_code}")
               exit(exit_code)
             end
+
+            # If you want to create a notification and log a message without specifying a handle using the global $evm
+            #    ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_notify(notify_level, msg, subject)
+            #
+            # If you want to create a notification and log a message using a specific handle
+            #    ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_notify(notify_level, msg, subject, handle)
+            #
+            # Valid types are : info, warning, error and success
+            def self.log_and_notify(notify_level, message, subject, handle = $evm)
+              raise "Invalid notify level #{notify_level}" unless NOTIFY_LEVEL_TO_LOG_LEVEL.keys.include?(notify_level.downcase.to_s)
+              handle.create_notification(:level => notify_level.downcase, :message => message, :subject => subject)
+              handle.log(NOTIFY_LEVEL_TO_LOG_LEVEL[notify_level.downcase.to_s], message)
+            end
+
             # If you want to log the root MiqAeObject and use the global $evm
             #    ManageIQ::Automate::System::CommonMethods::Utils::LogObject.root
             #

--- a/spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb
+++ b/spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb
@@ -80,6 +80,61 @@ describe ManageIQ::Automate::System::CommonMethods::Utils::LogObject do
     end
   end
 
+  shared_examples_for "log_and_notify" do
+    it "check" do
+      expect(ae_service).to receive(:create_notification).with(:level => notify_level, :message => message, :subject => vm1)
+      expect(ae_service).to receive(:log).with(log_level, /#{message}/).exactly(1).times
+      # described_class.log_and_notify.log(level, message, subject, ae_service)
+      ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_notify(level, message, vm1, ae_service)
+    end
+  end
+
+  context "level is iNfo" do
+    let(:level) { 'iNfo' }
+    let(:notify_level) { 'info' }
+    let(:log_level) { 'info' }
+    let(:message) { 'info msg' }
+
+    it_behaves_like "log_and_notify"
+  end
+
+  context "level is success" do
+    let(:level) { 'success' }
+    let(:notify_level) { 'success' }
+    let(:log_level) { 'info' }
+    let(:message) { 'success msg' }
+
+    it_behaves_like "log_and_notify"
+  end
+
+  context "level is warniNG" do
+    let(:level) { 'warniNG' }
+    let(:notify_level) { 'warning' }
+    let(:log_level) { 'warn' }
+    let(:message) { 'warning msg' }
+
+    it_behaves_like "log_and_notify"
+  end
+
+  context "level is error" do
+    let(:level) { 'error' }
+    let(:notify_level) { 'error' }
+    let(:log_level) { 'error' }
+    let(:message) { 'error msg' }
+
+    it_behaves_like "log_and_notify"
+  end
+
+  it "log_and_notify failure" do
+    level = 'fred'
+    message = 'blah blah blah'
+    errormsg = 'Invalid notify level fred'
+    expect do
+      # described_class.log_and_notify.log(:fred, 'blah blah blah', vm1, ae_service)
+      ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_notify(level, message, vm1, ae_service)
+    end.to raise_error(RuntimeError, errormsg)
+  end
+
   context 'log ar_objects' do
     let(:ar_object) { svc_model_vm1 }
 


### PR DESCRIPTION
This utility method allows an user to create a notification and log message with a single method call.
You can create an info, warning, success or error notification.
You can create an info, warn or error log message.

@miq-bot add_label enhancement