### PR TITLE
Fix userid in transformation throttler launch

### DIFF
--- a/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils.rb
@@ -66,7 +66,7 @@ module ManageIQ
                 :namespace     => NAMESPACE,
                 :class_name    => CLASS_NAME,
                 :instance_name => throttler_type(handle),
-                :user_id       => 1,
+                :user_id       => handle.vmdb(:user).find_by(:userid => 'admin').id,
                 :attrs         => { :ttl => throttler_ttl(handle) }
               },
               'admin',

--- a/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/TransformationThrottler.class/__methods__/utils_spec.rb
@@ -159,13 +159,14 @@ describe ManageIQ::Automate::Transformation::TransformationThrottler::Utils do
 
   context "#launch" do
     it "with default values" do
+      user_admin = FactoryGirl.create(:user, :userid => 'admin')
       expect(ae_service).to receive(:execute).with(
         :create_automation_request,
         {
           :namespace     => 'Transformation/StateMachines',
           :class_name    => 'TransformationThrottler',
           :instance_name => 'Default',
-          :user_id       => 1,
+          :user_id       => user_admin.id,
           :attrs         => { :ttl => 3600 }
         },
         'admin',


### PR DESCRIPTION
In the existing implementation, the user_id passed to `create_automation_request` is hard coded to `1`. And that's obviously a bad idea. In the real world, the id of the admin user is derived from the region number, as all the ids in the VMDB.

A constant information is that the `userid` is `admin`, so it allows to retrieve the correct user object from the VMDB and use its id instead of `1`. This PR implements that change.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1594196