### PR TITLE
Introduce PhysicalServerProvision StateMachine

### DIFF
--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Lifecycle.class/__class__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Lifecycle.class/__class__.yaml
@@ -1,0 +1,613 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Lifecycle
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: assertion
+      name: guard
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_entry
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship1
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method1
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship2
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method2
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship3
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method3
+      display_name: 
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship4
+      display_name: 
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method4
+      display_name: 
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship5
+      display_name: 
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method5
+      display_name: 
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship6
+      display_name: 
+      datatype: string
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method6
+      display_name: 
+      datatype: string
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship7
+      display_name: 
+      datatype: string
+      priority: 15
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method7
+      display_name: 
+      datatype: string
+      priority: 16
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship8
+      display_name: 
+      datatype: string
+      priority: 17
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method8
+      display_name: 
+      datatype: string
+      priority: 18
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship9
+      display_name: 
+      datatype: string
+      priority: 19
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method9
+      display_name: 
+      datatype: string
+      priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship10
+      display_name: 
+      datatype: string
+      priority: 21
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method10
+      display_name: 
+      datatype: string
+      priority: 22
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship11
+      display_name: 
+      datatype: string
+      priority: 23
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method11
+      display_name: 
+      datatype: string
+      priority: 24
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship12
+      display_name: 
+      datatype: string
+      priority: 25
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method12
+      display_name: 
+      datatype: string
+      priority: 26
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship13
+      display_name: 
+      datatype: string
+      priority: 27
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: Method13
+      display_name: 
+      datatype: string
+      priority: 28
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: Relationship14
+      display_name: 
+      datatype: string
+      priority: 29
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_exit
+      display_name: 
+      datatype: string
+      priority: 30
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Lifecycle.class/provisioning.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Lifecycle.class/provisioning.yaml
@@ -1,0 +1,14 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Provisioning
+    inherits: 
+    description: 
+  fields:
+  - Relationship5:
+      value: "/PhysicalInfrastructure/PhysicalServer/Provisioning/Profile/${/#user.normalized_ldap_group}#get_state_machine"
+  - Relationship6:
+      value: "/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/${/#state_machine}/default"

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/Profile.class/__class__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/Profile.class/__class__.yaml
@@ -1,0 +1,73 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Profile
+    display_name: 
+    name: Profile
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: auto_approval_state_machine
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: ProvisionRequestApproval
+      substitute: true
+      message: get_auto_approval_state_machine
+      visibility: 
+      collect: "/state_machine = auto_approval_state_machine"
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: quota_state_machine
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: get_quota_state_machine
+      visibility: 
+      collect: "/state_machine = quota_state_machine"
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: state_machine
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: Provision
+      substitute: true
+      message: get_state_machine
+      visibility: 
+      collect: "/state_machine = state_machine"
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/Profile.class/_missing.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/Profile.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/Profile.class/evmgroup-super_administrator.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/Profile.class/evmgroup-super_administrator.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: EvmGroup-super_administrator
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__class__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__class__.yaml
@@ -1,0 +1,413 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Methods
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: relationship
+      name: rel1
+      display_name: ''
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth1
+      display_name: ''
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: redfish_rel1
+      display_name: ''
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: redfish_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: redfish_meth1
+      display_name: ''
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: redfish_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: redfish_rel2
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: redfish_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: redfish_meth2
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: redfish_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: redfish_rel3
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: redfish_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: redfish_meth3
+      display_name: 
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: redfish_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: lenovo_rel1
+      display_name: 
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: lenovo_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: lenovo_meth1
+      display_name: 
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: lenovo_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: lenovo_rel2
+      display_name: 
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: lenovo_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: lenovo_meth2
+      display_name: 
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: lenovo_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: lenovo_rel3
+      display_name: 
+      datatype: string
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: lenovo_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: lenovo_meth3
+      display_name: 
+      datatype: string
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: lenovo_ph_infra
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: common_rel1
+      display_name: ''
+      datatype: string
+      priority: 15
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: common_meth1
+      display_name: ''
+      datatype: string
+      priority: 16
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: common_rel2
+      display_name: 
+      datatype: string
+      priority: 17
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: common_meth2
+      display_name: 
+      datatype: string
+      priority: 18
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: common_rel3
+      display_name: 
+      datatype: string
+      priority: 19
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: common_meth3
+      display_name: 
+      datatype: string
+      priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/check_provision.rb
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/check_provision.rb
@@ -1,0 +1,45 @@
+#
+# Description: <Method description here>
+#
+module ManageIQ
+  module Automate
+    module PhysicalInfrastructure
+      module PhysicalServer
+        module Provisioning
+          module StateMachines
+            module Methods
+              class CheckProvision
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
+
+                def main
+                  task = @handle.root["physical_server_provision_task"]
+                  result = task.statemachine_task_status
+                  server = task.source
+                  server_str = "PhysicalServer id=#{server.id} ems_ref=#{server.ems_ref}"
+
+                  @handle.log('info', "ProvisionCheck (#{server_str}) returned <#{result}> for state <#{task.state}> and status <#{task['status']}>")
+
+                  case result
+                  when 'error'
+                    @handle.root['ae_result'] = 'error'
+                    @handle.root['ae_reason'] = task.message.sub('Error: ', '')
+                    @handle.log('error', "ProvisionCheck (#{server_str}) error <#{task.message}>")
+                  when 'retry'
+                    @handle.root['ae_result'] = 'retry'
+                    @handle.root['ae_retry_interval'] = '1.minute'
+                  when 'ok'
+                    @handle.root['ae_result'] = 'ok'
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::PhysicalInfrastructure::PhysicalServer::Provisioning::StateMachines::Methods::CheckProvision.new.main

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/check_provision.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/check_provision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: check_provision
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -1,0 +1,28 @@
+#
+# Description: Trigger internal state machine that performs the actual provisioning.
+#
+module ManageIQ
+  module Automate
+    module PhysicalInfrastructure
+      module PhysicalServer
+        module Provisioning
+          module StateMachines
+            module Methods
+              class Provision
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
+
+                def main
+                  @handle.root['physical_server_provision_task'].execute
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::PhysicalInfrastructure::PhysicalServer::Provisioning::StateMachines::Methods::Provision.new.main

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/provision.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/provision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: provision
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/checkprovision.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/checkprovision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CheckProvision
+    inherits: 
+    description: 
+  fields:
+  - common_meth2:
+      value: check_provision

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/postprovision.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/postprovision.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: PostProvision
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/preprovision.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/preprovision.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: PreProvision
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/provision.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/provision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Provision
+    inherits: 
+    description: 
+  fields:
+  - common_meth2:
+      value: provision

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__class__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__class__.yaml
@@ -1,0 +1,133 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Factory State Machines
+    display_name: 
+    name: Provision
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: CustomizeRequest
+      display_name: ''
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: PreProvision
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: Provision
+      display_name: ''
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: ''
+      on_exit: ''
+      on_error: ''
+      max_retries: ''
+      max_time: 
+  - field:
+      aetype: state
+      name: CheckProvision
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: PostProvision
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: Finished
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.rb
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.rb
@@ -1,0 +1,69 @@
+#
+# Description: This method updates the service provisioning status
+# Required inputs: status
+#
+module ManageIQ
+  module Automate
+    module PhysicalInfrastructure
+      module PhysicalServer
+        module Provisioning
+          module StateMachines
+            module Provision
+              class UpdateProvisionStatus
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
+
+                def task
+                  @task ||= @handle.root['physical_server_provision_task'].tap do |task|
+                    unless task
+                      @handle.log(:error, 'physical_server_provision_task object not provided')
+                      exit(MIQ_STOP)
+                    end
+                    unless task.source
+                      @handle.log(:error, 'physical_server_provision_task.source object not provided (PhysicalServer expected)')
+                      exit(MIQ_STOP)
+                    end
+                  end
+                end
+
+                def status_param
+                  @handle.inputs['status']
+                end
+
+                def fire_notification(msg)
+                  @handle.create_notification(
+                    :level   => "error",
+                    :subject => task.miq_request,
+                    :message => "Physical Server Provision Error: #{msg}"
+                  )
+                end
+
+                def main
+                  # Update Task Message
+                  task.message = status_param
+
+                  # Update Request Message
+                  msg = "[#{@handle.root['miq_server'].name}] "
+                  msg += "PhysicalServer [#{task.source.id}|#{task.source.ems_ref}] "
+                  msg += "Step [#{@handle.root['ae_state']}] "
+                  msg += "Message [#{task.message}] "
+                  msg += "Current Retry Number [#{@handle.root['ae_state_retries']}]" if @handle.root['ae_result'] == 'retry'
+                  task.miq_request.user_message = msg
+
+                  # Let user know if Request failed
+                  if @handle.root['ae_result'] == "error"
+                    fire_notification(msg)
+                    @handle.log(:error, "PhysicalServer Provision Error: #{msg}")
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::PhysicalInfrastructure::PhysicalServer::Provisioning::StateMachines::Provision::UpdateProvisionStatus.new.main

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: update_provision_status
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs:
+  - field:
+      aetype: 
+      name: status
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/default.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/default.yaml
@@ -1,0 +1,36 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: default
+    inherits: 
+    description: 
+  fields:
+  - PreProvision:
+      value: "/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods/PreProvision#${/#physical_server_provision_task.source.emstype}"
+      on_entry: update_provision_status(status => "Executing PreProvision")
+      on_exit: update_provision_status(status => "Executed PreProvision")
+      on_error: update_provision_status(status => "Errored PreProvision")
+      max_retries: '100'
+  - Provision:
+      value: "/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods/Provision#${/#physical_server_provision_task.source.emstype}"
+      on_entry: update_provision_status(status => "Started Provisioning")
+      on_exit: update_provision_status(status => "Done Provisioning")
+      on_error: update_provision_status(status => "Errored while Provisioning")
+      max_retries: '100'
+  - CheckProvision:
+      value: "/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods/CheckProvision#${/#physical_server_provision_task.source.emstype}"
+      on_entry: update_provision_status(status => "Checking if Provisioning Done")
+      on_exit: update_provision_status(status => "Provisioning Completed")
+      on_error: update_provision_status(status => "Provisioning Errored")
+      max_retries: '100'
+  - PostProvision:
+      value: "/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods/PostProvision#${/#physical_server_provision_task.source.emstype}"
+      on_entry: update_provision_status(status => "Executing PostProvision")
+      on_exit: update_provision_status(status => "Executed PostProvision")
+      on_error: update_provision_status(status => "Errored PostProvision")
+      max_retries: '100'
+  - Finished:
+      on_exit: update_provision_status(status => "Provisioning Finished")

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/__namespace__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: StateMachines
+    description: ''
+    display_name: 
+    priority: 
+    enabled: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/__namespace__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Provisioning
+    description: ''
+    display_name: 
+    priority: 
+    enabled: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/__namespace__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: PhysicalServer
+    description: ''
+    display_name: 
+    priority: 
+    enabled: 

