### PR TITLE
[V2V] Expose virt-v2v-wrapper error message in progress.states

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed.rb
@@ -36,8 +36,8 @@ module ManageIQ
               @handle.set_state_var(:ae_state_progress, 'message' => message, 'percent' => percent.round(2))
               set_retry
             when 'failed'
-              @handle.set_state_var(:ae_state_progress, 'message' => 'Disks transformation failed.')
-              raise "Disks transformation failed."
+              message = @task.get_option(:virtv2v_message)
+              raise message
             when 'succeeded'
               @handle.set_state_var(:ae_state_progress, 'message' => 'Disks transformation succeeded.', 'percent' => 100)
             end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed_spec.rb
@@ -68,9 +68,10 @@ describe ManageIQ::Automate::Transformation::Common::VMCheckTransformed do
 
     context "conversion has failed" do
       it "raises with a message stating conversion has failed" do
+        errormsg = 'virtv2v failed somehow'
         ae_service.root['ae_state_retries'] = 2
         allow(svc_model_task).to receive(:get_option).with(:virtv2v_status).and_return('failed')
-        errormsg = 'Disks transformation failed.'
+        allow(svc_model_task).to receive(:get_option).with(:virtv2v_message).and_return(errormsg)
         expect { described_class.new(ae_service).main }.to raise_error(errormsg)
         expect(ae_service.get_state_var(:ae_state_progress)).to eq('message' => errormsg)
       end


### PR DESCRIPTION
When the disk conversion fails, the error message is really vague: _Disk Transformation failed_, so the user needs to look into the wrapper and virt-v2v logs to identify the cause. Since recently, virt-v2v-wrapper provides a human-readable error message based on virt-v2v log. An example is below

```json
    {
      "started": true,
      "disks": [
        {
          "path": "[datastore13] tg-mini2/tg-mini2_3.vmdk",
          "progress": 100
        },
        {
          "path": "[datastore13] tg-mini2/tg-mini2_4.vmdk",
          "progress": 100
        }
      ],
      "pid": 30375,
      "disk_count": 2,
      "return_code": 0,
      "failed": true,
      "finished": true,
      "last_message": {
        "message": "Failed to create port",
        "type": "error"
      }
    }
```

The VMCheckTransformed state of the transformation state machine is responsible for setting the error message in the `ae_state_progress` state variable. The error message is set in the task options hash by the backend. This PR makes the method raise with the error message, which is caught in the `rescue` statement. Then, the `WeightedUpdateStatus` message will set it as the state message in `task[:options][:progress]["states"]`. This will allow the UI to expose the message.

Not relying only on the `:virtv2v_message` in the backend allows to leverage a more generic approach where the last message is always in `task[:options][:progress]["states"][task[:options][:progress]["current_state"]]["message"]`.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1595365
Depends On: https://github.com/ManageIQ/manageiq/pull/18564