### PR TITLE
[GAPRINDASHVILI] Add transformation utils methods

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.rb
@@ -1,0 +1,54 @@
+module ManageIQ
+  module Automate
+    module Transformation
+      module Common
+        class Utils
+          STATE_MACHINE_PHASES=%(transformation cleanup)
+
+          def self.log_and_raise(message, handle = $evm)
+            handle.log(:error, message)
+            raise "ERROR - #{message}"
+          end
+
+          def self.transformation_phase(handle = $evm)
+            @transformation_phase = handle.root['state_machine_phase'].tap do |phase|
+              log_and_raise('Transformation phase is not valid', handle) if STATE_MACHINE_PHASES.exclude?(phase)
+            end
+          end
+
+          def self.task_and_vms(handle = $evm)
+            %w(source destination).each { |vm_type| send("#{vm_type}_vm", handle) }
+          end
+
+          def self.task(handle = $evm)
+            send("#{transformation_phase(handle)}_task", handle)
+          end
+
+          def self.transformation_task(handle = $evm)
+            @task ||= handle.root['service_template_transformation_plan_task'].tap do |task|
+              log_and_raise('A service_template_transformation_plan_task is needed for this method to continue', handle) if task.nil?
+            end
+          end
+
+          def self.cleanup_task(handle = $evm)
+            log_and_raise('service_template_transformation_plan_task_id is not defined') if handle.root['service_template_transformation_plan_task_id'].nil?
+            @task ||= handle.vmdb(:service_template_transformation_plan_task).find_by(:id => handle.root['service_template_transformation_plan_task_id']).tap do |task|
+              log_and_raise('A service_template_transformation_plan_task is needed for this method to continue', handle) if task.nil?
+            end
+          end
+
+          def self.source_vm(handle = $evm)
+            @source_vm ||= task(handle).source.tap do |vm|
+              log_and_raise('Source VM has not been defined in the task', handle) if vm.nil?
+            end
+          end
+
+          def self.destination_vm(handle = $evm)
+            return if task(handle).get_option(:destination_vm_id).nil?
+            @destination_vm ||= handle.vmdb(:vm).find_by(:id => task(handle).get_option(:destination_vm_id))
+          end
+        end
+      end
+    end
+  end
+end

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.yaml
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils.yaml
@@ -1,0 +1,13 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Utils
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+    options: {}
+  inputs: []

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/utils_spec.rb
@@ -1,0 +1,224 @@
+require domain_file
+
+describe ManageIQ::Automate::Transformation::Common::Utils do
+  let(:user) { FactoryGirl.create(:user_with_email_and_group) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
+  let(:src_vm_vmware) { FactoryGirl.create(:vm_vmware) }
+  let(:dst_vm_redhat) { FactoryGirl.create(:vm_redhat) }
+  let(:dst_vm_openstack) { FactoryGirl.create(:vm_openstack) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }
+  let(:svc_model_src_vm_vmware) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(src_vm_vmware.id) }
+  let(:svc_model_dst_vm_redhat) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager_Vm.find(dst_vm_redhat.id) }
+  let(:svc_model_dst_vm_openstack) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm.find(dst_vm_openstack.id) }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current' => current_object,
+      'user'    => svc_model_user,
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object.parent = root
+      service.current_object = current_object
+    end
+  end
+
+  context "transformation phase" do
+    it "with task" do
+      ae_service.root['state_machine_phase'] = 'transformation'
+      expect(described_class.transformation_phase(ae_service)).to eq('transformation')
+    end
+
+    it "with task_id" do
+      ae_service.root['state_machine_phase'] = 'cleanup'
+      expect(described_class.transformation_phase(ae_service)).to eq('cleanup')
+    end
+
+    it "failure" do
+      ae_service.root['state_machine_phase'] = 'invalid'
+      errormsg = 'ERROR - Migration phase is not valid'
+      expect { described_class.transformation_phase(ae_service) }.to raise_error(errormsg)
+    end
+  end
+
+  shared_examples_for "transformation_task" do
+    it "with task" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      expect(described_class.transformation_task(ae_service).id).to eq(svc_model_task.id)
+      expect(described_class.task(ae_service).id).to eq(svc_model_task.id)
+    end
+
+    it "without task" do
+      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
+      expect(described_class.transformation_task(ae_service)).to raise_error(errormsg)
+      expect(described_class.task(ae_service)).to raise_error(errormsg)
+    end
+  end
+
+  context "transformation_task vmware to redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+
+    it_behaves_like "transformation_task"
+  end
+
+  context "transformation_task vmware to openstack" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+
+    it_behaves_like "transformation_task"
+  end
+
+  shared_examples_for "cleanup_task" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask }
+
+    it "with task_id and with task" do
+      ae_service.root['service_template_transformation_plan_task_id'] = svc_model_task.id
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:find_by).with(:id => svc_model_task.id).and_return(svc_model_task)
+      expect(described_class.cleanup_task(ae_service).id).to eq(svc_model_task.id)
+      expect(described_class.task(ae_service).id).to eq(svc_model_task.id)
+    end
+
+    it "with task_id and without task" do
+      ae_service.root['service_template_transformation_plan_task_id'] = svc_model_task.id
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:find_by).with(:id => svc_model_task.id).and_return(nil)
+      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
+      expect(described_class.cleanup_task(ae_service)).to raise_error(errormsg)
+      expect(described_class.task(ae_service)).to raise_error(errormsg)
+    end
+
+    it "without task_id" do
+      errormsg = 'ERROR - A service_template_transformation_plan_task is needed for this method to continue'
+      expect(described_class.cleanup_task(ae_service)).to raise_error(errormsg)
+      expect(described_class.task(ae_service)).to raise_error(errormsg)
+    end
+  end
+
+  context "cleanup_task vmware to redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+
+    it_behaves_like "cleanup_task"
+  end
+
+  context "cleanup_task vmware to openstack" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+
+    it_behaves_like "cleanup_task"
+  end
+
+  shared_examples_for "task" do
+    it "in transformation" do
+      ae_service.root['state_machine_phase'] = 'transformation'
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      expect(described_class.transformation_task(ae_service).id).to eq(svc_model_task.id)
+      expect(described_class.task(ae_service).id).to eq(svc_model_task.id)
+    end
+
+    it "in cleanup" do
+      ae_service.root['state_machine_phase'] = 'cleanup'
+      ae_service.root['service_template_transformation_plan_task_id'] = svc_model_task.id
+      allow(ae_service).to receive(:vmdb).with(:service_template_transformation_plan_task).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:find_by).with(:id => svc_model_task.id).and_return(svc_model_task)
+      expect(described_class.cleanup_task(ae_service).id).to eq(svc_model_task.id)
+      expect(described_class.task(ae_service).id).to eq(svc_model_task.id)
+    end
+  end
+
+  shared_examples_for "source_vm" do
+    before do
+      ae_service.root['state_machine_phase'] = 'transformation'
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+    end
+
+    it "with source vm" do
+      allow(svc_model_task).to receive(:source) { svc_model_src_vm }
+      expect(described_class.source_vm(ae_service).id).to eq(svc_model_src_vm.id)
+    end
+
+    it "without source vm" do
+      allow(svc_model_task).to receive(:source).and_return(nil)
+      errormsg = 'ERROR - Source VM has not been defined in the task'
+      expect(described_class.source_vm(ae_service)).to raise_error(errormsg)
+    end
+  end
+
+  context "source_vm vmware" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    it_behaves_like "source_vm"
+  end
+
+  shared_examples_for "destination_vm" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceVm }
+
+    before do
+      ae_service.root['state_machine_phase'] = 'transformation'
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+    end
+
+    it "with destination vm" do
+      allow(svc_model_task).to receive(:get_option).with(:destination_vm_id).and_return(nil)
+      expect(described_class.destination_vm(ae_service)).to be_nil
+    end
+
+    it "without destination vm" do
+      allow(svc_model_task).to receive(:get_option).with(:destination_vm_id).and_return(svc_model_dst_vm.id)
+      allow(ae_service).to receive(:vmdb).with(:vm).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:find_by).with(:id => svc_model_dst_vm.id).and_return(svc_model_dst_vm)
+      expect(described_class.destination_vm(ae_service).id).to eq(svc_model_dst_vm.id)
+    end
+  end
+
+  context "destination_vm redhat" do
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+    it_behaves_like "destination_vm"
+  end
+
+  context "destination_vm openstack" do
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+    it_behaves_like "destination_vm"
+  end
+
+  shared_examples_for "task_and_vms" do
+    let(:svc_vmdb_handle) { MiqAeMethodService::MiqAeServiceVm }
+
+    before do
+      ae_service.root['state_machine_phase'] = 'transformation'
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      allow(svc_model_task).to receive(:source) { svc_model_src_vm }
+      allow(svc_model_task).to receive(:get_option).with(:destination_vm_id).and_return(svc_model_dst_vm.id)
+      allow(ae_service).to receive(:vmdb).with(:vm).and_return(svc_vmdb_handle)
+      allow(svc_vmdb_handle).to receive(:find_by).with(:id => svc_model_dst_vm.id).and_return(svc_model_dst_vm)
+    end
+
+    it "task_and_vms in transformation with destination_vm" do
+      ae_service.root['service_template_transformation_plan_task'] = svc_model_task
+      described_class.task_and_vms(ae_service)
+      expect(@task.id).to eq(svc_model_task.id)
+      expect(@source_vm.id).to eq(svc_model_src_vm.id)
+      expect(@destination_vm.id).to eq(svc_model_dst_vm.id)
+    end
+  end
+
+  context "task_and_vms vmware to redhat" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_redhat }
+
+    it_behaves_like "task_and_vms"
+  end
+
+  context "task_and_vms vmware to openstack" do
+    let(:svc_model_src_vm) { svc_model_src_vm_vmware }
+    let(:svc_model_dst_vm) { svc_model_dst_vm_openstack }
+
+    it_behaves_like "task_and_vms"
+  end
+end


### PR DESCRIPTION
Missing util methods for v2v for Gaprindashvili branch.  Should get tests green.

@simaishi This is the same exact same changes as https://github.com/ManageIQ/manageiq-content/pull/391 just with squashed commits.  Ultimately we probably just want to backport the other PR and close this.