### PR TITLE
Fixed State Machine and Instances for Vm Retirement.

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
@@ -259,7 +259,7 @@ object:
       datatype: string
       priority: 13
       owner: 
-      default_value: "/Cloud/VM/Retirement/Email/vm_retirement_emails?event=vm_retired"
+      default_value: "/System/Notification/Email/CloudVmRetired?event=vm_retired"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
@@ -259,7 +259,7 @@ object:
       datatype: string
       priority: 13
       owner: 
-      default_value: "/Infrastructure/VM/Retirement/Email/vm_retirement_emails?event=vm_retired"
+      default_value: "/System/Notification/Email/InfrastructureVmRetired?event=vm_retired"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretired.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudvmretired.yaml
@@ -9,8 +9,7 @@ object:
     description: 
   fields:
   - to:
-      value: "${/#vm.owner.email} ||${/#miq_provision.miq_request.get_option(:owner_email)}
-        || ${/#miq_provision.miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
+      value: "${/#vm_retire_task.miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
   - subject:
       value: 'Your Virtual Machine : ${/#vm} has been retired.'
   - body:

--- a/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretired.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/infrastructurevmretired.yaml
@@ -9,8 +9,7 @@ object:
     description: 
   fields:
   - to:
-      value: "${/#vm.owner.email} ||${/#miq_provision.miq_request.get_option(:owner_email)}
-        || ${/#miq_provision.miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
+      value: "${/#vm_retire_task.miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
   - subject:
       value: 'Your Virtual Machine : ${/#vm} has been retired.'
   - body:


### PR DESCRIPTION
Modified VMRetirement class schema values to use new email Instances For Infra and Cloud.
Modified Email instances CloudVmRetired and InfrastructureVmRetired to use

${/#vm_retire_task.miq_request.requester.email} ||  ${/Configuration/Email/Default#default_recipient}

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1687524

@miq-bot add_label bug
