### PR TITLE
[WIP] Send into retry if not all child tasks are retired

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired.rb
@@ -26,6 +26,9 @@ module ManageIQ
                 if task.miq_request_tasks.all? { |t| t.state == 'finished' }
                   result = 'ok'
                   @handle.log('info', "Child tasks finished.")
+                else
+                  result = 'retry'
+                  @handle.log('info', "Not all child tasks finished.")
                 end
 
                 case result


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-content/pull/493, which fixes the service bundle retirement order (the top, root-level service should be retired last) got in yesterday but if the tasks of child services of a service bundle aren't finished retiring, we should be doing a retry. 493 handled the case where all tasks are finished only.  

This should be tested, but there's an existing spec at https://github.com/lfu/manageiq-content/blob/2c4db88147ed9f2207b62efdbf34ed39d22ab542/spec/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired_spec.rb#L17 which I think is passing and probably shouldn't be. 