### PR TITLE
VM Retirement Request - clear values from vmretire_request_starting instance.

### DIFF
--- a/content/automate/ManageIQ/System/Policy.class/vmretirerequest_starting.yaml
+++ b/content/automate/ManageIQ/System/Policy.class/vmretirerequest_starting.yaml
@@ -7,8 +7,4 @@ object:
     name: VmRetireRequest_starting
     inherits: 
     description: 
-  fields:
-  - rel4:
-      value: "/System/Process/parse_provider_category"
-  - rel5:
-      value: "/${/#ae_provider_category}/VM/Lifecycle/Retirement?vm_id=${process#vm_id} "
+  fields: []


### PR DESCRIPTION
This instance used to call into automate to initiate retirement.
With retirement as a request, retirement is initiated when the tasks are
created. We need to clear the values of this instance because the
request task processing will create the request tasks only if the
request_starting event succeeds.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1706208
Also requires: https://github.com/ManageIQ/manageiq/pull/18738