### PR TITLE
Change refresh target to src_vm_or_dest_host for DrsMigrateVM_Task_Complete

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/drsmigratevm_task_complete.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/EVM.class/drsmigratevm_task_complete.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=src_vm"
+      value: "/System/event_handlers/event_action_refresh?target=src_vm_or_dest_host"


### PR DESCRIPTION
If the VM was migrated off of the host before refresh adds the VM to the database then the src_vm target for this "/System/event_handlers/event_action_refresh?target=src_vm" won't work.
We need to refresh the dest_host.

Depends on https://github.com/ManageIQ/manageiq/pull/18715.

https://bugzilla.redhat.com/show_bug.cgi?id=1696889

@miq-bot add_label bug, hammer/yes, changelog/yes