### PR TITLE
[V2V] Remove check on power_off variable

### DIFF
--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweroff.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweroff.rb
@@ -13,7 +13,6 @@ module ManageIQ
 
               def main
                 return if @source_vm.power_state == 'off'
-                raise "VM '#{@source_vm.name} is powered on, but we are not allowed to shut it down. Aborting." unless @task.get_option(:power_off)
                 if @handle.state_var_exist?(:vm_shutdown_in_progress)
                   @source_vm.stop if @handle.root['ae_state_retries'].to_i > 10
                 else


### PR DESCRIPTION
When we designed the migration workflow, we didn't want to force the shutdown of the VM. We wanted to have an explicit sign-off. So, we implemented a check on a `power_off`boolean variable. This variable was set to `true` in the first state of the state machine. The associated UI was never implemented and we always shutdown the VMs.

When the throttling code was moved to the backend, the variable was not set anymore, so all migrations fail. As it's not used, removing the check on `power_off` variable is cleaner.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1688465