### PR TITLE
[Gaprindashvili] Remove the `if` conditionals to improve test coverage

### DIFF
--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials.rb
@@ -63,6 +63,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::AvailableCredentials.new.main
-end
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::AvailableCredentials.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -130,6 +130,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::StateMachines::Job::LaunchAnsibleJob.new.main
-end
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::StateMachines::Job::LaunchAnsibleJob.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_completion.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_completion.rb
@@ -67,6 +67,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::StateMachines::Job::WaitForCompletion.new.main
-end
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::StateMachines::Job::WaitForCompletion.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_ip.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_ip.rb
@@ -47,6 +47,5 @@ module ManageIQ
     end
   end
 end
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::StateMachines::Job::WaitForIP.new.main
-end
+
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::StateMachines::Job::WaitForIP.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
@@ -80,6 +80,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::CheckProvisioned.new.main
-end
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::CheckProvisioned.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/post_provision.rb
@@ -54,6 +54,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::PostProvision.new.main
-end
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::PostProvision.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision.rb
@@ -61,6 +61,5 @@ module ManageIQ
     end
   end
 end
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::Preprovision.new.main
-end
+
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::Preprovision.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/provision.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/provision.rb
@@ -52,6 +52,5 @@ module ManageIQ
     end
   end
 end
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::Provision.new.main
-end
+
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::Provision::Provision.new.main

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -54,6 +54,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::UpdateServiceProvisionStatus.new.main
-end
+ManageIQ::Automate::AutomationManagement::AnsibleTower::Service::Provisioning::StateMachines::UpdateServiceProvisionStatus.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.rb
@@ -55,6 +55,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableAvailabilityZones.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableAvailabilityZones.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_flavors.rb
@@ -55,6 +55,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableFlavors.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableFlavors.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_images.rb
@@ -60,6 +60,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableImages.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableImages.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_os_types.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_os_types.rb
@@ -53,6 +53,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableOsTypes.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableOsTypes.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_resource_groups.rb
@@ -56,6 +56,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableResoureceGroups.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableResoureceGroups.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_tenants.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_tenants.rb
@@ -50,6 +50,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableTenants.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Operations::AvailableTenants.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -121,6 +121,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::CheckProvisioned.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::CheckProvisioned.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.rb
@@ -38,6 +38,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::PostProvision.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::PostProvision.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/preprovision.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/preprovision.rb
@@ -51,6 +51,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::PreProvision.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::PreProvision.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -37,6 +37,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::Provision.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::Provision.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -52,7 +52,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Provisioning::
-    StateMachines::UpdateServiceProvisionStatus.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::UpdateServiceProvisionStatus.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured.rb
@@ -104,6 +104,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachines::Methods::CheckReconfigured.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachines::Methods::CheckReconfigured.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/postreconfigure.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/postreconfigure.rb
@@ -54,6 +54,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachines::PostReconfigure.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachines::PostReconfigure.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
@@ -42,6 +42,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::CheckRemovedFromProvider.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::CheckRemovedFromProvider.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
@@ -32,6 +32,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::DeleteFromVmdb.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::DeleteFromVmdb.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
@@ -27,6 +27,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::FinishRetirement.new.main
-end
+ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::FinishRetirement.new.main

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname.rb
@@ -70,6 +70,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName.new.main
-end
+ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName.new.main

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Placement.class/__methods__/best_fit_amazon.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Placement.class/__methods__/best_fit_amazon.rb
@@ -81,6 +81,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::VM::Provisioning::Placement::BestFitAmazon.new.main
-end
+ManageIQ::Automate::Cloud::VM::Provisioning::Placement::BestFitAmazon.new.main

--- a/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -83,6 +83,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Cloud::VM::Retirement::Email::VmRetireExtend.new.main
-end
+ManageIQ::Automate::Cloud::VM::Retirement::Email::VmRetireExtend.new.main

--- a/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -55,7 +55,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::ConfigurationManagement::AnsibleTower::Service::
-    Provisioning::StateMachines::UpdateServiceProvisionStatus.new.main
-end
+ManageIQ::Automate::ConfigurationManagement::AnsibleTower::Service::Provisioning::StateMachines::UpdateServiceProvisionStatus.new.main

