### PR TITLE
Remove call to retire_service_resources from retire_service method

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/retire_service.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/retire_service.rb
@@ -1,5 +1,5 @@
 #
-# Description: This method attempts to retire all of the vms under this top level service
+# Description: Placeholder method for custom automation
 #
 
-$evm.root["service"].retire_service_resources
+# service = $evm.root["service"]


### PR DESCRIPTION
The method has been turned into a no-op method so removing the reference.

Continuing the work identified in https://github.com/ManageIQ/manageiq/pull/16933#discussion_r175805070
and started in https://github.com/ManageIQ/manageiq/pull/19413
which lead to https://github.com/ManageIQ/manageiq-automation_engine/pull/379
😓 

Will need to undo the damage I have done by reverting/closing the referenced PRs.  