### PR TITLE
[Transformation][AnsiblePlaybook] Send service_template credential id as part of service dialog

### DIFF
--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -27,7 +27,10 @@ module ManageIQ
             return if service_template.nil?
             target_host = target_host(task, transformation_hook)
             return if target_host.blank?
-            service_dialog_options = { :hosts => target_host.ipaddresses.first }
+            service_dialog_options = {
+              :credential => service_template.options[:config_info][:provision][:credential_id],
+              :hosts => target_host.ipaddresses.first
+            }
             service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
             task.set_option("#{transformation_hook}_ansible_playbook_service_request_id".to_sym, service_request.id)
           rescue => e

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -29,7 +29,7 @@ module ManageIQ
             return if target_host.blank?
             service_dialog_options = {
               :credential => service_template.options[:config_info][:provision][:credential_id],
-              :hosts => target_host.ipaddresses.first
+              :hosts      => target_host.ipaddresses.first
             }
             service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
             task.set_option("#{transformation_hook}_ansible_playbook_service_request_id".to_sym, service_request.id)

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -28,7 +28,7 @@ module ManageIQ
             target_host = target_host(task, transformation_hook)
             return if target_host.blank?
             service_dialog_options = {
-              :credential => service_template.options[:config_info][:provision][:credential_id],
+              :credential => service_template.config_info[:provision][:credential_id],
               :hosts      => target_host.ipaddresses.first
             }
             service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)

--- a/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
@@ -42,7 +42,7 @@ describe ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService d
           :credential_id => credential.id
         }
       }
-     }
+    }
   end
 
   let(:service_template_ansible_playbook_pre) { ServiceTemplateAnsiblePlaybook.create_catalog_item(ansible_playbook_pre_catalog_item_options, user) }
@@ -65,7 +65,7 @@ describe ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService d
       :config_info => {
         :transformation_mapping_id => mapping.id,
         :pre_service_id            => service_template_ansible_playbook_pre.id,
-        :post_service_id            => service_template_ansible_playbook_post.id,
+        :post_service_id           => service_template_ansible_playbook_post.id,
         :actions                   => [
           {:vm_id => src_vm_vmware.id.to_s, :pre_service => true, :post_service => true}
         ],
@@ -125,7 +125,7 @@ describe ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService d
     it "creates a service provision request and store the request id in task" do
       service_dialog_options = {
         :credential => credential.id,
-        :hosts => "10.0.0.1"
+        :hosts      => "10.0.0.1"
       }
       expect(ae_service).to receive(:execute).with(:create_service_provision_request, same_class_and_id(svc_model_service_template_ansible_playbook_pre), service_dialog_options)
       described_class.new(ae_service).main

--- a/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
@@ -1,0 +1,135 @@
+require_domain_file
+
+RSpec::Matchers.define :same_class_and_id do |obj|
+  match { |actual| actual.class == obj.class && actual.id == obj.id }
+end
+
+describe ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService do
+  let(:user) { FactoryBot.create(:user_with_email_and_group) }
+  let(:group) { FactoryBot.create(:miq_group) }
+  let(:ems_vmware) { FactoryBot.create(:ems_vmware) }
+  let(:ems_redhat) { FactoryBot.create(:ems_redhat) }
+  let(:src_cluster_vmware) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
+  let(:dst_cluster_redhat) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
+
+  let(:src_lan) { FactoryBot.create(:lan) }
+  let(:src_nic) { FactoryBot.create(:guest_device_nic, :lan => src_lan, :network => src_network) }
+  let(:src_network) { FactoryBot.create(:network, :ipaddress => '10.0.0.1') }
+  let(:src_hardware) { FactoryBot.create(:hardware, :nics => [src_nic], :networks => [src_network]) }
+
+  let(:src_vm_vmware) { FactoryBot.create(:vm_vmware, :ext_management_system => ems_vmware, :ems_cluster => src_cluster_vmware, :hardware => src_hardware) }
+  let(:dst_vm_redhat) { FactoryBot.create(:vm_redhat, :ext_management_system => ems_redhat, :ems_cluster => dst_cluster_redhat) }
+
+  let(:credential) { FactoryBot.create(:ansible_machine_credential) }
+  let(:ansible_playbook_pre_catalog_item_options) do
+    {
+      :name        => 'Pre-migration playbook',
+      :description => 'Pre-migration playbook',
+      :config_info => {
+        :provision => {
+          :credential_id => credential.id
+        }
+      }
+    }
+  end
+
+  let(:ansible_playbook_post_catalog_item_options) do
+    {
+      :name        => 'Post-migration playbook',
+      :description => 'Post-migration playbook',
+      :config_info => {
+        :provision => {
+          :credential_id => credential.id
+        }
+      }
+     }
+  end
+
+  let(:service_template_ansible_playbook_pre) { ServiceTemplateAnsiblePlaybook.create_catalog_item(ansible_playbook_pre_catalog_item_options, user) }
+  let(:service_template_ansible_playbook_post) { ServiceTemplateAnsiblePlaybook.create_catalog_item(ansible_playbook_post_catalog_item_options, user) }
+  let(:ansible_playbook_pre_service_request) { FactoryBot.create(:service_template_provision_request, :source => service_template_ansible_playbook_pre) }
+
+  let(:mapping) do
+    FactoryBot.create(
+      :transformation_mapping,
+      :transformation_mapping_items => [
+        FactoryBot.create(:transformation_mapping_item, :source => src_cluster_vmware, :destination => dst_cluster_redhat)
+      ]
+    )
+  end
+
+  let(:plan_catalog_item_options) do
+    {
+      :name        => 'Transformation Plan',
+      :description => 'a description',
+      :config_info => {
+        :transformation_mapping_id => mapping.id,
+        :pre_service_id            => service_template_ansible_playbook_pre.id,
+        :post_service_id            => service_template_ansible_playbook_post.id,
+        :actions                   => [
+          {:vm_id => src_vm_vmware.id.to_s, :pre_service => true, :post_service => true}
+        ],
+      }
+    }
+  end
+
+  let(:transformation_plan) { ServiceTemplateTransformationPlan.create_catalog_item(plan_catalog_item_options) }
+  let(:transformation_plan_request) { FactoryBot.create(:service_template_transformation_plan_request, :source => transformation_plan) }
+  let(:transformation_plan_task) { FactoryBot.create(:service_template_transformation_plan_task, :source => src_vm_vmware, :miq_request => transformation_plan_request) }
+
+  let(:svc_model_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
+  let(:svc_model_group) { MiqAeMethodService::MiqAeServiceMiqGroup.find(group.id) }
+  let(:svc_model_src_nic) { MiqAeMethodService::MiqAeServiceGuestDevice.find(src_nic.id) }
+  let(:svc_model_src_network) { MiqAeMethodService::MiqAeServiceNetwork.find(src_network.id) }
+  let(:svc_model_src_vm_vmware) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(src_vm_vmware.id) }
+  let(:svc_model_dst_vm_redhat) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager_Vm.find(dst_vm_redhat.id) }
+  let(:svc_model_transformation_plan_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(transformation_plan_task.id) }
+  let(:svc_model_service_template_ansible_playbook_pre) { MiqAeMethodService::MiqAeServiceServiceTemplateAnsiblePlaybook.find(service_template_ansible_playbook_pre.id) }
+  let(:svc_model_ansible_playbook_pre_service_request) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest.find(ansible_playbook_pre_service_request.id) }
+
+  let(:root) do
+    Spec::Support::MiqAeMockObject.new(
+      'current'                                   => current_object,
+      'user'                                      => svc_model_user,
+      'service_template_transformation_plan_task' => svc_model_transformation_plan_task,
+      'state_machine_phase'                       => 'transformation'
+    )
+  end
+
+  let(:current_object) { Spec::Support::MiqAeMockObject.new }
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root
+      service.object = current_object
+    end
+  end
+
+  before do
+    allow(ae_service).to receive(:execute).and_return(svc_model_ansible_playbook_pre_service_request)
+    allow(ae_service).to receive(:inputs).and_return('transformation_hook' => 'pre')
+    svc_model_transformation_plan_task.set_option(:destination_vm_id, dst_vm_redhat.id)
+  end
+
+  describe "target_host" do
+    it "returns source vm for pre migration" do
+      expect(described_class.new(ae_service).target_host(svc_model_transformation_plan_task, "pre").id).to eq(svc_model_src_vm_vmware.id)
+    end
+
+    it "returns destination vm for post migration" do
+      expect(described_class.new(ae_service).target_host(svc_model_transformation_plan_task, "post").id).to eq(svc_model_dst_vm_redhat.id)
+    end
+  end
+
+  describe "main" do
+    it "creates a service provision request and store the request id in task" do
+      service_dialog_options = {
+        :credential => credential.id,
+        :hosts => "10.0.0.1"
+      }
+      expect(ae_service).to receive(:execute).with(:create_service_provision_request, same_class_and_id(svc_model_service_template_ansible_playbook_pre), service_dialog_options)
+      described_class.new(ae_service).main
+      expect(svc_model_transformation_plan_task.options[:pre_ansible_playbook_service_request_id]).to eq(svc_model_ansible_playbook_pre_service_request.id)
+    end
+  end
+end

