### PR TITLE
Refactor delete_from_vmdb method for Infra VM Retirement.

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb.rb
@@ -1,11 +1,34 @@
 #
 # Description: This method removes the VM from the VMDB database
 #
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Retirement
+          module StateMachines
+            module Methods
+              class DeleteFromVmdb
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-vm = $evm.root['vm']
+                def main
+                  vm = @handle.root['vm']
 
-if vm && $evm.get_state_var('vm_removed_from_provider')
-  $evm.log('info', "Removing VM <#{vm.name}> from VMDB")
-  vm.remove_from_vmdb
-  $evm.root['vm'] = nil
+                  if vm && @handle.get_state_var('vm_removed_from_provider')
+                    @handle.log('info', "Removing VM <#{vm.name}> from VMDB")
+                    vm.remove_from_vmdb
+                    @handle.root['vm'] = nil
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end
+
+ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::Methods::DeleteFromVmdb.new.main

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/delete_from_vmdb_spec.rb
@@ -1,0 +1,37 @@
+require_domain_file
+
+describe ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::Methods::DeleteFromVmdb do
+  let(:svc_vm)      { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+  let(:ems)         { FactoryBot.create(:ems_vmware) }
+  let(:vm)          { FactoryBot.create(:vm_vmware, :ems_id => ems.id) }
+  let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+  let(:root_hash)   { { 'vm' => svc_vm } }
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it 'removes vm from vmdb' do
+    ae_service.set_state_var('vm_removed_from_provider', true)
+    expect(svc_vm).to(receive(:remove_from_vmdb))
+    described_class.new(ae_service).main
+  end
+
+  context 'does not remove vm from vmdb' do
+    it '#nil vm' do
+      root_hash['vm'] = nil
+      expect(ae_service).not_to(receive(:log))
+      described_class.new(ae_service).main
+    end
+
+    it '#without vm_removed_from_provider state_var' do
+      expect(svc_vm).not_to(receive(:remove_from_provider))
+      expect(ae_service).not_to(receive(:log))
+      described_class.new(ae_service).main
+    end
+  end
+end


### PR DESCRIPTION
This PR is based on the issue below.
ManageIQ/manageiq#12038

@miq-bot add_label refactoring
@miq-bot assign @tinaafitz