--- a/content/automate/ManageIQ/PhysicalInfrastructure/__namespace__.yaml
+++ b/content/automate/ManageIQ/PhysicalInfrastructure/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: PhysicalInfrastructure
+    description: ''
+    display_name: 
+    priority: 
+    enabled: 

--- a/spec/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/check_provision_spec.rb
+++ b/spec/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/check_provision_spec.rb
@@ -1,0 +1,40 @@
+require_domain_file
+
+describe ManageIQ::Automate::PhysicalInfrastructure::PhysicalServer::Provisioning::StateMachines::Methods::CheckProvision do
+  let(:admin)       { FactoryBot.create(:user_admin) }
+  let(:server)      { FactoryBot.create(:physical_server) }
+  let(:svc_server)  { MiqAeMethodService::MiqAeServicePhysicalServer.find_by(:id => server.id) }
+  let(:request)     { FactoryBot.create(:physical_server_provision_request, :requester => admin) }
+  let(:task)        { FactoryBot.create(:physical_server_provision_task, :miq_request => request, :source => server) }
+  let(:svc_task)    { MiqAeMethodService::MiqAeServiceMiqProvisionTask.find_by(:id => task.id) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(:physical_server_provision_task => svc_task) }
+  let(:ae_service)  { Spec::Support::MiqAeMockService.new(root_object) }
+
+  describe 'check provision status' do
+    context 'provisioning completed' do
+      before { task.update!(:state => 'provisioned', :status => 'Ok') }
+      it 'refreshes the request status' do
+        described_class.new(ae_service).main
+        expect(root_object['ae_result']).to eq('ok')
+      end
+    end
+
+    context 'provisioning failed' do
+      before { task.update!(:state => 'finished', :status => 'Error', :message => 'Error: because') }
+      it 'refreshes the request status' do
+        described_class.new(ae_service).main
+        expect(root_object['ae_result']).to eq('error')
+        expect(root_object['ae_reason']).to eq('because')
+      end
+    end
+
+    context 'provisioning running' do
+      before { task.update!(:state => 'active', :status => 'Ok') }
+      it 'retries the current step' do
+        described_class.new(ae_service).main
+        expect(root_object['ae_result']).to eq('retry')
+        expect(root_object['ae_retry_interval']).to eq('1.minute')
+      end
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/provision_spec.rb
+++ b/spec/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Methods.class/__methods__/provision_spec.rb
@@ -1,0 +1,17 @@
+require_domain_file
+
+describe ManageIQ::Automate::PhysicalInfrastructure::PhysicalServer::Provisioning::StateMachines::Methods::Provision do
+  let(:admin)       { FactoryBot.create(:user_admin) }
+  let(:server)      { FactoryBot.create(:physical_server) }
+  let(:svc_server)  { MiqAeMethodService::MiqAeServicePhysicalServer.find_by(:id => server.id) }
+  let(:request)     { FactoryBot.create(:physical_server_provision_request, :requester => admin) }
+  let(:task)        { FactoryBot.create(:physical_server_provision_task, :miq_request => request, :source => server) }
+  let(:svc_task)    { MiqAeMethodService::MiqAeServiceMiqProvisionTask.find_by(:id => task.id) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(:physical_server_provision_task => svc_task) }
+  let(:ae_service)  { Spec::Support::MiqAeMockService.new(root_object) }
+
+  it 'calls execute on task' do
+    expect(svc_task).to receive(:execute)
+    described_class.new(ae_service).main
+  end
+end

