### PR TITLE
[WIP] Add support for VMware to OpenStack transformation

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -4,7 +4,7 @@ module ManageIQ
       module Common
         class AssessTransformation
           SUPPORTED_SOURCE_EMS_TYPES = %w(vmwarews).freeze
-          SUPPORTED_DESTINATION_EMS_TYPES = %w(openstack, rhevm).freeze
+          SUPPORTED_DESTINATION_EMS_TYPES = %w(openstack rhevm).freeze
 
           def initialize(handle = $evm)
             @handle = handle

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -3,8 +3,8 @@ module ManageIQ
     module Transformation
       module Common
         class AssessTransformation
-          SUPPORTED_SOURCE_EMS_TYPES = %w('vmwarews').freeze
-          SUPPORTED_DESTINATION_EMS_TYPES = %w('openstack', 'rhevm').freeze
+          SUPPORTED_SOURCE_EMS_TYPES = %w(vmwarews).freeze
+          SUPPORTED_DESTINATION_EMS_TYPES = %w(openstack, rhevm).freeze
 
           def initialize(handle = $evm)
             @handle = handle

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -3,9 +3,9 @@ module ManageIQ
     module Transformation
       module Common
         class AssessTransformation
-          SUPPORTED_SOURCE_EMS_TYPES = ['vmwarews'].freeze
-          SUPPORTED_DESTINATION_EMS_TYPES = ['openstack', 'rhevm'].freeze
-          
+          SUPPORTED_SOURCE_EMS_TYPES = %w('vmwarews').freeze
+          SUPPORTED_DESTINATION_EMS_TYPES = %w('openstack', 'rhevm').freeze
+
           def initialize(handle = $evm)
             @handle = handle
             @task = ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
@@ -74,7 +74,7 @@ module ManageIQ
           def destination_network_ref_openstack(network)
             network.ems_ref
           end
-          
+
           def transformation_type
             raise "Unsupported source EMS type: #{source_ems.emstype}." unless SUPPORTED_SOURCE_EMS_TYPES.include?(source_ems.emstype)
             raise "Unsupported destination EMS type: #{destination_ems.emstype}." unless SUPPORTED_DESTINATION_EMS_TYPES.include?(destination_ems.emstype)
@@ -88,7 +88,7 @@ module ManageIQ
               raise "No transformation plan" if plan.nil?
             end
           end
-          
+
           def destination_flavor
             return unless destination_ems.emstype == 'openstack'
             flavor_id = transformation_plan.options[:config_info]['osp_flavor']
@@ -97,7 +97,7 @@ module ManageIQ
               raise "No flavor" if flavor.nil?
             end
           end
-          
+
           def destination_security_group
             return unless destination_ems.emstype == 'openstack'
             security_group_id = transformation_plan.options[:config_info]['osp_security_group']
@@ -106,7 +106,7 @@ module ManageIQ
               raise "No security group" if sg.nil?
             end
           end
-          
+
           def populate_task_options
             @task.set_option(:source_ems_id, source_ems.id)
             @task.set_option(:destination_ems_id, destination_ems.id)

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -4,8 +4,8 @@ module ManageIQ
       module Common
         class AssessTransformation
           SUPPORTED_SOURCE_EMS_TYPES = ['vmwarews'].freeze
-          SUPPORTED_DESTINATION_EMS_TYPES = ['rhevm'].freeze
-
+          SUPPORTED_DESTINATION_EMS_TYPES = ['openstack', 'rhevm'].freeze
+          
           def initialize(handle = $evm)
             @handle = handle
             @task = ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
@@ -19,7 +19,7 @@ module ManageIQ
               raise "[#{@source_vm.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping. Aborting." if destination_network.nil?
               {
                 :source      => source_network.name,
-                :destination => destination_network.name,
+                :destination => destination_network_ref(destination_network),
                 :mac_address => nic.address
               }
             end
@@ -63,6 +63,18 @@ module ManageIQ
             end
           end
 
+          def destination_network_ref(network)
+            send("destination_network_ref_#{destination_ems.emstype}", network)
+          end
+
+          def destination_network_ref_rhevm(network)
+            network.name
+          end
+
+          def destination_network_ref_openstack(network)
+            network.ems_ref
+          end
+          
           def transformation_type
             raise "Unsupported source EMS type: #{source_ems.emstype}." unless SUPPORTED_SOURCE_EMS_TYPES.include?(source_ems.emstype)
             raise "Unsupported destination EMS type: #{destination_ems.emstype}." unless SUPPORTED_DESTINATION_EMS_TYPES.include?(destination_ems.emstype)
@@ -71,11 +83,37 @@ module ManageIQ
             "#{source_ems.emstype}2#{destination_ems.emstype}"
           end
 
