### PR TITLE
Added blank lines to log_object method for readability.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object.rb
@@ -72,6 +72,7 @@ module ManageIQ
               handle.log("info", "Listing #{log_prefix} Attributes - Begin")
               obj.attributes.sort.each { |k, v| handle.log("info", "   Attribute - #{k}: #{v}") }
               handle.log("info", "Listing #{log_prefix} Attributes - End")
+              handle.log("info", "")
             end
 
             def self.log_and_raise(message, handle = $evm)
@@ -100,9 +101,10 @@ module ManageIQ
             def self.attributes(obj, log_prefix, handle = $evm)
               handle.log("info", " #{log_prefix} Begin Attributes [object.attributes]")
               obj.attributes.sort.each do |k, v|
-                handle.log("info", "  Attribute:  #{k} = #{v.inspect}")
+                handle.log("info", "    #{k} = #{v.inspect}")
               end
               handle.log("info", " #{log_prefix} End Attributes [object.attributes]")
+              handle.log("info", "")
             end
 
             def self.associations(obj, log_prefix, handle = $evm)
@@ -112,6 +114,7 @@ module ManageIQ
                 handle.log("info", "   Associations - #{assc}")
               end
               handle.log("info", " #{log_prefix} End Associations [object.associations]")
+              handle.log("info", "")
             end
 
             def self.tags(obj, log_prefix, handle = $evm)
@@ -122,6 +125,7 @@ module ManageIQ
                 handle.log("info", "    Category:<#{tag_text.first.inspect}> Tag:<#{tag_text.last.inspect}>")
               end
               handle.log("info", " #{log_prefix} End Tags [object.tags]")
+              handle.log("info", "")
             end
           end
         end

--- a/spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb
+++ b/spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb
@@ -39,6 +39,7 @@ describe ManageIQ::Automate::System::CommonMethods::Utils::LogObject do
   it '.root' do
     expect(ae_service).to receive(:log).with('info', /Listing root Attributes/).exactly(log_header_footer_count).times
     expect(ae_service).to receive(:log).with('info', /   Attribute/).exactly(root_attr_count).times
+    expect(ae_service).to receive(:log).with('info', //).exactly(1).times
 
     # described_class.root(ae_service)
     ManageIQ::Automate::System::CommonMethods::Utils::LogObject.root(ae_service)
@@ -47,6 +48,7 @@ describe ManageIQ::Automate::System::CommonMethods::Utils::LogObject do
   it '.current' do
     expect(ae_service).to receive(:log).with('info', /Listing current Attributes/).exactly(log_header_footer_count).times
     expect(ae_service).to receive(:log).with('info', /   Attribute/).exactly(current_attr_count).times
+    expect(ae_service).to receive(:log).with('info', //).exactly(1).times
 
     # described_class.current(ae_service)
     ManageIQ::Automate::System::CommonMethods::Utils::LogObject.current(ae_service)
@@ -63,6 +65,7 @@ describe ManageIQ::Automate::System::CommonMethods::Utils::LogObject do
   it '.log' do
     expect(ae_service).to receive(:log).with('info', /Listing My Object Attributes/).exactly(log_header_footer_count).times
     expect(ae_service).to receive(:log).with('info', /   Attribute/).exactly(root_attr_count).times
+    expect(ae_service).to receive(:log).with('info', //).exactly(1).times
 
     # described_class.log(ae_service, root)
     ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log(root, 'My Object', ae_service)
@@ -144,16 +147,19 @@ describe ManageIQ::Automate::System::CommonMethods::Utils::LogObject do
       expect(ae_service).to receive(:log).with('info', /key:/).exactly(1).times
 
       expect(ae_service).to receive(:log).with('info', / VMDB Object Begin Attributes/).exactly(1).times
-      expect(ae_service).to receive(:log).with('info', /  Attribute:/).exactly(vm1.attributes.count).times
+      expect(ae_service).to receive(:log).with('info', /  /).exactly(vm1.attributes.count).times
       expect(ae_service).to receive(:log).with('info', / VMDB Object End Attributes/).exactly(1).times
+      expect(ae_service).to receive(:log).with('info', //).exactly(1).times
 
       expect(ae_service).to receive(:log).with('info', / VMDB Object Begin Associations/).exactly(1).times
       expect(ae_service).to receive(:log).with('info', /   Associations -/).exactly(MiqAeMethodService::MiqAeServiceVm.associations.count).times
       expect(ae_service).to receive(:log).with('info', / VMDB Object End Associations/).exactly(1).times
+      expect(ae_service).to receive(:log).with('info', //).exactly(1).times
 
       expect(ae_service).to receive(:log).with('info', / VMDB Object Begin Tags /).exactly(1).times
       expect(ae_service).to receive(:log).with('info', /    Category:/).exactly(vm1.tags.count).times
       expect(ae_service).to receive(:log).with('info', / VMDB Object End Tags/).exactly(1).times
+      expect(ae_service).to receive(:log).with('info', //).exactly(1).times
       # described_class.log_ar_objects('VMDB Object', ae_service)
       ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_ar_objects('VMDB Object', ae_service)
     end
@@ -168,16 +174,19 @@ describe ManageIQ::Automate::System::CommonMethods::Utils::LogObject do
       expect(ae_service).to receive(:log).with('info', /key:/).exactly(1).times
 
       expect(ae_service).to receive(:log).with('info', / My Database Object Begin Attributes/).exactly(1).times
-      expect(ae_service).to receive(:log).with('info', /  Attribute:/).exactly(vm1.attributes.count).times
+      expect(ae_service).to receive(:log).with('info', /  /).exactly(vm1.attributes.count).times
       expect(ae_service).to receive(:log).with('info', / My Database Object End Attributes/).exactly(1).times
+      expect(ae_service).to receive(:log).with('info', //).exactly(1).times
 
       expect(ae_service).to receive(:log).with('info', / My Database Object Begin Associations/).exactly(1).times
       expect(ae_service).to receive(:log).with('info', /   Associations -/).exactly(MiqAeMethodService::MiqAeServiceVm.associations.count).times
       expect(ae_service).to receive(:log).with('info', / My Database Object End Associations/).exactly(1).times
+      expect(ae_service).to receive(:log).with('info', //).exactly(1).times
 
       expect(ae_service).to receive(:log).with('info', / My Database Object Begin Tags /).exactly(1).times
       expect(ae_service).to receive(:log).with('info', /    Category:/).exactly(vm1.tags.count).times
       expect(ae_service).to receive(:log).with('info', / My Database Object End Tags/).exactly(1).times
+      expect(ae_service).to receive(:log).with('info', //).exactly(1).times
       # described_class.log_ar_objects('My Database Object', ae_service)
       ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_ar_objects('My Database Object', ae_service)
     end


### PR DESCRIPTION
Changed method to be more consistent with the replaced InspectMe method.

This makes it easier to read the log messages.

Added blank lines between sections and removed the 'Attribute:' string form the detail lines.
Updated spec.