### PR TITLE
Add tests for orchestration stack retirement

### DIFF
--- a/spec/automation/unit/builtin_method_validation/parse_automation_request_spec.rb
+++ b/spec/automation/unit/builtin_method_validation/parse_automation_request_spec.rb
@@ -1,3 +1,4 @@
+
 describe "parse_automation_request" do
   let(:user) { FactoryGirl.create(:user_with_group) }
   let(:inst) { "/System/Process/parse_automation_request" }
@@ -7,7 +8,8 @@ describe "parse_automation_request" do
     expect(ws.root.attributes).to include(
       "target_component" => "VM",
       "target_class"     => "Lifecycle",
-      "target_instance"  => "Provisioning")
+      "target_instance"  => "Provisioning"
+    )
   end
 
   it "for vm_retired request" do
@@ -15,7 +17,8 @@ describe "parse_automation_request" do
     expect(ws.root.attributes).to include(
       "target_component" => "VM",
       "target_class"     => "Lifecycle",
-      "target_instance"  => "Retirement")
+      "target_instance"  => "Retirement"
+    )
   end
 
   it "for vm_migrate request" do
@@ -23,7 +26,17 @@ describe "parse_automation_request" do
     expect(ws.root.attributes).to include(
       "target_component" => "VM",
       "target_class"     => "Lifecycle",
-      "target_instance"  => "Migrate")
+      "target_instance"  => "Migrate"
+    )
+  end
+
+  it "for orchestration_stack_retire request" do
+    ws = MiqAeEngine.instantiate("#{inst}?request=orchestration_stack_retire", user)
+    expect(ws.root.attributes).to include(
+      "target_component" => "Orchestration",
+      "target_class"     => "Lifecycle",
+      "target_instance"  => "Retirement"
+    )
   end
 
   it "for configured_system_provision request" do
@@ -32,6 +45,7 @@ describe "parse_automation_request" do
       "target_component"     => "Configured_System",
       "target_class"         => "Lifecycle",
       "target_instance"      => "Provisioning",
-      "ae_provider_category" => "infrastructure")
+      "ae_provider_category" => "infrastructure"
+    )
   end
 end

--- a/spec/automation/unit/builtin_method_validation/parse_provider_category_spec.rb
+++ b/spec/automation/unit/builtin_method_validation/parse_provider_category_spec.rb
@@ -1,9 +1,10 @@
 describe "parse_provider_category" do
-  let(:infra_ems)       { FactoryGirl.create(:ems_vmware_with_authentication) }
-  let(:infra_vm)        { FactoryGirl.create(:vm_vmware, :ems_id => infra_ems.id, :evm_owner => user) }
-  let(:migrate_request) { FactoryGirl.create(:vm_migrate_request, :requester => user) }
-  let(:user)            { FactoryGirl.create(:user_with_group) }
-  let(:inst)            { "/System/Process/parse_provider_category" }
+  let(:infra_ems)        { FactoryGirl.create(:ems_vmware_with_authentication) }
+  let(:infra_vm)         { FactoryGirl.create(:vm_vmware, :ems_id => infra_ems.id, :evm_owner => user) }
+  let(:migrate_request)  { FactoryGirl.create(:vm_migrate_request, :requester => user) }
+  let(:user)             { FactoryGirl.create(:user_with_group) }
+  let(:inst)             { "/System/Process/parse_provider_category" }
+  let(:orch_retire_task) { FactoryGirl.create(:orchestration_stack_retire_task) }
 
   let(:infra_miq_request_task) do
     FactoryGirl.create(:miq_request_task, :miq_request => migrate_request, :source => infra_vm)
@@ -64,6 +65,11 @@ describe "parse_provider_category" do
       ws = MiqAeEngine.instantiate("#{inst}?OrchestrationStack::orchestration_stack=#{stack.id}", user)
       expect(ws.root["ae_provider_category"]).to eq("cloud")
       expect(prepend_namespace(ws)).to match(/amazon/i)
+    end
+
+    it "for orchestration stack retire task" do
+      ws = MiqAeEngine.instantiate("#{inst}?OrchestrationStack::orchestration_stack_retire_task=#{stack.id}", user)
+      expect(ws.root["ae_provider_category"]).to eq("cloud")
     end
 
     it "for miq_provision" do


### PR DESCRIPTION
Orchestration Stack retirement needed tests in the parse provider category method and also in the parse automation request method. The changes in https://github.com/ManageIQ/manageiq-automation_engine/pull/238 got merged with tests as a todo. 