### PR TITLE
V2V - Workaround for network mappings storage

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -25,6 +25,8 @@ module ManageIQ
 
           def main
             raise 'Preflight check has failed' unless @task.preflight_check
+            # TODO(fdupont-redhat): Find why network mappings are not stored
+            # by call to preflight_check.
             @task.set_option(:network_mappings, @task.network_mappings)
             %w(task_options factory_config).each { |ci| send("populate_#{ci}") }
           rescue => e

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/assesstransformation.rb
@@ -25,6 +25,7 @@ module ManageIQ
 
           def main
             raise 'Preflight check has failed' unless @task.preflight_check
+            @task.set_option(:network_mappings, @task.network_mappings)
             %w(task_options factory_config).each { |ci| send("populate_#{ci}") }
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)


### PR DESCRIPTION
When migrating a VM to OpenStack, we need the IP addresses of the source virutal machine to create the associated network ports. This PR add a statement to store the network mappings, which contain the IP addresses if VMware tools are running, into the task options hash for later consumption.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1649020