### PR TITLE
ignore .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/manageiq
 /spec/reports/
 /tmp/
+/.idea/


### PR DESCRIPTION
Ignore the .idea directory used by RubyMine. This is already in the .gitignore for the manageiq repo (and probably others).