--- a/spec/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status_spec.rb
+++ b/spec/content/automate/ManageIQ/PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status_spec.rb
@@ -1,0 +1,66 @@
+require_domain_file
+
+describe ManageIQ::Automate::PhysicalInfrastructure::PhysicalServer::Provisioning::StateMachines::Provision::UpdateProvisionStatus do
+  let(:admin)       { FactoryBot.create(:user_admin) }
+  let(:server)      { FactoryBot.create(:physical_server) }
+  let(:svc_server)  { MiqAeMethodService::MiqAeServicePhysicalServer.find_by(:id => server.id) }
+  let(:request)     { FactoryBot.create(:physical_server_provision_request, :requester => admin) }
+  let(:task)        { FactoryBot.create(:physical_server_provision_task, :miq_request => request, :source => server) }
+  let(:svc_task)    { MiqAeMethodService::MiqAeServiceMiqProvisionTask.find_by(:id => task.id) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(:physical_server_provision_task => svc_task) }
+  let(:ae_service)  { Spec::Support::MiqAeMockService.new(root_object) }
+
+  subject { described_class.new(ae_service) }
+
+  describe '#status_param' do
+    before { ae_service.inputs['status'] = 'the status' }
+    it { expect(subject.status_param).to eq('the status') }
+  end
+
+  describe '#task' do
+    it 'when all ok' do
+      expect(subject.task).to eq(svc_task)
+    end
+
+    context 'when no task' do
+      let(:svc_task) { nil }
+      it 'is stopped' do
+        expect { subject.task } .to raise_error(SystemExit)
+      end
+    end
+
+    context 'when no task.source' do
+      let(:server) { nil }
+      it 'is stopped' do
+        expect { subject.task } .to raise_error(SystemExit)
+      end
+    end
+  end
+
+  describe '#main' do
+    before do
+      ae_service.inputs['status'] = 'the status'
+      root_object['miq_server'] = double('MIQ_SERVER', :name => 'miq server name')
+      root_object['ae_state'] = 'at state'
+    end
+    context 'when no error' do
+      it 'updates task and request message' do
+        subject.main
+        expect(task.reload.message).to eq('the status')
+        request_msg = request.reload.options[:user_message]
+        expect(request_msg).to include('[miq server name]')
+        expect(request_msg).to include("PhysicalServer [#{server.id}|#{server.ems_ref}]")
+        expect(request_msg).to include('Step [at state]')
+        expect(request_msg).to include('Message [the status]')
+      end
+    end
+
+    context 'when error' do
+      before { root_object['ae_result'] = 'error' }
+      it 'fires notification' do
+        expect(subject).to receive(:fire_notification)
+        subject.main
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this commit we implement a new external state machine
    
```
PhysicalInfrastructure/PhysicalServer/Provisioning/StateMachines/Provision
```
    
which in essence invokes (also new) internal state machine and then polls for    its status. The external state machine uses AE messages to allow for different     customization for redfish-managed servers than for lenovo-manager ones.

Depends on 
https://github.com/ManageIQ/manageiq/pull/18573
https://github.com/ManageIQ/manageiq-automation_engine/pull/306

@miq-bot add_label enhancement