--- a/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
@@ -1,9 +1,5 @@
 require_domain_file
 
-RSpec::Matchers.define :same_class_and_id do |obj|
-  match { |actual| actual.class == obj.class && actual.id == obj.id }
-end
-
 describe ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService do
   let(:user) { FactoryBot.create(:user_with_email_and_group) }
   let(:group) { FactoryBot.create(:miq_group) }
@@ -127,7 +123,7 @@ describe ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService d
         :credential => credential.id,
         :hosts      => "10.0.0.1"
       }
-      expect(ae_service).to receive(:execute).with(:create_service_provision_request, same_class_and_id(svc_model_service_template_ansible_playbook_pre), service_dialog_options)
+      expect(ae_service).to receive(:execute).with(:create_service_provision_request, svc_model_service_template_ansible_playbook_pre, service_dialog_options)
       described_class.new(ae_service).main
       expect(svc_model_transformation_plan_task.options[:pre_ansible_playbook_service_request_id]).to eq(svc_model_ansible_playbook_pre_service_request.id)
     end


### PR DESCRIPTION
With Ivanchuk, we identified that the method Transformation/Ansible/LaunchPlaybookAsAService doesn't generate the right service dialog when ordering the Ansible Playbook service template. The initial behavior is to not pass the `credential` field, leading to a nil entry. We discovered that it's now translated into an empty string. Then the credential is not passed to Ansible Runner and the playbook fails to connect to the hosts.

This PR changes the method to include the credential id stored in service template options in the dialog fields. This ensures that the correct credential is picked and passed to Ansible Runner. The behavior has been tested on a live environment and the password is visible in `/tmp/ansible-runner*/env/passwords` file, as expected.

Fixes RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1739247
Depends on: https://github.com/ManageIQ/manageiq-automation_engine/pull/348