### PR TITLE
Use the Ems last_inventory_date for ReconfigVM

### DIFF
--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.rb
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/check_refreshed.rb
@@ -17,37 +17,21 @@ module ManageIQ
               end
 
               def main
-                check_status(refresh_task)
-              end
-
-              private
-
-              def check_status(task)
-                case task.state
-                when STATE_FINISHED
-                  if task.status == STATUS_OK
-                    @handle.root['ae_result'] = 'ok'
-                  else
-                    @handle.root['ae_result'] = 'error'
-                    @handle.log(:error, "Refresh task ended with error: #{task.message}")
-                  end
+                if event.ext_management_system.last_inventory_date >= event.timestamp
+                  @handle.root['ae_result'] = 'ok'
                 else
                   @handle.root['ae_result'] = 'retry'
                   @handle.root['ae_retry_interval'] = '1.minute'
                 end
               end
 
-              def refresh_task
-                task_id = @handle.get_state_var(:refresh_task_id).first
-                @handle.log(:info, "Stored refresh task ID: [#{task_id}]")
-                fetch_task(task_id)
-              end
+              private
 
-              def fetch_task(task_id)
-                @handle.vmdb(:miq_task).find_by(:id => task_id).tap do |task|
-                  if task.nil?
-                    @handle.log(:error, "Refresh task with id: #{task_id} not found")
-                    raise "Refresh task with id: #{task_id} not found"
+              def event
+                @handle.root["event_stream"].tap do |event|
+                  if event.nil?
+                    @handle.log(:error, 'Event object is nil')
+                    raise 'Event object not found'
                   end
                 end
               end

--- a/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.rb
+++ b/content/automate/ManageIQ/System/Event/StateMachines/Refresh.class/__methods__/target_refresh.rb
@@ -16,9 +16,7 @@ module ManageIQ
               end
 
               def main
-                task_id = event.refresh(refresh_target, true)
-                raise "Refresh task not created" if task_id.blank?
-                @handle.set_state_var(:refresh_task_id, task_id)
+                event.refresh(refresh_target, false)
               end
 
               private


### PR DESCRIPTION
Instead of using a task to wait for a refresh to finish, check the EMS's
last_inventory_date which mark the date when the inventory was
collected.

This lets us check if the inventory in the DB includes the changes which
an Event is being processed for.

This is important because streaming refresh doesn't use the typical
EmsRefresh.refresh workflow and so no task gets created.

Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/388