### PR TITLE
Fix Service Retirement requests leaving the Service as 'retiring'.

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -20,6 +20,12 @@ if service.retiring?
   exit MIQ_ABORT
 end
 
+unless $evm.root['service_retire_task']
+  $evm.log(:error, "Service retire task not found")
+  $evm.log(:error, "The old style retirement is incompatible with the new retirement state machine.")
+  exit(MIQ_ABORT)
+end
+
 $evm.create_notification(:type => :service_retiring, :subject => service)
 service.start_retirement
 

--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
@@ -16,7 +16,7 @@ module ManageIQ
 
                 if @handle.root['ae_result'] == "error"
                   @handle.create_notification(:level   => "error",
-                                              :subject => task.miq_request,
+                                              :subject => task.try(:miq_request),
                                               :message => "Service Retire Error: #{updated_message}")
                   @handle.log(:error, "Service Retire Error: #{updated_message}")
                 end


### PR DESCRIPTION
This will fix the problem when someone uses the older api call and leaves the service in a 'retiring' state.
If there is no task, the process is aborted and the state is 'initializing'.

This will allow the retirement process will start again instead of being denied because the state is 'retiring'

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1698480

@miq-bot add_label bug
@miq-bot assign @tinaafitz

Start_retirement is an old style method with no spec. I don't think it makes sense to build an old style spec for the old method. I would like to followup this PR with a PR that refactors the method and I will build a spec for that.