### PR TITLE
Fixed State machine for Cloud Orchestration Retirement using old values.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/StackRetirement.class/__class__.yaml
@@ -178,7 +178,7 @@ object:
       datatype: string
       priority: 9
       owner: 
-      default_value: "/Cloud/Orchestration/Retirement/Email/stack_retirement_emails?event=stack_retired"
+      default_value: "/System/Notification/Email/CloudOrchestrationVmRetired?event=stack_retired"
       substitute: true
       message: create
       visibility: 

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmretired.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudorchestrationvmretired.yaml
@@ -9,10 +9,10 @@ object:
     description: 
   fields:
   - to:
-      value: "${/#vm.owner.email} || ${/#miq_request.get_option(:owner_email)} ||
-        ${/#miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}"
+      value: "${/#orchestration_stack_retire_task.miq_request.requester.email} ||
+        ${/Configuration/Email/Default#default_recipient}"
   - subject:
-      value: 'Stack Retirement Alert for : ${/#orchestration_stack}.'
+      value: 'Stack Retirement Alert for : ${/#orchestration_stack.name}.'
   - body:
-      value: 'Hello,<br/><br/>Your Stack named : ${/#orchestration_stack} has been
-        retired.<br/><br/> Thank you<br/> ${#signature}'
+      value: 'Hello,<br/><br/>Your Stack named : ${/#orchestration_stack.name} has
+        been retired.<br/><br/> Thank you<br/> ${#signature}'


### PR DESCRIPTION
Modified Cloud/Orchestration Retirement class schema values to use new email Instance.
Modified Email instance CloudOrchestrationVmRetired to use:

${/#orchestration_stack_retire_task.miq_request.requester.email} || ${/Configuration/Email/Default#default_recipient}

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1690508

@miq-bot add_label bug