### PR TITLE
Fix check_reconfigured ae_result to prevent retry loop and failure.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured.rb
@@ -88,8 +88,10 @@ module ManageIQ
                   @handle.log("info", "Check refresh status of stack (#{service.stack_name})")
 
                   if refresh_may_have_completed?(service)
-                    @handle.root['ae_result'] = @handle.get_state_var('update_result')
-                    @handle.root['ae_reason'] = @handle.get_state_var('update_reason')
+                    @handle.root['ae_result'] = 'ok'
+                    @handle.root['ae_reason'] = ''
+                    @handle.set_state_var('update_result', @handle.root['ae_result'])
+                    @handle.set_state_var('update_reason', @handle.root['ae_reason'])
                   else
                     @handle.root['ae_result']         = 'retry'
                     @handle.root['ae_retry_interval'] = '30.seconds'

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/check_reconfigured_spec.rb
@@ -43,8 +43,8 @@ describe ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachine
   end
 
   context "with a service" do
-    let(:update_result) { 'ae_result' }
-    let(:update_reason) { 'ae_reason' }
+    let(:update_result) { 'ok' }
+    let(:update_reason) { '' }
 
     before do
       allow(svc_model_service_reconfigure_task).to receive(:source).and_return(svc_model_service)
@@ -57,7 +57,6 @@ describe ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachine
         ae_service.set_state_var('update_result', update_result)
         ae_service.set_state_var('update_reason', update_reason)
 
-        expect(svc_model_service_reconfigure_task).to receive(:user_message=).with(update_reason)
         described_class.new(ae_service).main
         expect(ae_service.root['ae_result']).to eq(update_result)
         expect(ae_service.root['ae_reason']).to eq(update_reason)
@@ -95,7 +94,6 @@ describe ManageIQ::Automate::Cloud::Orchestration::Reconfiguration::StateMachine
         allow(svc_model_service).to receive(:orchestration_stack_status)
           .and_return(['rollback_complete', update_reason])
 
-        expect(svc_model_service_reconfigure_task).to receive(:user_message=).with(update_reason)
         described_class.new(ae_service).main
         expect(ae_service.get_state_var('update_result')).to eq('error')
         expect(ae_service.get_state_var('update_reason')).to eq(update_reason)


### PR DESCRIPTION
Reset ae_reason and ae_result in check_refreshed when refresh_may_have_completed is true.

The update_result and update_reason state_vars contained the
previous values.  The state_var update_result
value was still set to retry from the previous execution which caused
the state machine to retry instead of proceeding to the next state.
It had an additional side affect in that the retry was set with no retry
interval which caused the state machine to retry immediately instead of
waiting the usual 1 minute time interval.

Resetting those values enabled the state machine to progress to the next
state and complete successfully.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1720212