### PR TITLE
Removing dependecy on the spec helper file from the main repo

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
---require manageiq/spec/spec_helper
 --require spec_helper
 --color
 --order random

--- a/.rspec_ci
+++ b/.rspec_ci
@@ -1,4 +1,3 @@
---require manageiq/spec/spec_helper
 --require spec_helper
 --color
 --order random


### PR DESCRIPTION
Removing the requirement for the `spec_helper` file from the manageiq repository.

Fixes #6 