### PR TITLE
Include params from ws_values in launch_ansible_job.

### DIFF
--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -116,7 +116,8 @@ module ManageIQ
 
                 def extra_variables
                   result = ansible_vars_from_objects(@handle.object, {})
-                  ansible_vars_from_options(result)
+                  result = ansible_vars_from_options(result)
+                  ansible_vars_from_ws_values(result)
                 end
 
                 def run(job_template, target)

--- a/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -66,6 +66,15 @@ module ManageIQ
                   end
                 end
 
+                def ansible_vars_from_ws_values(ext_vars)
+                  options = @handle.root["miq_provision"].try(:options) || {}
+                  ws_values = options[:ws_values] || {}
+                  ws_values.each_with_object(ext_vars) do |(key, value), hash|
+                    match_data = ANSIBLE_DIALOG_VAR_REGEX.match(key.to_s)
+                    hash[match_data[1]] = value if match_data
+                  end
+                end
+
                 def var_search(obj, name)
                   return nil unless obj
                   obj.attributes.key?(name) ? obj.attributes[name] : var_search(obj.parent, name)

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job_spec.rb
@@ -165,4 +165,17 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::Sta
     described_class.new(service).main
     expect(service.get_state_var(:ansible_job_id)).to eq(job.id)
   end
+
+  it "get dialog parameters from ws_values" do
+    prov_options[:ws_values] = {}
+    prov_options[:ws_values][:dialog_param_name] = 'fred'
+    ext_vars['name'] = 'fred'
+    root = Spec::Support::MiqAeMockObject.new(:job_template_name => job_template.name)
+    root[:miq_provision] = svc_provision
+    service = Spec::Support::MiqAeMockService.new(root)
+    service.object = root
+    expect(job_class).to receive(:create_job).once.with(anything, job_args).and_return(svc_job)
+    described_class.new(service).main
+    expect(service.get_state_var(:ansible_job_id)).to eq(job.id)
+  end
 end


### PR DESCRIPTION
This is helpful for VMs provisioned via a build_vm_provision_request where only standard options can be passed through.