### PR TITLE
Keep the encrypted value as is when creating service provision request.

### DIFF
--- a/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
+++ b/content/automate/ManageIQ/System/Request.class/__methods__/order_ansible_playbook.rb
@@ -29,7 +29,8 @@ module ManageIQ
             key_list = @handle.root.attributes.keys.select { |k| k.start_with?('dialog_param') }
             key_list.each_with_object({}) do |key, hash|
               match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key)
-              hash["param_#{match_data[1]}"] = @handle.root[key] if match_data
+              next unless match_data
+              hash["param_#{match_data[1]}"] = @handle.root.encrypted?(key) ? @handle.root.encrypted_string(key) : @handle.root[key]
             end
           end
 


### PR DESCRIPTION
Currently the encrypted value is sent to service provision request as "********" when called via custom button.

Depends on https://github.com/ManageIQ/manageiq/pull/18031.
Depends on https://github.com/ManageIQ/manageiq-automation_engine/pull/237.
Related to https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/127.

https://bugzilla.redhat.com/show_bug.cgi?id=1602883

@miq-bot add_label bug, gaprindashvili/yes, hammer/yes