### PR TITLE
[HAMMER] Add retry_interval to VMCheckTransformed

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/vmchecktransformed.rb
@@ -11,6 +11,7 @@ module ManageIQ
           def set_retry
             @handle.root['ae_result'] = 'retry'
             @handle.root['ae_retry_server_affinity'] = true
+            @handle.root['ae_retry_interval'] = '1.minutes'
             @handle.log(:info, "Disk transformation is not finished. Checking in #{@handle.root['ae_retry_interval']}")
           end
 


### PR DESCRIPTION
So far, we believed that the default retry interval in Automate was 1 minute, and experimentation tended to confirm this. Apparently, it's not the case, as we saw retries every ~4 seconds when no retry interval was specified. This leads to having a TTL for VMCheckTransformed state of about 1 hour and 40 minutes, instead of 25 hours. The consequence is that long migrations fail.

This PR adds a explicit retry interval to ensure that the TTL is effectively 25 hours.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1755632