+          def transformation_plan
+            @transformation_plan ||= @task.miq_request.source.tap do |plan|
+              raise "No transformation plan" if plan.nil?
+            end
+          end
+          
+          def destination_flavor
+            return unless destination_ems.emstype == 'openstack'
+            flavor_id = transformation_plan.options[:config_info]['osp_flavor']
+            raise 'No flavor id in task' if flavor_id.nil?
+            @destination_flavor ||= @handle.vmdb(:flavor).find_by(:id => flavor_id).tap do |flavor|
+              raise "No flavor" if flavor.nil?
+            end
+          end
+          
+          def destination_security_group
+            return unless destination_ems.emstype == 'openstack'
+            security_group_id = transformation_plan.options[:config_info]['osp_security_group']
+            raise 'No security group id in task' if security_group_id.nil?
+            @destination_security_group ||= @handle.vmdb(:security_group).find_by(:id => security_group_id).tap do |sg|
+              raise "No security group" if sg.nil?
+            end
+          end
+          
           def populate_task_options
             @task.set_option(:source_ems_id, source_ems.id)
             @task.set_option(:destination_ems_id, destination_ems.id)
             @task.set_option(:virtv2v_networks, virtv2v_networks)
             @task.set_option(:virtv2v_disks, virtv2v_disks)
+            @task.set_option(:destination_flavor_id, destination_flavor.id) unless destination_flavor.nil?
+            @task.set_option(:destination_security_group_id, destination_security_group.id) unless destination_security_group.nil?
             @task.set_option(:transformation_type, transformation_type)
             @task.set_option(:source_vm_power_state, @source_vm.power_state)
             @task.set_option(:collapse_snapshots, true)

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -91,7 +91,7 @@ module ManageIQ
 
           def destination_flavor
             return unless destination_ems.emstype == 'openstack'
-            flavor_id = transformation_plan.options[:config_info]['osp_flavor']
+            flavor_id = transformation_plan.options[:config_info][:osp_flavor]
             raise 'No flavor id in task' if flavor_id.nil?
             @destination_flavor ||= @handle.vmdb(:flavor).find_by(:id => flavor_id).tap do |flavor|
               raise "No flavor" if flavor.nil?
@@ -100,7 +100,7 @@ module ManageIQ
 
           def destination_security_group
             return unless destination_ems.emstype == 'openstack'
-            security_group_id = transformation_plan.options[:config_info]['osp_security_group']
+            security_group_id = transformation_plan.options[:config_info][:osp_security_group]
             raise 'No security group id in task' if security_group_id.nil?
             @destination_security_group ||= @handle.vmdb(:security_group).find_by(:id => security_group_id).tap do |sg|
               raise "No security group" if sg.nil?

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__class__.yaml
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__class__.yaml
@@ -1,0 +1,33 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: OpenStack
+    name: openstack
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: method
+      name: execute
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/setdescription.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/setdescription.rb
@@ -1,0 +1,28 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Infrastructure
+        module VM
+          module OpenStack
+            class SetDescription
+              def initialize(handle = $evm)
+                @handle = handle
+                @destination_vm = ManageIQ::Transformation::Common::Utils.destination_vm(@handle)
+              end
+
+              def main
+                description = "Migrated by Cloudforms on #{Time.now.utc}."
+                ManageIQ::Automate::Transformation::Infrastructure::VM::OpenStack::Utils.vm_set_description(destination_vm, description)
+              rescue => e
+                @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+                raise
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::Transformation::Infrastructure::VM::OpenStack::SetDescription.new.main

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/setdescription.yaml
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/setdescription.yaml
@@ -1,0 +1,16 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: SetDescription
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    embedded_methods:
+    - "/Transformation/Common/Utils"
+    - "/Transformation/Infrastructure/VM/openstack/Utils"
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/utils.rb
@@ -1,0 +1,20 @@
+#
+# Utility library for OpenStack
+#
+
+module ManageIQ
+  module Automate
+    module Transformation
+      module Infrastructure
+        module VM
+          module OpenStack
+            class Utils
+              def self.vm_set_description(vm, description)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/utils.yaml
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/__methods__/utils.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Utils
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/_missing.yaml
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/openstack.class/_missing.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: "${#_missing_instance}"

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -179,13 +179,13 @@ module ManageIQ
                 :vmware_fingerprint         => ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::Utils.host_fingerprint(source_vm.host),
                 :vmware_uri                 => vmware_uri_vddk(source_vm),
                 :vmware_password            => source_vm.host.authentication_password,
