### PR TITLE
[WIP] Allow OrchestrationStack retirement to be triggered from Service

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin.rb
@@ -1,0 +1,47 @@
+#
+# Description: common methods needed when working with OrchestrationStacks.
+#
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Lifecycle
+          module OrchestrationMixin
+            def get_stack(handle)
+              return unless handle
+              stack = get_stack_from(handle, :object) || get_stack_from(handle, :root) || get_service(handle).try(:orchestration_stack)
+              handle.log(:info, 'Could not find related stack') unless stack
+              stack
+            end
+
+            def get_service(handle)
+              return unless handle
+              if (service = handle.object['service'])
+                handle.log(:info, "Fetched service from $evm.object['service']")
+                service
+              elsif (service = handle.root['service'])
+                handle.log(:info, "Fetched service from $evm.root['service']")
+                service
+              else
+                handle.log(:info, 'Could not find related service')
+                nil
+              end
+            end
+
+            def get_stack_from(handle, object_name)
+              return unless handle && (object = handle.try(object_name))
+              if (stack = object['orchestration_stack'])
+                handle.log(:info, "Fetched stack from $evm.#{object_name}['orchestration_stack']")
+                stack
+              elsif (stack_id = object['orchestration_stack_id'].to_i) && stack_id != 0 &&
+                    (stack = handle.vmdb('orchestration_stack', stack_id))
+                handle.log(:info, "Fetched stack from $evm.#{object_name}['orchestration_stack_id']")
+                stack
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/content/automate/ManageIQ/Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: orchestration_mixin
+    display_name:
+    description:
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/Email.class/__methods__/stack_retirement_emails.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/Email.class/__methods__/stack_retirement_emails.rb
@@ -11,87 +11,97 @@
 #    requester replies to the email
 # 3. signature - used to stamp the email with a custom signature
 #
-$evm.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
-stack = $evm.object['orchestration_stack']
-if stack.nil?
-  stack_id = $evm.object['orchestration_stack_id'].to_i
-  stack = $evm.vmdb('orchestration_stack', stack_id) unless stack_id == 0
-end
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Retirement
+          module StateMachines
+            module Methods
+              class StackRetirementEmails
+                include ManageIQ::Automate::Cloud::Orchestration::Lifecycle::OrchestrationMixin
 
-if stack.nil?
-  stack = $evm.root['orchestration_stack']
-  if stack.nil?
-    stack_id = $evm.root['orchestration_stack_id'].to_i
-    stack = $evm.vmdb('orchestration_stack', stack_id) unless stack_id == 0
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
+
+                def main
+                  @handle.log("warn", "[DEPRECATION] This method will be deprecated. Please use similarly named method from System/Notification/Email class.")
+                  stack = get_stack(@handle)
+
+                  raise "Stack not specified" if stack.nil?
+
+                  stack_name = stack['name']
+
+                  event_type = @handle.object['event'] || @handle.root['event_type']
+
+                  evm_owner_id = stack.attributes['evm_owner_id']
+                  owner = nil
+                  owner = @handle.vmdb('user', evm_owner_id) unless evm_owner_id.nil?
+
+                  to = owner ? owner.email : @handle.object['to_email_address']
+
+                  if event_type == "stack_retire_warn"
+
+                    from = nil
+                    from ||= @handle.object['from_email_address']
+
+                    signature = nil
+                    signature ||= @handle.object['signature']
+
+                    subject = "Stack Retirement Warning for #{stack_name}"
+
+                    body = "Hello, "
+                    body += "<br><br>Your stack: [#{stack_name}] will be retired on [#{stack['retires_on']}]."
+                    body += "<br><br>If you need to use this stack past this date please request an"
+                    body += "<br><br>extension by contacting Support."
+                    body += "<br><br> Thank you,"
+                    body += "<br> #{signature}"
+                  end
+
+                  if event_type == "stack_entered_retirement"
+
+                    from = nil
+                    from ||= @handle.object['from_email_address']
+
+                    signature = nil
+                    signature ||= @handle.object['signature']
+
+                    subject = "Stack #{stack_name} has entered retirement"
+
+                    body = "Hello, "
+                    body += "<br><br>Your stack named [#{stack_name}] has been retired."
+                    body += "<br><br>You will have up to 3 days to un-retire this stack. Afterwhich time the stack will be deleted."
+                    body += "<br><br> Thank you,"
+                    body += "<br> #{signature}"
+                  end
+
+                  if event_type == "stack_retired"
+
+                    from = nil
+                    from ||= @handle.object['from_email_address']
+
+                    signature = nil
+                    signature ||= @handle.object['signature']
+
+                    subject = "Stack Retirement Alert for #{stack_name}"
+
+                    body = "Hello, "
+                    body += "<br><br>Your stack named [#{stack_name}] has been retired."
+                    body += "<br><br> Thank you,"
+                    body += "<br> #{signature}"
+                  end
+
+                  @handle.log("info", "Sending email to <#{to}> from <#{from}> subject: <#{subject}>") if @debug
+                  @handle.execute('send_email', to, from, subject, body)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end
 
