### PR TITLE
Fix virt-v2v kill

### DIFF
--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -1,28 +1,38 @@
 module ManageIQ
   module Automate
     module Transformation
-      module TransformationHost
+      module TransformationHosts
         module Common
           class KillVirtV2V
             def initialize(handle = $evm)
               @handle = handle
+              @task = ManageIQ::Automate::Transformation::Common::Utils.task(@handle)
             end
 
-            def task_virtv2v_state(task, transformation_host)
+            def task_virtv2v_state(transformation_host)
               require 'json'
-              return if task.get_option(:virtv2v_started_on).blank? || task.get_option(:virtv2v_finished_on).present?
-              return if task.get_option(:virtv2v_wrapper).blank?
-              result = Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "cat '#{task.get_option(:virtv2v_wrapper)['state_file']}'")
+              return if @task.get_option(:virtv2v_started_on).blank? || @task.get_option(:virtv2v_finished_on).present?
+              return if @task.get_option(:virtv2v_wrapper).blank?
+              result = ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.remote_command(@task, transformation_host, "cat '#{@task.get_option(:virtv2v_wrapper)['state_file']}'")
               return if !result[:success] || result[:stdout].empty?
               JSON.parse(result[:stdout])
             end
 
+            def kill_virtv2v(transformation_host, pid)
+              signal = 'KILL'
+              unless @handle.get_state_var('virtv2v_graceful_kill')
+                signal = 'TERM'
+                @handle.set_state_var('virtv2v_graceful_kill', true)
+                @handle.root['ae_result'] = 'retry'
+                @handle.root['ae_retry_interval'] = '30.seconds'
+              end
+              ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.remote_command(@task, transformation_host, "kill -s #{signal} #{pid}")
+            end
+
             def main
-              task = @handle.vmdb(:service_template_transformation_plan_task).find_by(:id => @handle.root['service_template_transformation_plan_task_id'])
-              transformation_host = @handle.vmdb(:host).find_by(:id => task.get_option(:transformation_host_id))
-              virtv2v_state = task_virtv2v_state(task, transformation_host)
-              @handle.log(:info, "VirtV2V State: #{virtv2v_state.inspect}")
-              Transformation::TransformationHosts::Common::Utils.remote_command(task, transformation_host, "kill -9 #{virtv2v_state['pid']}") if virtv2v_state.present?
+              transformation_host = @handle.vmdb(:host).find_by(:id => @task.get_option(:transformation_host_id))
+              virtv2v_state = task_virtv2v_state(transformation_host)
+              kill_virtv2v(transformation_host, virtv2v_state['pid']) if virtv2v_state.present?
             rescue => e
               @handle.set_state_var(:ae_state_progress, 'message' => e.message)
               raise
@@ -34,4 +44,4 @@ module ManageIQ
   end
 end
 
-ManageIQ::Automate::Transformation::TransformationHost::Common::KillVirtV2V.new.main
+ManageIQ::Automate::Transformation::TransformationHosts::Common::KillVirtV2V.new.main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.rb
@@ -18,15 +18,19 @@ module ManageIQ
               JSON.parse(result[:stdout])
             end
 
-            def kill_virtv2v(transformation_host, pid)
-              signal = 'KILL'
-              unless @handle.get_state_var('virtv2v_graceful_kill')
-                signal = 'TERM'
+            def kill_signal
+              if @handle.get_state_var('virtv2v_graceful_kill')
+                'KILL'
+              else
                 @handle.set_state_var('virtv2v_graceful_kill', true)
                 @handle.root['ae_result'] = 'retry'
                 @handle.root['ae_retry_interval'] = '30.seconds'
+                'TERM'
               end
-              ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.remote_command(@task, transformation_host, "kill -s #{signal} #{pid}")
+            end
+
+            def kill_virtv2v(transformation_host, pid)
+              ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils.remote_command(@task, transformation_host, "kill -s #{kill_signal} #{pid}")
             end
 
             def main

--- a/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.yaml
+++ b/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v.yaml
@@ -10,6 +10,7 @@ object:
     language: ruby
     location: inline
     embedded_methods:
+    - "/Transformation/Common/Utils"
     - "/Transformation/TransformationHosts/Common/Utils"
     - "/Transformation/TransformationHosts/ovirt_host/Utils"
     options: {}

