### PR TITLE
Bug 1721417: ManageIQ | Infrastructure | Retire of retired VM - finis…

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
@@ -4,6 +4,6 @@
 
 vm = $evm.root['vm']
 if vm && !vm.retired?
- vm.finish_retirement
- $evm.create_notification(:type => :vm_retired, :subject => vm)
+  vm.finish_retirement
+  $evm.create_notification(:type => :vm_retired, :subject => vm)
 end

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/finish_retirement.rb
@@ -3,5 +3,7 @@
 #
 
 vm = $evm.root['vm']
-vm.finish_retirement if vm
-$evm.create_notification(:type => :vm_retired, :subject => vm) if vm
+if vm && !vm.retired?
+ vm.finish_retirement
+ $evm.create_notification(:type => :vm_retired, :subject => vm)
+end


### PR DESCRIPTION
In case of VM has been retired earlier and method /ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods/finish_retirement end up with and Error messages into automation.log that VM is already retired