### PR TITLE
[V2V] Remove check of task.options[:collapse_snapshots]

### DIFF
--- a/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/collapsesnapshots.rb
+++ b/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/collapsesnapshots.rb
@@ -14,7 +14,6 @@ module ManageIQ
               def main
                 return unless @source_vm.vendor == 'vmware'
                 return if @source_vm.snapshots.empty?
-                raise "VM '#{@source_vm.name}' has snapshots, but we are not allowed to collapse them. Exiting." unless @task.get_option(:collapse_snapshots)
                 @source_vm.remove_all_snapshots
               rescue => e
                 @handle.set_state_var(:ae_state_progress, 'message' => e.message)


### PR DESCRIPTION
The method `/Transformation/Infrastructure/VM/Common/CollapseSnapshots` checks that task.options[:collapse_snapshots] is true. No code set this value so it will always fail if VM has snapshots.

This PR removes the check, because snapshot removal is mandatory.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1744563