### PR TITLE
Use task cancelation_status to trigger cancelation

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -139,7 +139,7 @@ module ManageIQ
                   if @handle.root['ae_state_step'] == 'on_error'
                     task.message = 'Failed'
                     create_cleanup_request(task)
-                  elsif task.get_option('cancel_requested') && task.get_option(:cleanup_request_id).blank?
+                  elsif task.cancelation_status == 'cancel_requested' && task.get_option(:cleanup_request_id).blank?
                     task.message = 'Canceled'
                     create_cleanup_request(task)
                     raise "Task cancellation requested."

--- a/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/MiqAe.class/__methods__/weightedupdatestatus.rb
@@ -139,7 +139,7 @@ module ManageIQ
                   if @handle.root['ae_state_step'] == 'on_error'
                     task.message = 'Failed'
                     create_cleanup_request(task)
-                  elsif task.cancelation_status == 'cancel_requested' && task.get_option(:cleanup_request_id).blank?
+                  elsif task.cancel_requested? && task.get_option(:cleanup_request_id).blank?
                     task.message = 'Canceled'
                     create_cleanup_request(task)
                     raise "Task cancellation requested."

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -24,7 +24,7 @@ module ManageIQ
           end
 
           def main
-            @task.set_option('cancel_requested', true) unless @task.preflight_check
+            raise 'Preflight check has failed' unless @task.preflight_check
             %w(task_options factory_config).each { |ci| send("populate_#{ci}") }
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation_spec.rb
@@ -123,6 +123,7 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
   shared_examples_for "main" do
     it "global summary test" do
       allow(svc_model_src_vm).to receive(:power_state).and_return("on")
+      allow(svc_model_task).to receive(:preflight_check).and_return(true)
       described_class.new(ae_service).main
       expect(svc_model_task.get_option(:source_vm_power_state)).to eq("on")
       expect(svc_model_task.get_option(:collapse_snapshots)).to be true
@@ -237,13 +238,7 @@ describe ManageIQ::Automate::Transformation::Common::AssessTransformation do
 
     it "sets cancel_requested option if preflight check returns false" do
       allow(svc_model_task).to receive(:preflight_check).and_return(false)
-      described_class.new(ae_service).main
-      expect(svc_model_task.get_option('cancel_requested')).to eq(true)
-    end
-
-    it "raises if task preflight check raises" do
-      errormsg = 'Unexpected error'
-      allow(svc_model_task).to receive(:preflight_check).and_raise(errormsg)
+      errormsg = 'Preflight check has failed'
       expect { described_class.new(ae_service).main }.to raise_error(errormsg)
       expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => errormsg)
     end


### PR DESCRIPTION
To prevent cancel_request option override, https://github.com/ManageIQ/manageiq/pull/17825 introduced an attribute to the task object. This PR changes the Automate code to rely on this attribute.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1614864