--- a/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/killvirtv2v_spec.rb
@@ -1,0 +1,126 @@
+require_domain_file
+require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb')
+require File.join(ManageIQ::Content::Engine.root, 'content/automate/ManageIQ/Transformation/TransformationHosts/Common.class/__methods__/utils.rb')
+
+describe ManageIQ::Automate::Transformation::TransformationHosts::Common::KillVirtV2V do
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:host) { FactoryGirl.create(:host) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }
+  let(:svc_model_host) { MiqAeMethodService::MiqAeServiceHost.find(host.id) }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current'             => current_object,
+      'user'                => svc_model_user,
+      'state_machine_phase' => 'cleanup'
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root
+      service.object = current_object
+    end
+  end
+
+  let(:svc_vmdb_handle_host) { MiqAeMethodService::MiqAeServiceHost }
+
+  before do
+    allow(ManageIQ::Automate::Transformation::Common::Utils).to receive(:task).with(ae_service).and_return(svc_model_task)
+    allow(svc_model_task).to receive(:get_option).with(:transformation_host_id).and_return(svc_model_host.id)
+
+    allow(ae_service).to receive(:vmdb).with(:host).and_return(svc_vmdb_handle_host)
+    allow(svc_vmdb_handle_host).to receive(:find_by).with(:id => svc_model_host.id).and_return(svc_model_host)
+  end
+
+  before(:each) do
+    ManageIQ::Automate::Transformation::TransformationHosts::Common::KillVirtV2V.instance_variable_set(:@task, nil)
+  end
+
+  context "#task_virtv2v_state" do
+    it "when virtv2v not started" do
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_started_on).and_return(nil)
+      expect(described_class.new(ae_service).task_virtv2v_state(svc_model_host)).to be_nil
+    end
+
+    it "when virtv2v is finished" do
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_started_on).and_return(Time.now.utc - 1)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_finished_on).and_return(Time.now.utc)
+      expect(described_class.new(ae_service).task_virtv2v_state(svc_model_host)).to be_nil
+    end
+
+    it "when virtv2v-wrapper has failed" do
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_started_on).and_return(Time.now.utc - 1)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_finished_on).and_return(nil)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_wrapper).and_return(nil)
+      expect(described_class.new(ae_service).task_virtv2v_state(svc_model_host)).to be_nil
+    end
+
+    it "when remote command fails" do
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_started_on).and_return(Time.now.utc - 1)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_finished_on).and_return(nil)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_wrapper).and_return('state_file' => '/tmp/fake_state_file.state')
+      allow(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:remote_command).with(svc_model_task, svc_model_host, "cat '/tmp/fake_state_file.state'").and_return(:success => false, :stdout => 'No such file or directory')
+      expect(described_class.new(ae_service).task_virtv2v_state(svc_model_host)).to be_nil
+    end
+
+    it "when state file is empty" do
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_started_on).and_return(Time.now.utc - 1)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_finished_on).and_return(nil)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_wrapper).and_return('state_file' => '/tmp/fake_state_file.state')
+      allow(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:remote_command).with(svc_model_task, svc_model_host, "cat '/tmp/fake_state_file.state'").and_return(:success => true, :stdout => '')
+      expect(described_class.new(ae_service).task_virtv2v_state(svc_model_host)).to be_nil
+    end
+
+    it "when state file is ok" do
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_started_on).and_return(Time.now.utc - 1)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_finished_on).and_return(nil)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_wrapper).and_return('state_file' => '/tmp/fake_state_file.state')
+      allow(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:remote_command).with(svc_model_task, svc_model_host, "cat '/tmp/fake_state_file.state'").and_return(:success => true, :stdout => '{ "pid": "1234" }')
+      expect(described_class.new(ae_service).task_virtv2v_state(svc_model_host)).to eq('pid' => '1234')
+    end
+  end
+
+  context "#kill_virtv2v" do
+    it "when virtv2v has not received SIGTERM" do
+      allow(ae_service).to receive(:get_state_var).with('virtv2v_graceful_kill').and_return(nil)
+      expect(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:remote_command).with(svc_model_task, svc_model_host, 'kill -s TERM 1234')
+      described_class.new(ae_service).kill_virtv2v(svc_model_host, '1234')
+      expect(ae_service.root['ae_result']).to eq('retry')
+      expect(ae_service.root['ae_retry_interval']).to eq('30.seconds')
+    end
+
+    it "when virtv2v has not received SIGTERM" do
+      allow(ae_service).to receive(:get_state_var).with('virtv2v_graceful_kill').and_return(true)
+      expect(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:remote_command).with(svc_model_task, svc_model_host, 'kill -s KILL 1234')
+      described_class.new(ae_service).kill_virtv2v(svc_model_host, '1234')
+    end
+  end
+
+  context "#main" do
+    it "wraping up" do
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_started_on).and_return(Time.now.utc - 1)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_finished_on).and_return(nil)
+      allow(svc_model_task).to receive(:get_option).with(:virtv2v_wrapper).and_return('state_file' => '/tmp/fake_state_file.state')
+      allow(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:remote_command).with(svc_model_task, svc_model_host, "cat '/tmp/fake_state_file.state'").and_return(:success => true, :stdout => '{ "pid": "1234" }')
+      allow(ae_service).to receive(:get_state_var).with('virtv2v_graceful_kill').and_return(true)
+      expect(ManageIQ::Automate::Transformation::TransformationHosts::Common::Utils).to receive(:remote_command).with(svc_model_task, svc_model_host, 'kill -s KILL 1234')
+      described_class.new(ae_service).main
+    end
+  end
+
+  context "catchall exception rescue" do
+    before do
+      allow(svc_model_task).to receive(:get_option).with(:transformation_host_id).and_raise(StandardError.new('kaboom'))
+    end
+    it "forcefully raise" do
+      expect { described_class.new(ae_service).main }.to raise_error('kaboom')
+      expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => 'kaboom')
+    end
+  end
+end


### PR DESCRIPTION
In the course of a discussion with Richard W.M. Jones, he said that:

> It's not too nice to send kill -9 to virt-v2v because it means none of the at-exit handlers get to run, so it will leave temporary files all over the place.  It's better to send an ordinary kill signal (eg. SIGTERM).  If virt-v2v doesn't exit after some grace period, eg. 30 seconds, then it's a bug, but maybe you could then send SIGKILL.

This PR aims at fixing this by first using SIGTERM to kill virt-v2v with a grace period of 30 seconds, using retry. After that grace period, virt-v2v is sent SIGKILL, as it was the case before.

While I was at it, I added the specs for this method.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1633526
