### PR TITLE
V2v wait for ip ansible playbook launch

### DIFF
--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -5,34 +5,43 @@ module ManageIQ
         class LaunchPlaybookAsAService
           def initialize(handle = $evm)
             @handle = handle
+            @task = ManageIQ::Automate::Transformation::Common::Utils.task
+            @transformation_hook = @handle.inputs['transformation_hook']
           end
 
-          def target_host(task, transformation_hook)
-            target_host = nil
-            case transformation_hook
+          def target_host
+            case @transformation_hook
             when 'pre'
-              target_host = task.source
+              @target_host ||= ManageIQ::Automate::Transformation::Common::Utils.source_vm
             when 'post'
-              target_host = @handle.vmdb(:vm).find_by(:id => task.get_option(:destination_vm_id))
+              @target_host ||= ManageIQ::Automate::Transformation::Common::Utils.destination_vm
             end
-            target_host
+          end
+
+          def set_retry
+            target_host.refresh
+            @handle.root['ae_result'] = 'retry'
+            @handle.root['ae_retry_interval'] = '15.seconds'
+          end
+
+          def ipaddress_available
+            ipaddr = target_host.ipaddresses.first
+            set_retry if ipaddr.nil?
+            ipaddr.present?
           end
 
           def main
-            task = @handle.root['service_template_transformation_plan_task']
-            transformation_hook = @handle.inputs['transformation_hook']
-
-            return if transformation_hook == '_'
-            service_template = task.send("#{transformation_hook}_ansible_playbook_service_template")
+            return if @transformation_hook == '_'
+            service_template = @task.send("#{@transformation_hook}_ansible_playbook_service_template")
             return if service_template.nil?
-            target_host = target_host(task, transformation_hook)
             return if target_host.blank?
+            return unless ipaddress_available
             service_dialog_options = {
               :credential => service_template.config_info[:provision][:credential_id],
               :hosts      => target_host.ipaddresses.first
             }
             service_request = @handle.execute(:create_service_provision_request, service_template, service_dialog_options)
-            task.set_option("#{transformation_hook}_ansible_playbook_service_request_id".to_sym, service_request.id)
+            @task.set_option("#{@transformation_hook}_ansible_playbook_service_request_id".to_sym, service_request.id)
           rescue => e
             @handle.set_state_var(:ae_state_progress, 'message' => e.message)
             raise

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.rb
@@ -32,10 +32,12 @@ module ManageIQ
 
           def main
             return if @transformation_hook == '_'
+
             service_template = @task.send("#{@transformation_hook}_ansible_playbook_service_template")
             return if service_template.nil?
             return if target_host.blank?
             return unless ipaddress_available
+
             service_dialog_options = {
               :credential => service_template.config_info[:provision][:credential_id],
               :hosts      => target_host.ipaddresses.first

--- a/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.yaml
+++ b/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice.yaml
@@ -9,6 +9,8 @@ object:
     scope: instance
     language: ruby
     location: inline
+    embedded_methods:
+    - "/Transformation/Common/Utils"
     options: {}
   inputs:
   - field:

--- a/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
+++ b/content/automate/ManageIQ/Transformation/StateMachines/Ansible.class/transformationplaybook.yaml
@@ -16,6 +16,7 @@ object:
         => "Launch ${#transformation_hook} migration playbook", task_message => "Migrating")
       on_error: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 20, description
         => "Launch ${#transformation_hook} migration playbook", task_message => "Migrating")
+      max_retries: '60'
   - State5:
       value: "/Transformation/Ansible/CheckPlaybookAsAService?transformation_hook=${#transformation_hook}"
       on_entry: /System/CommonMethods/MiqAe.WeightedUpdateStatus(weight => 80, description

--- a/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Ansible.class/__methods__/launchplaybookasaservice_spec.rb
@@ -86,9 +86,9 @@ describe ManageIQ::Automate::Transformation::Ansible::LaunchPlaybookAsAService d
 
   let(:root) do
     Spec::Support::MiqAeMockObject.new(
-      'current'                                   => current_object,
-      'user'                                      => svc_model_user,
-      'state_machine_phase'                       => 'transformation'
+      'current'             => current_object,
+      'user'                => svc_model_user,
+      'state_machine_phase' => 'transformation'
     )
   end
 


### PR DESCRIPTION
The method `/Transformation/Ansible/LaunchPlaybookAsAService` doesn't check if the IP address of the VM is present in the inventory. For post-migration, the IP address can take some time to appear once the VM is started: the oVirt agent needs to collect it, then ManageIQ needs to refresh its inventory.

If the IP address isn't present, the Ansible Playbook service template will use its default, i.e. localhost. The consequence is that the playbook is run with the ManageIQ appliance as only host in the inventory. Depending on the playbook tasks, this could irremediably break the appliance.

This pull request adds a check on the IP address presence and allows to retry after a refresh on the VM. It also sets `max_retries` to 60 on the state, meaning a 15 minutes period with 15 seconds retry interval. This should be enough for the agent to display the VM and for the refresh to finish.

Fixes RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1739487
Built on #559 