### PR TITLE
Disconnect storage when disconnecting a VM

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/destroyvm_task_complete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/destroyvm_task_complete.yaml
@@ -11,6 +11,4 @@ object:
   - rel3:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
   - rel4:
-      value: "/System/event_handlers/src_vm_disconnect_storage"
-  - rel5:
       value: "/System/event_handlers/event_action_refresh?target=src_vm"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
@@ -9,8 +9,6 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/src_vm_disconnect_storage"
-  - rel5:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_destroy&param="
-  - rel6:
+  - rel5:
       value: "/System/event_handlers/event_action_refresh?target=src_vm"


### PR DESCRIPTION
Instead of calling disconnect_storage separately from the targeted
refresh, disconnect the storage when disconnect_inv is called from the
targeted refresh.

Depends: https://github.com/ManageIQ/manageiq/pull/18200

https://bugzilla.redhat.com/show_bug.cgi?id=1644770