### PR TITLE
[V2V] Allow a retry to let virt-v2v start

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed.rb
@@ -44,8 +44,12 @@ module ManageIQ
               @handle.set_state_var(:ae_state_progress, 'message' => 'Disks transformation succeeded.', 'percent' => 100)
             end
           rescue => e
-            @handle.set_state_var(:ae_state_progress, 'message' => e.message)
-            raise
+            if @handle.root['ae_state_retries'] > 1
+              @handle.set_state_var(:ae_state_progress, 'message' => e.message)
+              raise
+            else
+              set_retry
+            end
           end
         end
       end


### PR DESCRIPTION
In slow environments, virt-v2v-wrapper may need a few seconds to start virt-v2v and to create the state file. This can lead the transformation check to fail because the file doesn't exist. With this PR, we allow a retry of VMCheckTransformed, i.e. 1 minute, to let virt-v2v-wrapper start the conversion and create the state file.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1653407