### PR TITLE
manageiq-core.manageiq-automate Wrap all values in quotes

### DIFF
--- a/content/ansible/roles/manageiq-core.manageiq-automate/library/manageiq_automate.py
+++ b/content/ansible/roles/manageiq-core.manageiq-automate/library/manageiq_automate.py
@@ -110,10 +110,16 @@ class ManageIQAutomate(object):
     def exists(self, path):
         """
             Validate all passed objects before attempting to set or get values from them
+
+            Wrap all reduced values in quotes so the bool() method will not
+            return a False on falsey values
         """
         list_path = path.split("|")
+        str = None
         try:
-            return bool(reduce(operator.getitem, list_path, self._target))
+            reduced_str = reduce(operator.getitem, list_path, self._target)
+            str = "%s" % (reduced_str)
+            return bool(str)
         except KeyError as error:
             return False
 


### PR DESCRIPTION
Reworks the exists() method to wrap all values in quotes so
the bool() method will not interpret the values as false.

This change brings the shipped role / module in line with release 0.1.1 on [Galaxy](https://galaxy.ansible.com/syncrou/manageiq-automate)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1730311

