### PR TITLE
Adding better information about Quota in Used method.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
@@ -22,14 +22,14 @@ module ManageIQ
 
             def used(quota_source)
               quota_used = consumption(quota_source)
-              @handle.log("info", "Quota Used: #{quota_used.inspect}")
+              @handle.log("info", "Quota Used: (:cpu=>#{quota_used[:cpu]}, :memory=>#{quota_used[:memory]} (#{quota_used[:memory].to_s(:human_size)}), :vms=>#{quota_used[:vms]}, storage=>#{quota_used[:storage]} (#{quota_used[:storage].to_s(:human_size)}), provisioned_storage=>#{quota_used[:provisioned_storage]} (#{quota_used[:provisioned_storage].to_s(:human_size)}))")
 
               quota_source_type = root_quota_source_type
               @handle.log("info", "Quota source type: #{quota_source_type}")
 
               validate_user_email if quota_source_type == 'user'
               quota_active = active_provision_counts(quota_source_type)
-              @handle.log("info", "Quota #{active_method_name(quota_source_type)}: #{quota_active.inspect}")
+              @handle.log("info", "Quota #{active_method_name(quota_source_type)}: (:cpu=>#{quota_active[:cpu]}, :memory=>#{quota_active[:memory]} (#{quota_active[:memory].to_s(:human_size)}), :vms=>#{quota_active[:vms]}, storage=>#{quota_active[:storage]} (#{quota_active[:storage].to_s(:human_size)}))")
 
               merge_counts(quota_used, quota_active)
             end
@@ -77,7 +77,7 @@ module ManageIQ
 
             def merge_counts(quota_used, quota_active)
               @handle.root['quota_used'] = quota_used.merge(quota_active) { |_key, val1, val2| val1 + val2 }
-              @handle.log("info", "Quota Totals: #{@handle.root['quota_used'].inspect}")
+              @handle.log("info", "Quota Totals: (:cpu=>#{quota_used[:cpu]}, :memory=>#{quota_used[:memory]} (#{quota_used[:memory].to_s(:human_size)}), :vms=>#{quota_used[:vms]}, storage=>#{quota_used[:storage]} (#{quota_used[:storage].to_s(:human_size)}), provisioned_storage=>#{quota_used[:provisioned_storage]} (#{quota_used[:provisioned_storage].to_s(:human_size)}))")
             end
           end
         end


### PR DESCRIPTION
Added Human_size totals in 3 log messages.

No spec change because only 3 log messages were changed.

Old messages:

<AEMethod used> Quota Used: {:cpu=>495, :memory=>1334023553024, :vms=>188, :storage=>11278429978624, :provisioned_storage=>12612453531648}
<AEMethod used> Quota active_provisions_by_tenant: {:cpu=>0, :memory=>0, :vms=>0, :storage=>0, :provisioned_storage=>0}
<AEMethod used> Quota Totals: {:cpu=>495, :memory=>1334023553024, :vms=>188, :storage=>11278429978624, :provisioned_storage=>12612453531648}


New messages:

<AEMethod used> Quota Used: (:cpu=>724, :memory=>1969494163456 (1.79 TB), :vms=>333, storage=>20490299139584 (18.6 TB), provisioned_storage=>22459793303040 (20.4 TB))
<AEMethod used> Quota active_provisions_by_tenant: (:cpu=>42, :memory=>68719476736 (64 GB), :vms=>41, storage=>23344220995584 (21.2 TB))
<AEMethod used> Quota Totals: (:cpu=>724, :memory=>1969494163456 (1.79 TB), :vms=>333, storage=>20490299139584 (18.6 TB), provisioned_storage=>22459793303040 (20.4 TB))