### PR TITLE
Changed disk_name to symbol in requested Quota method.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -165,8 +165,9 @@ def requested_storage(args_hash)
     if args_hash[:resource].options[:disk_remove]
       args_hash[:resource].options[:disk_remove].each do |disk|
         $evm.log(:info, "Reconfigure Disk Removal: #{disk.inspect}")
-        current_size = get_disk_size(disk['disk_name'])
-        $evm.log(:info, "Reconfigure Disk Removal Disk: <#{disk['disk_name']}> Disk Size: <#{current_size.to_s(:human_size)}>")
+        disk = HashWithIndifferentAccess.new(disk)
+        current_size = get_disk_size(disk[:disk_name])
+        $evm.log(:info, "Reconfigure Disk Removal Disk: <#{disk[:disk_name]}> Disk Size: <#{current_size.to_s(:human_size)}>")
         args_hash[:prov_value] -= current_size
       end
     end

--- a/spec/automation/unit/method_validation/requested_spec.rb
+++ b/spec/automation/unit/method_validation/requested_spec.rb
@@ -244,7 +244,7 @@ describe "Quota Validation" do
     it "removes a disk " do
       setup_model("vmware_reconfigure")
       @reconfigure_request.update_attributes(:options => {:src_ids => [@vm_vmware.id], :request_type => :vm_reconfigure,\
-      :disk_remove => [{"disk_name" => disk.filename, "persistent" => true, "thin_provisioned" => false,\
+      :disk_remove => [{:disk_name => disk.filename, :persistent => true, :thin_provisioned => false,\
       "dependent" => true, "bootable" => false}]})
       ws = run_automate_method(reconfigure_attrs)
       check_results(ws.root['quota_requested'], -10.megabytes, 0, 1, 0.megabytes)
@@ -253,7 +253,7 @@ describe "Quota Validation" do
     it "remove a disk thats not found" do
       setup_model("vmware_reconfigure")
       @reconfigure_request.update_attributes(:options => {:src_ids => [@vm_vmware.id], :request_type => :vm_reconfigure,\
-      :disk_remove => [{"disk_name" => "not found", "persistent" => true, "thin_provisioned" => false,\
+      :disk_remove => [{:disk_name => "not found", :persistent => true, :thin_provisioned => false,\
       "dependent" => true, "bootable" => false}]})
       expect { run_automate_method(reconfigure_attrs) }.to raise_error(MiqAeException::UnknownMethodRc)
     end


### PR DESCRIPTION
Disk_name changed to symbol.

Tested on VMware and Redhat machines for 5.8, 5.9. and 5.10.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1629096