### PR TITLE
[GAPRINDASHVILI] Correct require_domain_file statement

### DIFF
--- a/spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes_spec.rb
@@ -1,4 +1,4 @@
-require domain_file
+require_domain_file
 
 describe ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes do
   let(:user) { FactoryGirl.create(:user_with_email_and_group) }


### PR DESCRIPTION
Fixed upstream in PR https://github.com/ManageIQ/manageiq-content/pull/390

Requires https://github.com/ManageIQ/manageiq-automation_engine/pull/196 backported to `Gaprindashvili` branch to resolve test failures.