-raise "Stack not specified" if stack.nil?
-
-stack_name = stack['name']
-
-event_type = $evm.object['event'] || $evm.root['event_type']
-
-evm_owner_id = stack.attributes['evm_owner_id']
-owner = nil
-owner = $evm.vmdb('user', evm_owner_id) unless evm_owner_id.nil?
-
-if owner
-  to = owner.email
-else
-  to = $evm.object['to_email_address']
-end
-
-if event_type == "stack_retire_warn"
-
-  from = nil
-  from ||= $evm.object['from_email_address']
-
-  signature = nil
-  signature ||= $evm.object['signature']
-
-  subject = "Stack Retirement Warning for #{stack_name}"
-
-  body = "Hello, "
-  body += "<br><br>Your stack: [#{stack_name}] will be retired on [#{stack['retires_on']}]."
-  body += "<br><br>If you need to use this stack past this date please request an"
-  body += "<br><br>extension by contacting Support."
-  body += "<br><br> Thank you,"
-  body += "<br> #{signature}"
-end
-
-if event_type == "stack_entered_retirement"
-
-  from = nil
-  from ||= $evm.object['from_email_address']
-
-  signature = nil
-  signature ||= $evm.object['signature']
-
-  subject = "Stack #{stack_name} has entered retirement"
-
-  body = "Hello, "
-  body += "<br><br>Your stack named [#{stack_name}] has been retired."
-  body += "<br><br>You will have up to 3 days to un-retire this stack. Afterwhich time the stack will be deleted."
-  body += "<br><br> Thank you,"
-  body += "<br> #{signature}"
-end
-
-if event_type == "stack_retired"
-
-  from = nil
-  from ||= $evm.object['from_email_address']
-
-  signature = nil
-  signature ||= $evm.object['signature']
-
-  subject = "Stack Retirement Alert for #{stack_name}"
-
-  body = "Hello, "
-  body += "<br><br>Your stack named [#{stack_name}] has been retired."
-  body += "<br><br> Thank you,"
-  body += "<br> #{signature}"
-end
-
-$evm.log("info", "Sending email to <#{to}> from <#{from}> subject: <#{subject}>") if @debug
-$evm.execute('send_email', to, from, subject, body)
+ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::StackRetirementEmails.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/Email.class/__methods__/stack_retirement_emails.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/Email.class/__methods__/stack_retirement_emails.yaml
@@ -9,4 +9,6 @@ object:
     scope: instance
     language: ruby
     location: inline
+    embedded_methods:
+    - "/ManageIQ/Cloud/Orchestration/Lifecycle/orchestration_mixin"
   inputs: []

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.rb
@@ -9,6 +9,7 @@ module ManageIQ
           module StateMachines
             module Methods
               class CheckRemovedFromProvider
+                include ManageIQ::Automate::Cloud::Orchestration::Lifecycle::OrchestrationMixin
 
                 def initialize(handle = $evm)
                   @handle = handle
@@ -16,9 +17,8 @@ module ManageIQ
 
                 def main
                   @handle.root['ae_result'] = 'ok'
-                  stack = @handle.root['orchestration_stack']
 
-                  if stack && @handle.get_state_var('stack_exists_in_provider')
+                  if (stack = get_stack(@handle)) && @handle.get_state_var('stack_exists_in_provider')
                     begin
                       status, _reason = stack.normalized_live_status
                       if status == 'not_exist' || status == 'delete_complete'

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider.yaml
@@ -9,4 +9,6 @@ object:
     scope: instance
     language: ruby
     location: inline
+    embedded_methods:
+    - "/ManageIQ/Cloud/Orchestration/Lifecycle/orchestration_mixin"
   inputs: []

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
@@ -9,14 +9,18 @@ module ManageIQ
           module StateMachines
             module Methods
               class FinishRetirement
+                include ManageIQ::Automate::Cloud::Orchestration::Lifecycle::OrchestrationMixin
+
                 def initialize(handle = $evm)
                   @handle = handle
                 end
 
                 def main
