### PR TITLE
Refactor delete_service_from_vmdb method for Service Retirement.

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/delete_service_from_vmdb.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/delete_service_from_vmdb.rb
@@ -2,10 +2,31 @@
 # Description: This method removes the Service from the VMDB database
 #
 
-service = $evm.root['service']
+module ManageIQ
+  module Automate
+    module Service
+      module Retirement
+        module StateMachines
+          module Methods
+            class DeleteServiceFromVmdb
+              def initialize(handle = $evm)
+                @handle = handle
+              end
 
-if service
-  $evm.log('info', "Deleting Service <#{service.name}> from VMDB")
-  service.remove_from_vmdb
-  $evm.root['service'] = nil
+              def main
+                service = @handle.root['service']
+                if service
+                  @handle.log('info', "Deleting Service <#{service.name}> from VMDB")
+                  service.remove_from_vmdb
+                  @handle.root['service'] = nil
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end
+
+ManageIQ::Automate::Service::Retirement::StateMachines::Methods::DeleteServiceFromVmdb.new.main

--- a/spec/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/delete_service_from_vmdb_spec.rb
+++ b/spec/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/delete_service_from_vmdb_spec.rb
@@ -1,0 +1,29 @@
+require_domain_file
+
+describe ManageIQ::Automate::Service::Retirement::StateMachines::Methods::DeleteServiceFromVmdb do
+  let(:admin) { FactoryBot.create(:user_admin) }
+  let(:request) { FactoryBot.create(:service_retire_request, :requester => admin) }
+  let(:service) { FactoryBot.create(:service) }
+  let(:task) { FactoryBot.create(:service_retire_task, :destination => service, :miq_request => request) }
+  let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceRetireTask.find(task.id) }
+  let(:svc_service) { MiqAeMethodService::MiqAeServiceService.find(service.id) }
+  let(:root_object) do
+    Spec::Support::MiqAeMockObject.new('service'             => svc_service,
+                                       'service_retire_task' => svc_task,
+                                       'service_action'      => 'Retirement')
+  end
+  let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
+
+  it 'removes service from vmdb' do
+    expect(ae_service).to(receive(:log))
+    expect(svc_service).to(receive(:remove_from_vmdb))
+    described_class.new(ae_service).main
+  end
+
+  it 'without service' do
+    ae_service.root['service'] = nil
+    expect(svc_service).not_to(receive(:remove_from_provider))
+    expect(ae_service).not_to(receive(:log))
+    described_class.new(ae_service).main
+  end
+end


### PR DESCRIPTION
This PR is based on the issue below.
ManageIQ/manageiq#12038

@miq-bot add_label refactoring
@miq-bot assign @tinaafitz