-                :osp_environment     => {
-                  :os_no_cache            => true,
-                  :os_auth_url            => openstack_auth_url(destination_ems),
-                  :os_user_domain_name    => destination_ems.uid_ems,
-                  :os_username            => destination_ems.authentication_userid,
-                  :os_password            => destination_ems.authentication_password,
-                  :os_project_name        => destination_cloud_tenant.name
+                :osp_environment            => {
+                  :os_no_cache         => true,
+                  :os_auth_url         => openstack_auth_url(destination_ems),
+                  :os_user_domain_name => destination_ems.uid_ems,
+                  :os_username         => destination_ems.authentication_userid,
+                  :os_password         => destination_ems.authentication_password,
+                  :os_project_name     => destination_cloud_tenant.name
                 },
                 :osp_destination_project_id => destination_cloud_tenant.ems_ref,
                 :osp_volume_type_id         => destination_cloud_volume_type.ems_ref,
@@ -211,15 +211,15 @@ module ManageIQ
               destination_security_group = handle.vmdb(:security_group).find_by(:id => task.get_option(:destination_security_group_id))
 
               {
-                :vm_name             => vmware_uri_ssh(source_vm, source_storage),
-                :transport_method    => 'ssh',
-                :osp_environment     => {
-                  :os_no_cache            => true,
-                  :os_auth_url            => openstack_auth_url(destination_ems),
-                  :os_user_domain_name    => destination_ems.uid_ems,
-                  :os_username            => destination_ems.authentication_userid,
-                  :os_password            => destination_ems.authentication_password,
-                  :os_project_name        => destination_cloud_tenant.name
+                :vm_name                    => vmware_uri_ssh(source_vm, source_storage),
+                :transport_method           => 'ssh',
+                :osp_environment            => {
+                  :os_no_cache         => true,
+                  :os_auth_url         => openstack_auth_url(destination_ems),
+                  :os_user_domain_name => destination_ems.uid_ems,
+                  :os_username         => destination_ems.authentication_userid,
+                  :os_password         => destination_ems.authentication_password,
+                  :os_project_name     => destination_cloud_tenant.name
                 },
                 :osp_destination_project_id => destination_cloud_tenant.ems_ref,
                 :osp_volume_type_id         => destination_cloud_volume_type.ems_ref,

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb
@@ -174,27 +174,26 @@ module ManageIQ
               destination_security_group = handle.vmdb(:security_group).find_by(:id => task.get_option(:destination_security_group_id))
 
               {
-                :vm_name             => source_vm.name,
-                :transport_method    => 'vddk',
-                :vmware_fingerprint  => ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::Utils.host_fingerprint(source_vm.host),
-                :vmware_uri          => vmware_uri_vddk(source_vm),
-                :vmware_password     => source_vm.host.authentication_password,
+                :vm_name                    => source_vm.name,
+                :transport_method           => 'vddk',
+                :vmware_fingerprint         => ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::Utils.host_fingerprint(source_vm.host),
+                :vmware_uri                 => vmware_uri_vddk(source_vm),
+                :vmware_password            => source_vm.host.authentication_password,
                 :osp_environment     => {
                   :os_no_cache            => true,
                   :os_auth_url            => openstack_auth_url(destination_ems),
                   :os_user_domain_name    => destination_ems.uid_ems,
                   :os_username            => destination_ems.authentication_userid,
                   :os_password            => destination_ems.authentication_password,
-                  :os_project_name        => destination_cloud_tenant.name,
-                  :os_project_id          => destination_cloud_tenant.ems_ref,
-                  :os_volume_type_id      => destination_cloud_volume_type.ems_ref,
-                  :os_flavor_id           => destination_flavor.ems_ref,
-                  :os_security_groups_ids => [destination_security_group.ems_ref]
+                  :os_project_name        => destination_cloud_tenant.name
                 },
-                :source_disks        => task[:options][:virtv2v_disks].map { |disk| disk[:path] },
-                :network_mappings    => task[:options][:virtv2v_networks],
-                :install_drivers     => true,
-                :insecure_connection => true
+                :osp_destination_project_id => destination_cloud_tenant.ems_ref,
+                :osp_volume_type_id         => destination_cloud_volume_type.ems_ref,
+                :osp_flavor_id              => destination_flavor.ems_ref,
+                :osp_security_groups_ids    => [destination_security_group.ems_ref],
+                :source_disks               => task[:options][:virtv2v_disks].map { |disk| disk[:path] },
+                :network_mappings           => task[:options][:virtv2v_networks],
+                :install_drivers            => true
               }
             end
             private_class_method :virtv2vwrapper_options_vmwarews2openstack_vddk
@@ -220,16 +219,15 @@ module ManageIQ
                   :os_user_domain_name    => destination_ems.uid_ems,
                   :os_username            => destination_ems.authentication_userid,
                   :os_password            => destination_ems.authentication_password,
-                  :os_project_name        => destination_cloud_tenant.name,
-                  :os_project_id          => destination_cloud_tenant.ems_ref,
-                  :os_volume_type_id      => destination_cloud_volume_type.ems_ref,
-                  :os_flavor_id           => destination_flavor.ems_ref,
-                  :os_security_groups_ids => [destination_security_group.ems_ref]
+                  :os_project_name        => destination_cloud_tenant.name
                 },
-                :source_disks        => task[:options][:virtv2v_disks].map { |disk| disk[:path] },
-                :network_mappings    => task[:options][:virtv2v_networks],
-                :install_drivers     => true,
-                :insecure_connection => true
+                :osp_destination_project_id => destination_cloud_tenant.ems_ref,
+                :osp_volume_type_id         => destination_cloud_volume_type.ems_ref,
+                :osp_flavor_id              => destination_flavor.ems_ref,
+                :osp_security_groups_ids    => [destination_security_group.ems_ref],
+                :source_disks               => task[:options][:virtv2v_disks].map { |disk| disk[:path] },
+                :network_mappings           => task[:options][:virtv2v_networks],
+                :install_drivers            => true
               }
             end
             private_class_method :virtv2vwrapper_options_vmwarews2openstack_ssh

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -66,7 +66,7 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
 
   let(:virtv2v_networks) do
     {
-      "rhevm" => [
+      "rhevm"     => [
         { :source => svc_model_src_lan_1.name, :destination => svc_model_dst_lan_1.name, :mac_address => svc_model_nic_1.address },
         { :source => svc_model_src_lan_2.name, :destination => svc_model_dst_lan_2.name, :mac_address => svc_model_nic_2.address },
       ],

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -107,7 +107,7 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
 
     allow(svc_model_task).to receive(:miq_request).and_return(svc_model_request)
     allow(svc_model_request).to receive(:source).and_return(svc_model_plan)
-    allow(svc_model_plan).to receive(:options).and_return(:config_info => { 'osp_flavor' => svc_model_dst_flavor.id, 'osp_security_group' => svc_model_dst_security_group.id })
+    allow(svc_model_plan).to receive(:options).and_return(:config_info => { :osp_flavor => svc_model_dst_flavor.id, :osp_security_group => svc_model_dst_security_group.id })
 
     allow(svc_model_src_vm).to receive(:hardware).and_return(svc_model_hardware)
     allow(disk_1).to receive(:storage).and_return(svc_model_src_storage_1)

--- a/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
@@ -361,11 +361,11 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
         :osp_environment     => {
           :os_no_cache            => true,
           :os_auth_url            => URI::Generic.build(
-                :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
-                :host   => svc_model_dst_ems_openstack.hostname,
-                :port   => svc_model_dst_ems_openstack.port,
-                :path   => svc_model_dst_ems_openstack.api_version
-              ),
+            :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
+            :host   => svc_model_dst_ems_openstack.hostname,
+            :port   => svc_model_dst_ems_openstack.port,
+            :path   => svc_model_dst_ems_openstack.api_version
+          ),
           :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
           :os_username            => svc_model_dst_ems_openstack.authentication_userid,
           :os_password            => svc_model_dst_ems_openstack.authentication_password,
@@ -390,11 +390,11 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
         :osp_environment     => {
           :os_no_cache            => true,
           :os_auth_url            => URI::Generic.build(
-                :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
-                :host   => svc_model_dst_ems_openstack.hostname,
-                :port   => svc_model_dst_ems_openstack.port,
-                :path   => svc_model_dst_ems_openstack.api_version
-              ),
+            :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
+            :host   => svc_model_dst_ems_openstack.hostname,
+            :port   => svc_model_dst_ems_openstack.port,
+            :path   => svc_model_dst_ems_openstack.api_version
+          ),
           :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
           :os_username            => svc_model_dst_ems_openstack.authentication_userid,
           :os_password            => svc_model_dst_ems_openstack.authentication_password,

--- a/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
@@ -25,6 +25,13 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
   let(:hardware) { FactoryGirl.create(:hardware) }
   let(:nic_1) { FactoryGirl.create(:guest_device_nic) }
   let(:nic_2) { FactoryGirl.create(:guest_device_nic) }
+  let(:dst_ems_openstack) { FactoryGirl.create(:ems_openstack) }
+  let(:dst_cloud_tenant) { FactoryGirl.create(:cloud_tenant) }
+  let(:dst_cloud_volume_type) { FactoryGirl.create(:cloud_volume_type) }
+  let(:dst_cloud_network_1) { FactoryGirl.create(:cloud_network) }
+  let(:dst_cloud_network_2) { FactoryGirl.create(:cloud_network) }
+  let(:dst_flavor) { FactoryGirl.create(:flavor) }
+  let(:dst_security_group) { FactoryGirl.create(:security_group) }
 
   let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
   let(:svc_model_task_1) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task_1.id) }
@@ -38,17 +45,24 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
   let(:svc_model_src_vm_vmware) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(src_vm_vmware.id) }
   let(:svc_model_src_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(src_cluster.id) }
   let(:svc_model_dst_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(dst_cluster.id) }
