### PR TITLE
Switch to call lookup_by_* methods

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names.rb
@@ -19,7 +19,7 @@ module ManageIQ
                   category_name = @handle.root['dialog_tag_category']
                   if category_name.present?
                     @handle.log(:info, "Selected tag category: #{category_name}")
-                    category = @handle.vmdb(:classification).find_by_name(category_name)
+                    category = @handle.vmdb(:classification).lookup_by_name(category_name)
                     unless category.nil?
                       category.entries.each do |tag|
                         values_hash[tag.name] = tag.description

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Transform/Import.class/__methods__/list_tag_names_spec.rb
@@ -33,7 +33,7 @@ describe ManageIQ::Automate::Infrastructure::VM::Transform::Import::ListTagNames
     expect(ae_service.object['visible']).to eq(true)
 
     tag_names = { nil => '<None>' }
-    Classification.find_by_name('department').entries.each do |tag|
+    Classification.lookup_by_name('department').entries.each do |tag|
       tag_names[tag.name] = tag.description
     end
 


### PR DESCRIPTION
The find_by_* methods defined in manageiq repo has conflicts with
rails dynamic finding and now they have been changed to lookup_by_*.
Switching the callers in this repo to the lookup_by_* methods.

Depend on https://github.com/ManageIQ/manageiq/pull/19313, https://github.com/ManageIQ/manageiq-automation_engine/pull/373