### PR TITLE
Fix TransformationPlanRequest approval - Set message

### DIFF
--- a/content/automate/ManageIQ/Transformation/StateMachines/TransformationPlanRequestApproval.class/__methods__/deny_request.rb
+++ b/content/automate/ManageIQ/Transformation/StateMachines/TransformationPlanRequestApproval.class/__methods__/deny_request.rb
@@ -1,5 +1,5 @@
 request = $evm.root['miq_request']
 message = $evm.object['reason']
 $evm.log('info', "Request denied because of #{message}")
-request.message = message
+request.set_message(message)
 request.deny('admin', message)

--- a/content/automate/ManageIQ/Transformation/StateMachines/TransformationPlanRequestApproval.class/__methods__/validate_request.rb
+++ b/content/automate/ManageIQ/Transformation/StateMachines/TransformationPlanRequestApproval.class/__methods__/validate_request.rb
@@ -2,7 +2,6 @@ request = $evm.root['miq_request']
 
 unless request.validate_conversion_hosts
   $evm.object['reason'] = 'No conversion host configured'
-  request.message = 'No conversion host configured'
   exit MIQ_ABORT
 end
 


### PR DESCRIPTION
deny_request and validate_request were using `request.message=` which doesn't exist. This PR makes them use `request.set_message()` instead.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1640816