### PR TITLE
Support handling of special passwords like provision dialogs

### DIFF
--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -46,6 +46,14 @@ def add_password_value(sequence, option_key, value, options_hash)
   prefixed_option_key = 'password::dialog_' + option_key
   add_hash_value(sequence, stripped_option_key.to_sym, value, options_hash)
   add_hash_value(sequence, prefixed_option_key.to_sym, value, options_hash)
+
+  if special_password?(option_key.to_sym)
+    add_hash_value(sequence, option_key.to_sym, value, options_hash)
+  end
+end
+
+def special_password?(option_key)
+  [:root_password, :sysprep_password, :sysprep_domain_password, :sysprep_admin_password].include?(option_key) ? true : false
 end
 
 def option_hash_value(dialog_key, dialog_value, options_hash)

--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -1,3 +1,4 @@
+SPECIAL_PASSWORD_FIELDS = [:root_password, :sysprep_password, :sysprep_domain_password, :sysprep_admin_password].freeze
 
 def vmdb_object_from_array_entry(entry)
   model, id = entry.split("::")
@@ -53,7 +54,7 @@ def add_password_value(sequence, option_key, value, options_hash)
 end
 
 def special_password?(option_key)
-  [:root_password, :sysprep_password, :sysprep_domain_password, :sysprep_admin_password].include?(option_key) ? true : false
+  SPECIAL_PASSWORD_FIELDS.include?(option_key) ? true : false
 end
 
 def option_hash_value(dialog_key, dialog_value, options_hash)

--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -1,4 +1,4 @@
-SPECIAL_PASSWORD_FIELDS = [:root_password, :sysprep_password, :sysprep_domain_password, :sysprep_admin_password].freeze
+PROVISION_DIALOG_PASSWORD_FIELDS = [:root_password, :sysprep_password, :sysprep_domain_password, :sysprep_admin_password].freeze
 
 def vmdb_object_from_array_entry(entry)
   model, id = entry.split("::")
@@ -48,13 +48,13 @@ def add_password_value(sequence, option_key, value, options_hash)
   add_hash_value(sequence, stripped_option_key.to_sym, value, options_hash)
   add_hash_value(sequence, prefixed_option_key.to_sym, value, options_hash)
 
-  if special_password?(option_key.to_sym)
+  if provision_dialog_password?(option_key.to_sym)
     add_hash_value(sequence, option_key.to_sym, value, options_hash)
   end
 end
 
-def special_password?(option_key)
-  SPECIAL_PASSWORD_FIELDS.include?(option_key) ? true : false
+def provision_dialog_password?(option_key)
+  PROVISION_DIALOG_PASSWORD_FIELDS.include?(option_key) ? true : false
 end
 
 def option_hash_value(dialog_key, dialog_value, options_hash)

--- a/spec/automation/unit/method_validation/dialog_parser_spec.rb
+++ b/spec/automation/unit/method_validation/dialog_parser_spec.rb
@@ -104,6 +104,17 @@ describe "DialogParser Automate Method" do
       expect(pdo).to eql(parsed_dialog_options_hash)
     end
 
+    it "with provisioing dialog password" do
+      dialog_hash = {'password::dialog_root_password' => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}
+      parsed_dialog_options_hash = {0 => {:"password::dialog_root_password" => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}",
+                                          :"password::root_password"        => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}",
+                                          :root_password                    => "v2:{i7uvqmb1Dr6WAxCpakNE9w==}"}}
+      setup_and_run_method(dialog_hash)
+      pdo = load_options
+
+      expect(pdo).to eql(parsed_dialog_options_hash)
+    end
+
     it "with no dialogs set" do
       @root_stp.options = @root_stp.options.merge(:dialog => {})
       @root_stp.save


### PR DESCRIPTION
Lifecycle Provisioning has four password fields that end up in the options hash of the provision request (https://github.com/ManageIQ/manageiq-ui-classic/blob/c8a72415ca7b15602745015c6a7e808c7535c3b6/app/views/miq_request/_prov_field.html.haml#L97). This allows the OOTB customization templates to be used effectively.

Before this change service provisioning did not add the encrypted password to the expected fields. (Note: this is the case when the service dialog text box field has the **Protected** attribute enabled). This has an effect of causing the OOTB customization templates to not function when they are referencing the password fields. An example of this is using the **Basic root pass template** which without this change will cause the root password to be set to an empty string.

This PR add handling for these four special password fields that can be passed in from a Service Dialog.

Options Hash Before:

```
{
 ...
 :sysprep_admin_password=>nil,
 ...
 :sysprep_domain_password=>nil,
 ...
 :root_password=>nil,
 ...
 :"password::root_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_root_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::sysprep_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_sysprep_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::sysprep_domain_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_sysprep_domain_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::sysprep_admin_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_sysprep_admin_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::user_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_user_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 ...
}
```

Options Hash After:

```
{
 ...
 :sysprep_admin_password=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 ...
 :sysprep_domain_password=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 ...
 :root_password=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 ...
 :"password::root_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_root_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::sysprep_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_sysprep_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :sysprep_password=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::sysprep_domain_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_sysprep_domain_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::sysprep_admin_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_sysprep_admin_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::user_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 :"password::dialog_user_password"=>"v2:{Fp1+1YhW5ssIaA+a7P7v1w==}",
 ...
}
```