-                  stack = @handle.root['orchestration_stack']
-                  stack.finish_retirement if stack
-                  @handle.create_notification(:type => :orchestration_stack_retired, :subject => stack) if stack
+                  if (stack = get_stack(@handle))
+                    stack.finish_retirement
+                    @handle.create_notification(:type => :orchestration_stack_retired, :subject => stack)
+                  end
+                  get_service(@handle).try(:finish_retirement)
                 end
               end
             end

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.yaml
@@ -9,4 +9,6 @@ object:
     scope: instance
     language: ruby
     location: inline
+    embedded_methods:
+    - "/ManageIQ/Cloud/Orchestration/Lifecycle/orchestration_mixin"
   inputs: []

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -1,18 +1,40 @@
 #
 # Description: This method removes the stack from the provider
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Retirement
+          module StateMachines
+            module Methods
+              class RemoveFromProviders
+                include ManageIQ::Automate::Cloud::Orchestration::Lifecycle::OrchestrationMixin
 
-# Get stack from root object
-stack = $evm.root['orchestration_stack']
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-if stack
-  ems = stack.ext_management_system
-  if stack.raw_exists?
-    $evm.log('info', "Removing stack:<#{stack.name}> from provider:<#{ems.try(:name)}>")
-    stack.raw_delete_stack
-    $evm.set_state_var('stack_exists_in_provider', true)
-  else
-    $evm.log('info', "Stack <#{stack.name}> no longer exists in provider:<#{ems.try(:name)}>")
-    $evm.set_state_var('stack_exists_in_provider', false)
+                def main
+                  if (stack = get_stack(@handle))
+                    ems = stack.ext_management_system
+                    if stack.raw_exists?
+                      @handle.log('info', "Removing stack:<#{stack.name}> from provider:<#{ems.try(:name)}>")
+                      stack.raw_delete_stack
+                      @handle.set_state_var('stack_exists_in_provider', true)
+                    else
+                      @handle.log('info', "Stack <#{stack.name}> no longer exists in provider:<#{ems.try(:name)}>")
+                      @handle.set_state_var('stack_exists_in_provider', false)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end
+
+ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::RemoveFromProviders.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.yaml
@@ -9,4 +9,6 @@ object:
     scope: instance
     language: ruby
     location: inline
+    embedded_methods:
+    - "/ManageIQ/Cloud/Orchestration/Lifecycle/orchestration_mixin"
   inputs: []

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -1,28 +1,51 @@
 #
 # Description: This method sets the retirement_state to retiring
 #
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Retirement
+          module StateMachines
+            module Methods
+              class StartRetirement
+                include ManageIQ::Automate::Cloud::Orchestration::Lifecycle::OrchestrationMixin
 
-$evm.log("info", "Listing Root Object Attributes:")
-$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
-$evm.log("info", "===========================================")
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-stack = $evm.root['orchestration_stack']
-if stack.nil?
-  $evm.log('error', "OrchestrationStack Object not found")
-  exit MIQ_ABORT
+                def main
+                  stack = get_stack(@handle)
+
+                  if stack.nil?
+                    @handle.log('error', "OrchestrationStack Object not found")
+                    exit MIQ_ABORT
+                  end
+
+                  if stack.retired?
+                    @handle.log('error', "Stack is already retired. Aborting current State Machine.")
+                    exit MIQ_ABORT
+                  end
+
+                  if stack.retiring?
+                    @handle.log('error', "Stack is in the process of being retired. Aborting current State Machine.")
+                    exit MIQ_ABORT
+                  end
+
+                  @handle.log('info', "Stack before start_retirement: #{stack.inspect} ")
+                  @handle.create_notification(:type => :vm_retiring, :subject => stack)
+
+                  stack.start_retirement
+                  get_service(@handle).try(:start_retirement)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end
 