-  let(:svc_model_src_storage) { MiqAeMethodService::MiqAeServiceStorage.find(src_storage) }
-  let(:svc_model_dst_storage) { MiqAeMethodService::MiqAeServiceStorage.find(dst_storage) }
-  let(:svc_model_src_lan_1) { MiqAeMethodService::MiqAeServiceLan.find(src_lan_1) }
-  let(:svc_model_src_lan_2) { MiqAeMethodService::MiqAeServiceLan.find(src_lan_2) }
-  let(:svc_model_dst_lan_1) { MiqAeMethodService::MiqAeServiceLan.find(dst_lan_1) }
-  let(:svc_model_dst_lan_2) { MiqAeMethodService::MiqAeServiceLan.find(dst_lan_2) }
-  let(:svc_model_hardware) { MiqAeMethodService::MiqAeServiceHardware.find(hardware) }
-  let(:svc_model_guest_device_1) { MiqAeMethodService::MiqAeServiceGuestDevice.find(guest_device_1) }
-  let(:svc_model_guest_device_2) { MiqAeMethodService::MiqAeServiceGuestDevice.find(guest_device_2) }
-  let(:svc_model_nic_1) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_1) }
-  let(:svc_model_nic_2) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_2) }
+  let(:svc_model_src_storage) { MiqAeMethodService::MiqAeServiceStorage.find(src_storage.id) }
+  let(:svc_model_dst_storage) { MiqAeMethodService::MiqAeServiceStorage.find(dst_storage.id) }
+  let(:svc_model_src_lan_1) { MiqAeMethodService::MiqAeServiceLan.find(src_lan_1.id) }
+  let(:svc_model_src_lan_2) { MiqAeMethodService::MiqAeServiceLan.find(src_lan_2.id) }
+  let(:svc_model_dst_lan_1) { MiqAeMethodService::MiqAeServiceLan.find(dst_lan_1.id) }
+  let(:svc_model_dst_lan_2) { MiqAeMethodService::MiqAeServiceLan.find(dst_lan_2.id) }
+  let(:svc_model_hardware) { MiqAeMethodService::MiqAeServiceHardware.find(hardware.id) }
+  let(:svc_model_guest_device_1) { MiqAeMethodService::MiqAeServiceGuestDevice.find(guest_device_1.id) }
+  let(:svc_model_guest_device_2) { MiqAeMethodService::MiqAeServiceGuestDevice.find(guest_device_2.id) }
+  let(:svc_model_nic_1) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_1.id) }
+  let(:svc_model_nic_2) { MiqAeMethodService::MiqAeServiceGuestDevice.find(nic_2.id) }
+  let(:svc_model_dst_ems_openstack) { MiqAeMethodService::MiqAeServiceExtManagementSystem.find(dst_ems_openstack.id) }
+  let(:svc_model_dst_cloud_tenant) { MiqAeMethodService::MiqAeServiceCloudTenant.find(dst_cloud_tenant.id) }
+  let(:svc_model_dst_cloud_volume_type) { MiqAeMethodService::MiqAeServiceCloudVolumeType.find(dst_cloud_volume_type.id) }
+  let(:svc_model_dst_cloud_network_1) { MiqAeMethodService::MiqAeServiceCloudNetwork.find(dst_cloud_network_1.id) }
+  let(:svc_model_dst_cloud_network_2) { MiqAeMethodService::MiqAeServiceCloudNetwork.find(dst_cloud_network_2.id) }
+  let(:svc_model_dst_flavor) { MiqAeMethodService::MiqAeServiceFlavor.find(dst_flavor.id) }
+  let(:svc_model_dst_security_group) { MiqAeMethodService::MiqAeServiceSecurityGroup.find(dst_security_group.id) }
 
   let(:disk_1) { instance_double("disk", :device_name => "Hard disk 1", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm.vmdk", :size => 17_179_869_184) }
   let(:disk_2) { instance_double("disk", :device_name => "Hard disk 2", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm-2.vmdk", :size => 17_179_869_184) }
@@ -269,7 +283,7 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
 
     it "when transformation method is vddk" do
       allow(svc_model_task_1).to receive(:get_option).with(:transformation_method).and_return('vddk')
-      expect(described_class.virtv2vwrapper_options(svc_model_task_1)).to eq(
+      expect(described_class.virtv2vwrapper_options(svc_model_task_1, ae_service)).to eq(
         :vm_name             => svc_model_src_vm_vmware.name,
         :transport_method    => 'vddk',
         :vmware_fingerprint  => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
@@ -288,13 +302,108 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
 
     it "when transformation method is ssh" do
       allow(svc_model_task_1).to receive(:get_option).with(:transformation_method).and_return('ssh')
-      expect(described_class.virtv2vwrapper_options(svc_model_task_1)).to eq(
+      expect(described_class.virtv2vwrapper_options(svc_model_task_1, ae_service)).to eq(
         :vm_name             => "ssh://root@10.0.0.1/vmfs/volumes/#{svc_model_src_storage.name}/#{svc_model_src_vm_vmware.location}",
         :transport_method    => 'ssh',
         :rhv_url             => "https://#{svc_model_dst_ems_redhat.hostname}/ovirt-engine/api",
         :rhv_cluster         => svc_model_dst_cluster.name,
         :rhv_storage         => svc_model_dst_storage.name,
         :rhv_password        => 'rhv_passwd',
+        :source_disks        => [disk_1.filename, disk_2.filename],
+        :network_mappings    => virtv2v_networks,
+        :install_drivers     => true,
+        :insecure_connection => true
+      )
+    end
+  end
+
+  context "#virtv2vwrapper_options as when transformation type is vmwarews2openstack" do
+    let(:svc_vmdb_handle_flavor) { MiqAeMethodService::MiqAeServiceFlavor }
+    let(:svc_vmdb_handle_security_group) { MiqAeMethodService::MiqAeServiceSecurityGroup }
+
+    before do
+      allow(ae_service).to receive(:vmdb).with(:flavor).and_return(svc_vmdb_handle_flavor)
+      allow(svc_vmdb_handle_flavor).to receive(:find_by).with(:id => svc_model_dst_flavor.id).and_return(svc_model_dst_flavor)
+      allow(ae_service).to receive(:vmdb).with(:security_group).and_return(svc_vmdb_handle_security_group)
+      allow(svc_vmdb_handle_security_group).to receive(:find_by).with(:id => svc_model_dst_security_group.id).and_return(svc_model_dst_security_group)
+      allow(svc_model_task_1).to receive(:get_option).with(:transformation_type).and_return('vmwarews2openstack')
+      svc_model_task_1[:options][:virtv2v_disks] = virtv2v_disks
+      svc_model_task_1[:options][:virtv2v_networks] = virtv2v_networks
+      allow(svc_model_task_1).to receive(:source).and_return(svc_model_src_vm_vmware)
+      allow(svc_model_src_vm_vmware).to receive(:ems_cluster).and_return(svc_model_src_cluster)
+      allow(svc_model_task_1).to receive(:transformation_destination).with(svc_model_src_cluster).and_return(svc_model_dst_cloud_tenant)
+      allow(svc_model_dst_cloud_tenant).to receive(:ext_management_system).and_return(svc_model_dst_ems_openstack)
+      allow(svc_model_dst_ems_openstack).to receive(:authentication_password).and_return('osp_passwd')
+      allow(svc_model_src_vm_vmware).to receive(:hardware).and_return(svc_model_hardware)
+      allow(svc_model_hardware).to receive(:disks).and_return([disk_1, disk_2])
+      allow(disk_1).to receive(:storage).and_return(svc_model_src_storage)
+      allow(svc_model_task_1).to receive(:transformation_destination).with(svc_model_src_storage).and_return(svc_model_dst_cloud_volume_type)
+      allow(svc_model_hardware).to receive(:nics).and_return([svc_model_nic_1, svc_model_nic_2])
+      allow(svc_model_task_1).to receive(:transformation_destination).with(svc_model_src_lan_1).and_return(svc_model_dst_cloud_network_1)
+      allow(svc_model_task_1).to receive(:transformation_destination).with(svc_model_src_lan_2).and_return(svc_model_dst_cloud_network_2)
+      allow(svc_model_task_1).to receive(:get_option).with(:destination_flavor_id).and_return(svc_model_dst_flavor.id)
+      allow(svc_model_task_1).to receive(:get_option).with(:destination_security_group_id).and_return(svc_model_dst_security_group.id)
+      allow(svc_model_src_vm_vmware).to receive(:host).and_return(svc_model_src_host)
+      allow(svc_model_src_host).to receive(:ipaddress).and_return('10.0.0.1')
+      allow(svc_model_src_host).to receive(:authentication_userid).and_return('esx_user')
+      allow(svc_model_src_host).to receive(:authentication_password).and_return('esx_passwd')
+      allow(ManageIQ::Automate::Transformation::Infrastructure::VM::VMware::Utils).to receive(:host_fingerprint).with(svc_model_src_host).and_return('01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67')
+    end
+
+    it "when transformation method is vddk" do
+      allow(svc_model_task_1).to receive(:get_option).with(:transformation_method).and_return('vddk')
+      expect(described_class.virtv2vwrapper_options(svc_model_task_1, ae_service)).to eq(
+        :vm_name             => svc_model_src_vm_vmware.name,
+        :transport_method    => 'vddk',
+        :vmware_fingerprint  => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+        :vmware_uri          => "esx://esx_user@10.0.0.1/?no_verify=1",
+        :vmware_password     => 'esx_passwd',
+        :osp_environment     => {
+          :os_no_cache            => true,
+          :os_auth_url            => URI::Generic.build(
+                :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
+                :host   => svc_model_dst_ems_openstack.hostname,
+                :port   => svc_model_dst_ems_openstack.port,
+                :path   => svc_model_dst_ems_openstack.api_version
+              ),
+          :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
+          :os_username            => svc_model_dst_ems_openstack.authentication_userid,
+          :os_password            => svc_model_dst_ems_openstack.authentication_password,
+          :os_project_name        => svc_model_dst_cloud_tenant.name,
+          :os_project_id          => svc_model_dst_cloud_tenant.ems_ref,
+          :os_volume_type_id      => svc_model_dst_cloud_volume_type.ems_ref,
+          :os_flavor_id           => svc_model_dst_flavor.ems_ref,
+          :os_security_groups_ids => [svc_model_dst_security_group.ems_ref]
+        },
+        :source_disks        => [disk_1.filename, disk_2.filename],
+        :network_mappings    => virtv2v_networks,
+        :install_drivers     => true,
+        :insecure_connection => true
+      )
+    end
+
+    it "when transformation method is ssh" do
+      allow(svc_model_task_1).to receive(:get_option).with(:transformation_method).and_return('ssh')
+      expect(described_class.virtv2vwrapper_options(svc_model_task_1, ae_service)).to eq(
+        :vm_name             => "ssh://root@10.0.0.1/vmfs/volumes/#{svc_model_src_storage.name}/#{svc_model_src_vm_vmware.location}",
+        :transport_method    => 'ssh',
+        :osp_environment     => {
+          :os_no_cache            => true,
+          :os_auth_url            => URI::Generic.build(
+                :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
+                :host   => svc_model_dst_ems_openstack.hostname,
+                :port   => svc_model_dst_ems_openstack.port,
+                :path   => svc_model_dst_ems_openstack.api_version
+              ),
+          :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
+          :os_username            => svc_model_dst_ems_openstack.authentication_userid,
+          :os_password            => svc_model_dst_ems_openstack.authentication_password,
+          :os_project_name        => svc_model_dst_cloud_tenant.name,
+          :os_project_id          => svc_model_dst_cloud_tenant.ems_ref,
+          :os_volume_type_id      => svc_model_dst_cloud_volume_type.ems_ref,
+          :os_flavor_id           => svc_model_dst_flavor.ems_ref,
+          :os_security_groups_ids => [svc_model_dst_security_group.ems_ref]
+        },
         :source_disks        => [disk_1.filename, disk_2.filename],
         :network_mappings    => virtv2v_networks,
         :install_drivers     => true,

--- a/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
@@ -353,12 +353,12 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
     it "when transformation method is vddk" do
       allow(svc_model_task_1).to receive(:get_option).with(:transformation_method).and_return('vddk')
       expect(described_class.virtv2vwrapper_options(svc_model_task_1, ae_service)).to eq(
-        :vm_name             => svc_model_src_vm_vmware.name,
-        :transport_method    => 'vddk',
-        :vmware_fingerprint  => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
-        :vmware_uri          => "esx://esx_user@10.0.0.1/?no_verify=1",
-        :vmware_password     => 'esx_passwd',
-        :osp_environment     => {
+        :vm_name                    => svc_model_src_vm_vmware.name,
+        :transport_method           => 'vddk',
+        :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+        :vmware_uri                 => "esx://esx_user@10.0.0.1/?no_verify=1",
+        :vmware_password            => 'esx_passwd',
+        :osp_environment            => {
           :os_no_cache            => true,
           :os_auth_url            => URI::Generic.build(
             :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
@@ -369,25 +369,24 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
           :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
           :os_username            => svc_model_dst_ems_openstack.authentication_userid,
           :os_password            => svc_model_dst_ems_openstack.authentication_password,
-          :os_project_name        => svc_model_dst_cloud_tenant.name,
-          :os_project_id          => svc_model_dst_cloud_tenant.ems_ref,
-          :os_volume_type_id      => svc_model_dst_cloud_volume_type.ems_ref,
-          :os_flavor_id           => svc_model_dst_flavor.ems_ref,
-          :os_security_groups_ids => [svc_model_dst_security_group.ems_ref]
+          :os_project_name        => svc_model_dst_cloud_tenant.name
         },
-        :source_disks        => [disk_1.filename, disk_2.filename],
-        :network_mappings    => virtv2v_networks,
-        :install_drivers     => true,
-        :insecure_connection => true
+        :osp_destination_project_id => svc_model_dst_cloud_tenant.ems_ref,
+        :osp_volume_type_id         => svc_model_dst_cloud_volume_type.ems_ref,
+        :osp_flavor_id              => svc_model_dst_flavor.ems_ref,
+        :osp_security_groups_ids    => [svc_model_dst_security_group.ems_ref],
+        :source_disks               => [disk_1.filename, disk_2.filename],
+        :network_mappings           => virtv2v_networks,
+        :install_drivers            => true
       )
     end
 
     it "when transformation method is ssh" do
       allow(svc_model_task_1).to receive(:get_option).with(:transformation_method).and_return('ssh')
       expect(described_class.virtv2vwrapper_options(svc_model_task_1, ae_service)).to eq(
-        :vm_name             => "ssh://root@10.0.0.1/vmfs/volumes/#{svc_model_src_storage.name}/#{svc_model_src_vm_vmware.location}",
-        :transport_method    => 'ssh',
-        :osp_environment     => {
+        :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/#{svc_model_src_storage.name}/#{svc_model_src_vm_vmware.location}",
+        :transport_method           => 'ssh',
+        :osp_environment            => {
           :os_no_cache            => true,
           :os_auth_url            => URI::Generic.build(
             :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
@@ -398,16 +397,15 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
           :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
           :os_username            => svc_model_dst_ems_openstack.authentication_userid,
           :os_password            => svc_model_dst_ems_openstack.authentication_password,
-          :os_project_name        => svc_model_dst_cloud_tenant.name,
-          :os_project_id          => svc_model_dst_cloud_tenant.ems_ref,
-          :os_volume_type_id      => svc_model_dst_cloud_volume_type.ems_ref,
-          :os_flavor_id           => svc_model_dst_flavor.ems_ref,
-          :os_security_groups_ids => [svc_model_dst_security_group.ems_ref]
+          :os_project_name        => svc_model_dst_cloud_tenant.name
         },
-        :source_disks        => [disk_1.filename, disk_2.filename],
-        :network_mappings    => virtv2v_networks,
-        :install_drivers     => true,
-        :insecure_connection => true
+        :osp_destination_project_id => svc_model_dst_cloud_tenant.ems_ref,
+        :osp_volume_type_id         => svc_model_dst_cloud_volume_type.ems_ref,
+        :osp_flavor_id              => svc_model_dst_flavor.ems_ref,
+        :osp_security_groups_ids    => [svc_model_dst_security_group.ems_ref],
+        :source_disks               => [disk_1.filename, disk_2.filename],
+        :network_mappings           => virtv2v_networks,
+        :install_drivers            => true
       )
     end
   end

--- a/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils_spec.rb
@@ -359,17 +359,17 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
         :vmware_uri                 => "esx://esx_user@10.0.0.1/?no_verify=1",
         :vmware_password            => 'esx_passwd',
         :osp_environment            => {
-          :os_no_cache            => true,
-          :os_auth_url            => URI::Generic.build(
+          :os_no_cache         => true,
+          :os_auth_url         => URI::Generic.build(
             :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
             :host   => svc_model_dst_ems_openstack.hostname,
             :port   => svc_model_dst_ems_openstack.port,
             :path   => svc_model_dst_ems_openstack.api_version
           ),
-          :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
-          :os_username            => svc_model_dst_ems_openstack.authentication_userid,
-          :os_password            => svc_model_dst_ems_openstack.authentication_password,
-          :os_project_name        => svc_model_dst_cloud_tenant.name
+          :os_user_domain_name => svc_model_dst_ems_openstack.uid_ems,
+          :os_username         => svc_model_dst_ems_openstack.authentication_userid,
+          :os_password         => svc_model_dst_ems_openstack.authentication_password,
+          :os_project_name     => svc_model_dst_cloud_tenant.name
         },
         :osp_destination_project_id => svc_model_dst_cloud_tenant.ems_ref,
         :osp_volume_type_id         => svc_model_dst_cloud_volume_type.ems_ref,
@@ -387,17 +387,17 @@ describe ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils 
         :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/#{svc_model_src_storage.name}/#{svc_model_src_vm_vmware.location}",
         :transport_method           => 'ssh',
         :osp_environment            => {
-          :os_no_cache            => true,
-          :os_auth_url            => URI::Generic.build(
+          :os_no_cache         => true,
+          :os_auth_url         => URI::Generic.build(
             :scheme => svc_model_dst_ems_openstack.security_protocol == 'non-ssl' ? 'http' : 'https',
             :host   => svc_model_dst_ems_openstack.hostname,
             :port   => svc_model_dst_ems_openstack.port,
             :path   => svc_model_dst_ems_openstack.api_version
           ),
-          :os_user_domain_name    => svc_model_dst_ems_openstack.uid_ems,
-          :os_username            => svc_model_dst_ems_openstack.authentication_userid,
-          :os_password            => svc_model_dst_ems_openstack.authentication_password,
-          :os_project_name        => svc_model_dst_cloud_tenant.name
+          :os_user_domain_name => svc_model_dst_ems_openstack.uid_ems,
+          :os_username         => svc_model_dst_ems_openstack.authentication_userid,
+          :os_password         => svc_model_dst_ems_openstack.authentication_password,
+          :os_project_name     => svc_model_dst_cloud_tenant.name
         },
         :osp_destination_project_id => svc_model_dst_cloud_tenant.ems_ref,
         :osp_volume_type_id         => svc_model_dst_cloud_volume_type.ems_ref,


### PR DESCRIPTION
This pull request add support for OpenStack target in transformation. To keep the PR small, some refactoring has been deferred. For example, Infrastructure/VM should be moved to VM, as transformations to Infrastructure or Cloud are very similar. Keeping that separation complexifies the code with no value. Thus, the OpenStack-related code is under Infrastructure/VM/OpenStack.

Some additional data checks are performed in assessment:

- Flavor and security group are collected from Transformation Plan.
- Networks identification has been split, as RHV networks are called by name, while OpenStack's are called by ems_ref, aka UUID.

The only real new method for OpenStack is SetDescription which is simply declared but does nothing (hence no specs provided), until we know how to do it properly (fog based).

The Transformation Hosts utility class welcomes two new methods that build the options hash for virt-v2v-wrapper, either for VDDK, or for SSH.

Depends on:

- [ManageIQ/manageiq-content#421](https://github.com/ManageIQ/manageiq-content/pull/421) (rebase needed)
- [ManageIQ/manageiq#18033](https://github.com/ManageIQ/manageiq/pull/18033)
- [ManageIQ/manageiq#18064](https://github.com/ManageIQ/manageiq/pull/18064)

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1632355