--- a/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects.rb
+++ b/content/automate/ManageIQ/Container/Openshift/Operations/Methods.class/__methods__/available_projects.rb
@@ -49,6 +49,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Container::Openshift::Operations::AvailableProjects.new.main
-end
+ManageIQ::Automate::Container::Openshift::Operations::AvailableProjects.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/Methods.class/__methods__/checkmigration.rb
@@ -52,6 +52,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Migrate::StateMachines::Checkmigration.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Migrate::StateMachines::Checkmigration.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/VMMigrate.class/__methods__/update_migration_status.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Migrate/StateMachines/VMMigrate.class/__methods__/update_migration_status.rb
@@ -57,6 +57,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Migrate::StateMachines::UpdateMigrationStatus.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Migrate::StateMachines::UpdateMigrationStatus.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Naming.class/__methods__/vmname.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Naming.class/__methods__/vmname.rb
@@ -70,6 +70,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Provisioning::Naming::VmName.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Provisioning::Naming::VmName.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -83,6 +83,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Retirement::Email::VmRetireExtend.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Retirement::Email::VmRetireExtend.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_powered_off.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_powered_off.rb
@@ -56,6 +56,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckPoweredOff.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckPoweredOff.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
@@ -54,6 +54,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckPreRetirement.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckPreRetirement.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
@@ -40,6 +40,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckRemovedFromProvider.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::CheckRemovedFromProvider.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.rb
@@ -36,6 +36,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::PreRetirement.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::PreRetirement.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/create_vm_import_request.rb
@@ -102,6 +102,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::CreateVmImportRequest.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::CreateVmImportRequest.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/install_drivers.rb
@@ -33,6 +33,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::InstallDrivers.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::InstallDrivers.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_clusters.rb
@@ -40,6 +40,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListClusters.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListClusters.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_driver_isos.rb
@@ -44,6 +44,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListDriverIsos.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListDriverIsos.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_infra_providers.rb
@@ -33,6 +33,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListInfraProviders.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListInfraProviders.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_storages.rb
@@ -45,6 +45,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListStorages.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListStorages.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_categories.rb
@@ -38,6 +38,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagCategories.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagCategories.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
@@ -44,6 +44,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/show_name.rb
@@ -27,6 +27,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::Import::ShowName.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::Import::ShowName.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/configure_vm_networks.rb
@@ -38,6 +38,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::ConfigureVmNetworks.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::ConfigureVmNetworks.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/submit_vm_import.rb
@@ -47,6 +47,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::SubmitVmImport.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::SubmitVmImport.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/StateMachines/VmImport.class/__methods__/wait_for_vm_import.rb
@@ -48,6 +48,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::WaitForVmImport.new.main
-end
+ManageIQ::Automate::Infrastructure::VM::Transform::StateMachines::WaitForVmImport.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/check_completed.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/check_completed.rb
@@ -84,6 +84,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::CheckCompleted.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::CheckCompleted.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/check_refreshed.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/check_refreshed.rb
@@ -65,6 +65,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::CheckRefreshed.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::CheckRefreshed.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/execute.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/execute.rb
@@ -58,6 +58,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Execute.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Execute.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/finish.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/finish.rb
@@ -46,6 +46,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Finish.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Finish.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/postprocess.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/postprocess.rb
@@ -58,6 +58,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::PostProcess.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::PostProcess.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/preprocess.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/preprocess.rb
@@ -67,6 +67,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::PreProcess.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::PreProcess.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/refresh.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/refresh.rb
@@ -59,6 +59,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Refresh.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Refresh.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/start.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/start.rb
@@ -46,6 +46,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Start.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::Start.new.main

--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/update_status.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/update_status.rb
@@ -84,6 +84,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::UpdateStatus.new.main
-end
+ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::UpdateStatus.new.main

--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -53,7 +53,5 @@ module ManageIQ
     end
   end
 end
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::Service::Provisioning::StateMachines::
-    ServiceProvision_Template::UpdateServiceProvisionStatus.new.main
-end
+
+ManageIQ::Automate::Service::Provisioning::StateMachines::ServiceProvision_Template::UpdateServiceProvisionStatus.new.main

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -156,6 +156,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::System::CommonMethods::MiqAe::WeightedUpdateStatus.new.main
-end
+ManageIQ::Automate::System::CommonMethods::MiqAe::WeightedUpdateStatus.new.main

--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
@@ -86,6 +86,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::System::CommonMethods::QuotaMethods::Used.new.main
-end
+ManageIQ::Automate::System::CommonMethods::QuotaMethods::Used.new.main

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status.rb
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/__methods__/update_vm_import_status.rb
@@ -49,6 +49,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::System::Event::EmsEvent::RHEVM::UpdateVmImportStatus.new.main
-end
+ManageIQ::Automate::System::Event::EmsEvent::RHEVM::UpdateVmImportStatus.new.main

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.rb
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.rb
@@ -59,6 +59,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::System::Event::StateMachines::Refresh::CheckRefreshed.new.main
-end
+ManageIQ::Automate::System::Event::StateMachines::Refresh::CheckRefreshed.new.main

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.rb
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.rb
@@ -46,6 +46,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::System::Event::StateMachines::Refresh::TargetRefresh.new.main
-end
+ManageIQ::Automate::System::Event::StateMachines::Refresh::TargetRefresh.new.main

