### PR TITLE
When all child retirement tasks are finished, service retirement is done.

### DIFF
--- a/spec/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired_spec.rb
+++ b/spec/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired_spec.rb
@@ -7,8 +7,6 @@ describe ManageIQ::Automate::Service::Retirement::StateMachines::Methods::CheckS
   let(:task) { FactoryBot.create(:service_retire_task, :destination => service, :miq_request => request) }
   let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceRetireTask.find(task.id) }
   let(:svc_service) { MiqAeMethodService::MiqAeServiceService.find(service.id) }
-  let(:vm) { FactoryBot.create(:vm) }
-  let(:retired_vm) { FactoryBot.create(:vm, :retired => true) }
   let(:root_object) do
     Spec::Support::MiqAeMockObject.new('service'             => svc_service,
                                        'service_retire_task' => svc_task,
@@ -16,34 +14,21 @@ describe ManageIQ::Automate::Service::Retirement::StateMachines::Methods::CheckS
   end
   let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
 
-  context "with non retired resource" do
+  context "with non finished task" do
     it "check" do
-      service.service_resources << FactoryBot.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service.id, :resource_id => vm.id)
-      expect(ae_service).to receive(:log).exactly(4).times
+      task.miq_request_tasks << FactoryBot.create(:service_retire_task, :miq_request => request, :state => 'active')
       described_class.new(ae_service).main
 
       expect(ae_service.root['ae_result']).to eq('retry')
     end
   end
 
-  context " with retired resource" do
+  context " with finished task" do
     it "check" do
-      service.service_resources << FactoryBot.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service.id, :resource_id => retired_vm.id)
-      expect(ae_service).to receive(:log).exactly(3).times
+      task.miq_request_tasks << FactoryBot.create(:service_retire_task, :miq_request => request, :state => 'finished')
       described_class.new(ae_service).main
 
       expect(ae_service.root['ae_result']).to eq('ok')
-    end
-  end
-
-  context "nil service" do
-    let(:root_object) do
-      Spec::Support::MiqAeMockObject.new('service'             => nil,
-                                         'service_retire_task' => task,
-                                         'service_action'      => 'Retirement')
-    end
-    it "check" do
-      expect { described_class.new(ae_service).main }.to raise_error('Service object has not been provided')
     end
   end
 end


### PR DESCRIPTION
Changes to check_service_retired method, so Ansible Tower Service can be retired.

https://bugzilla.redhat.com/show_bug.cgi?id=1650437

@miq-bot add_label bug, blocker, hammer/yes
@miq-bot assign @gmcculloug
@miq-bot add_reviewer @tinaafitz