### PR TITLE
Use OrchestrationTemplateRunner to queue orchestration stack deployment.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -19,14 +19,14 @@ module ManageIQ
                 service = task.destination
 
                 begin
-                  stack = service.deploy_orchestration_stack
+                  job = service.deploy_orchestration_stack
                   @handle.log("info",
-                              "Stack #{service.stack_name} with reference id (#{stack.ems_ref}) is being created")
+                              "Orchestration provisioning job with id (#{job.id}) is being created")
                 rescue => err
                   @handle.root['ae_result'] = 'error'
                   @handle.root['ae_reason'] = err.message
                   task.miq_request.user_message = err.message
-                  @handle.log("error", "Stack #{service.stack_name} creation failed. Reason: #{err.message}")
+                  @handle.log("error", "Orchestration provisioning job creation failed. Reason: #{err.message}")
                 end
               end
             end

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision_spec.rb
@@ -1,67 +1,33 @@
 require_domain_file
 
 describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::Provision do
-  let(:request)               { FactoryBot.create(:service_template_provision_request, :requester => user) }
-  let(:service_orchestration) { FactoryBot.create(:service_orchestration) }
-  let(:user)                  { FactoryBot.create(:user_with_group) }
+  let(:job_class)        { ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner }
+  let(:request)          { FactoryBot.create(:service_template_provision_request, :requester => user) }
+  let(:manager)          { FactoryBot.create(:ems_amazon) }
+  let(:user)             { FactoryBot.create(:user_with_group) }
+  let(:template)         { FactoryBot.create(:orchestration_template) }
+  let(:service_template) { FactoryBot.create(:service_template_orchestration, :orchestration_manager => manager, :orchestration_template => template) }
+  let(:job)              { FactoryBot.create(:job) }
 
-  let(:miq_request_task) do
-    FactoryBot.create(:miq_request_task,
-                       :destination => service_orchestration,
-                       :miq_request => request)
+  let(:service_orchestration) do
+    FactoryBot.create(:service_orchestration, :orchestration_manager => manager, :service_template => service_template, :orchestration_template => template)
   end
 
-  let(:svc_model_service) do
-    MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id)
-  end
+  let(:svc_model_service) { MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  let(:task)              { FactoryBot.create(:service_template_provision_task, :destination => service_orchestration, :miq_request => request) }
+  let(:svc_model_task)    { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(task.id) }
+  let(:root_object)       { Spec::Support::MiqAeMockObject.new('service_template_provision_task' => svc_model_task) }
+  let(:ae_service)        { Spec::Support::MiqAeMockService.new(root_object) }
 
-  let(:svc_model_miq_request_task) do
-    MiqAeMethodService::MiqAeServiceMiqRequestTask.find(miq_request_task.id)
-  end
-
-  let(:root_hash) do
-    { 'service_template' => MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
-  end
-
-  let(:root_object) do
-    obj = Spec::Support::MiqAeMockObject.new(root_hash)
-    obj["service_template_provision_task"] = svc_model_miq_request_task
-    obj
-  end
-
-  let(:ae_service) do
-    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
-      current_object = Spec::Support::MiqAeMockObject.new
-      current_object.parent = root_object
-      service.object = current_object
-    end
-  end
-
-  before(:each) do
-    allow(svc_model_miq_request_task).to receive(:destination) { svc_model_service }
-  end
-
-  it "provisions a stack through the service" do
-    expect(svc_model_service).to receive(:deploy_orchestration_stack)
+  it "launches an orchestration template runner job" do
+    expect(job_class).to receive(:create_job).and_return(job)
     described_class.new(ae_service).main
   end
 
-  it "catches the error at stack provisioning" do
-    allow(svc_model_service).to receive(:deploy_orchestration_stack) { raise "test failure" }
+  it "fails the step when job launching fails" do
+    expect(job_class).to receive(:create_job).and_raise('provider error')
     described_class.new(ae_service).main
-
-    expect(ae_service.root['ae_result']).to eq("error")
-    expect(ae_service.root['ae_reason']).to eq("test failure")
-    expect(request.reload.message).to eq("test failure")
-  end
-
-  it "truncates the error message exceeding 255 character limits" do
-    long_error = 't' * 300
-    allow(svc_model_service).to receive(:deploy_orchestration_stack) { raise long_error }
-    described_class.new(ae_service).main
-
-    expect(ae_service.root['ae_result']).to eq("error")
-    expect(ae_service.root['ae_reason']).to eq(long_error)
-    expect(request.reload.message).to eq('t' * 252 + '...')
+    expect(ae_service.root['ae_result']).to eq('error')
+    expect(ae_service.root['ae_reason']).to eq('provider error')
   end
 end


### PR DESCRIPTION
Provider specific provisions executed as part of a service provision are supposed to be queued to the provider zone.

Depends on https://github.com/ManageIQ/manageiq/pull/18374.

https://bugzilla.redhat.com/show_bug.cgi?id=1656351

@miq-bot add_label bug, gaprindashvili/yes, hammer/yes, services