-if stack.retired?
-  $evm.log('error', "Stack is already retired. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
-if stack.retiring?
-  $evm.log('error', "Stack is in the process of being retired. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
-$evm.log('info', "Stack before start_retirement: #{stack.inspect} ")
-$evm.create_notification(:type => :vm_retiring, :subject => stack)
-
-stack.start_retirement
+ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::StartRetirement.new.main

--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.yaml
@@ -9,4 +9,6 @@ object:
     scope: instance
     language: ruby
     location: inline
+    embedded_methods:
+    - "/ManageIQ/Cloud/Orchestration/Lifecycle/orchestration_mixin"
   inputs: []

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin_spec.rb
@@ -1,0 +1,94 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::Orchestration::Lifecycle::OrchestrationMixin do
+  let(:root)        { {} }
+  let(:object)      { {} }
+  let(:stack_by_id) { nil }
+  let(:handle) do
+    handle = double('handle', :root => root, :object => object)
+    allow(handle).to receive(:log)
+    allow(handle).to receive(:vmdb).and_return(stack_by_id)
+    handle
+  end
+
+  # Annonymous class where we include the module in order to test module functions.
+  subject { Class.new { include ManageIQ::Automate::Cloud::Orchestration::Lifecycle::OrchestrationMixin }.new }
+
+  describe '#get_stack' do
+    it('stack not found') { assert_not_stack }
+
+    describe 'from $evm.object' do
+      context '$evm.object["orchestration_stack"]' do
+        let(:object) { { 'orchestration_stack' => 'STACK' } }
+        it { assert_stack }
+      end
+
+      describe '$evm.object["orchestration_stack_id"]' do
+        let(:object) { { 'orchestration_stack_id' => 123 } }
+        it 'when stack by id not found' do
+          assert_not_stack
+        end
+
+        context 'when stack by id is found' do
+          let(:stack_by_id) { 'STACK' }
+          before            { FactoryGirl.create(:orchestration_stack_cloud, :id => 123) }
+          it { assert_stack }
+        end
+      end
+    end
+
+    describe 'from $evm.root' do
+      context '$evm.root["orchestration_stack"]' do
+        let(:root) { { 'orchestration_stack' => 'STACK' } }
+        it         { assert_stack }
+      end
+
+      describe '$evm.root["orchestration_stack_id"]' do
+        let(:root) { { 'orchestration_stack_id' => 123 } }
+        it('when stack by id not found') { assert_not_stack }
+
+        context 'when stack by id is found' do
+          let(:stack_by_id) { 'STACK' }
+          before            { FactoryGirl.create(:orchestration_stack_cloud, :id => 123) }
+          it                { assert_stack }
+        end
+      end
+
+      context 'stack from $evm.root["service"].orchestration_stack' do
+        let(:service) { double('service', :orchestration_stack => 'STACK') }
+        let(:root)    { { 'service' => service } }
+        it            { assert_stack }
+      end
+    end
+
+    def assert_stack
+      expect(subject.get_stack(handle)).to eq('STACK')
+    end
+
+    def assert_not_stack
+      expect(subject.get_stack(handle)).to be_nil
+    end
+  end
+
+  describe '#get_service' do
+    it('service not found') { assert_not_service }
+
+    context('from $evm.object') do
+      let(:object) { { 'service' => 'SERVICE' } }
+      it { assert_service }
+    end
+
+    context('from $evm.root') do
+      let(:root) { { 'service' => 'SERVICE' } }
+      it { assert_service }
+    end
+
+    def assert_service
+      expect(subject.get_service(handle)).to eq('SERVICE')
+    end
+
+    def assert_not_service
+      expect(subject.get_service(handle)).to be_nil
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/check_removed_from_provider_spec.rb
@@ -1,3 +1,4 @@
+require_default_domain_file('Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin.rb')
 require_domain_file
 
 describe ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::CheckRemovedFromProvider do

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/finish_retirement_spec.rb
@@ -1,3 +1,4 @@
+require_default_domain_file('Cloud/Orchestration/Lifecycle.class/__methods__/orchestration_mixin.rb')
 require_domain_file
 
 describe ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::FinishRetirement do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,10 @@ def require_domain_file
   AutomateClassDefinitionHook.require_with_hook(file_name)
 end
 
+def require_default_domain_file(path)
+  require ManageIQ::Content::Engine.root.join('content/automate/ManageIQ').join(path)
+end
+
 def domain_file
   caller_locations(1..1).first.path.sub("spec/", "").sub("_spec.rb", ".rb")
 end


### PR DESCRIPTION
Current stack retirement automation assumes being triggered on stack directly, but we want to be able to use the entrypoint

```
/Cloud/Orchestration/Retirement/StateMachines/StackRetirement/Default
```

from the service that handles stack as well. With this commit we therefore adjust existing stack retirement workflow to accept stack passed either as

```
$evm.root['orchestration_stack']
```

or as

```
$evm.root['service'].orchestration_stack
```

In latter case we also make sure that Service status gets properly updated (so that the service is then moved to "Retired Services" directory).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1632239

@miq-bot add_label enhancement,gaprindashvili/yes,hammer/yes
@miq-bot assign @tinaafitz

/cc @d-m-u @agrare

Related PRs:
- https://github.com/ManageIQ/manageiq/pull/18023
- https://github.com/ManageIQ/manageiq-providers-vmware/pull/324