--- a/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
@@ -86,6 +86,4 @@ module ManageIQ
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  ManageIQ::Automate::System::Request::OrderAnsiblePlaybook.new.main
-end
+ManageIQ::Automate::System::Request::OrderAnsiblePlaybook.new.main

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/checkplaybookasaservice.rb
@@ -47,6 +47,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Ansible::CheckPlaybookAsAService.new.main
-end
+ManageIQ::Automate::Transformation::Ansible::CheckPlaybookAsAService.new.main

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -40,6 +40,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService.new.main
-end
+ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService.new.main

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/acquiretransformationhost.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/acquiretransformationhost.rb
@@ -37,6 +37,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Common::AcquireTransformationHost.new.main
-end
+ManageIQ::Automate::Transformation::Common::AcquireTransformationHost.new.main

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -95,6 +95,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Common::AssessTransformation.new.main
-end
+ManageIQ::Automate::Transformation::Common::AssessTransformation.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/checkpoweredon.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/checkpoweredon.rb
@@ -36,6 +36,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::Common::CheckPoweredOn.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::Common::CheckPoweredOn.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweroff.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweroff.rb
@@ -39,6 +39,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::Common::PowerOff.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::Common::PowerOff.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
@@ -31,6 +31,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::Common::PowerOn.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::Common::PowerOn.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes.rb
@@ -82,6 +82,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkvmininventory.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/checkvmininventory.rb
@@ -36,6 +36,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::RedHat::CheckVmInInventory.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::RedHat::CheckVmInInventory.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/setdescription.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/rhevm.class/__methods__/setdescription.rb
@@ -28,6 +28,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::RedHat::SetDescription.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::RedHat::SetDescription.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/vmwarews.class/__methods__/collapsesnapshots.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/vmwarews.class/__methods__/collapsesnapshots.rb
@@ -34,6 +34,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::CollapseSnapshots.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::CollapseSnapshots.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/vmwarews.class/__methods__/setmigrated.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/vmwarews.class/__methods__/setmigrated.rb
@@ -52,6 +52,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::SetMigrated.new.main
-end
+ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::SetMigrated.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -34,6 +34,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::Common::KillVirtV2V.new.main
-end
+ManageIQ::Automate::Transformation::TransformationHost::Common::KillVirtV2V.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmchecktransformed.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmchecktransformed.rb
@@ -78,6 +78,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::Common::VMCheckTransformed.new.main
-end
+ManageIQ::Automate::Transformation::TransformationHost::Common::VMCheckTransformed.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/vmtransform.rb
@@ -53,6 +53,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::Common::VMTransform.new.main
-end
+ManageIQ::Automate::Transformation::TransformationHost::Common::VMTransform.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/rolecheck.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/rolecheck.rb
@@ -22,6 +22,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::OVirtHost::RoleCheck.new.main
-end
+ManageIQ::Automate::Transformation::TransformationHost::OVirtHost::RoleCheck.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/roledisable.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/roledisable.rb
@@ -23,6 +23,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::OVirtHost::RoleDisable.new.main
-end
+ManageIQ::Automate::Transformation::TransformationHost::OVirtHost::RoleDisable.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/roleenable.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/ovirt_host.class/__methods__/roleenable.rb
@@ -30,6 +30,4 @@ module ManageIQ
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  ManageIQ::Automate::Transformation::TransformationHost::OVirtHost::RoleEnable.new.main
-end
+ManageIQ::Automate::Transformation::TransformationHost::OVirtHost::RoleEnable.new.main

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ def require_domain_file
   spec_name = caller_locations.first.path
   file_name = spec_name.sub("spec/", "").sub("_spec.rb", ".rb")
 
-  require file_name
+  AutomateClassDefinitionHook.require_with_hook(file_name)
 end
 
 Dir[ManageIQ::AutomationEngine::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
@@ -40,3 +40,41 @@ RSpec.configure do |config|
     MiqAeDatastore.reset
   end
 end
+
+module AutomateClassDefinitionHook
+  mattr_accessor :hooking
+
+  def self.hooked
+    @hooked ||= []
+  end
+
+  def inherited(other)
+    AutomateClassDefinitionHook.hook(other)
+    super
+  end
+
+  def self.require_with_hook(file_name)
+    self.hooking = true
+    require(file_name).tap { unhook }
+  end
+
+  class TestLoadStub
+    def main
+    end
+  end
+
+  def self.hook(klass)
+    return unless hooking
+    if klass.name&.start_with?("ManageIQ::Automate::")
+      hooked << klass
+      klass.define_singleton_method(:new) { |*_args| AutomateClassDefinitionHook::TestLoadStub.new }
+    end
+  end
+
+  def self.unhook
+    hooked.delete_if { |klass| klass.singleton_class.send(:remove_method, :new) }
+    self.hooking = false
+  end
+end
+
+Object.singleton_class.prepend(AutomateClassDefinitionHook)


### PR DESCRIPTION
Backport of PR #390 - Methods back-ported from master will cause test errors on the Gaprindashvili branch due to this fundamental change.

Description from original PR:
Prevent the module from running when required by hooking the class definition and stubbing the call to .new during require. Doing this ensures that the .new calls a real class that already exists.

Unfortunately, the class name is occasionally misspelled and this code path was previously not covered. This adds test coverage for this path.