### PR TITLE
Save automate timeout value for service.execute step into service's options hash

### DIFF
--- a/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/execute.rb
+++ b/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/execute.rb
@@ -16,6 +16,7 @@ module ManageIQ
                 @handle.log("info", "Starting execute")
 
                 begin
+                  service.set_automate_timeout(@handle.field_timeout, service_action)
                   service.execute(service_action)
                   @handle.root['ae_result'] = 'ok'
                   @handle.log("info", "Ending execute")

--- a/spec/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/execute_spec.rb
+++ b/spec/content/automate/ManageIQ/Service/Generic/StateMachines/GenericLifecycle.class/__methods__/execute_spec.rb
@@ -10,7 +10,7 @@ describe ManageIQ::Automate::Service::Generic::StateMachines::GenericLifecycle::
   let(:svc_task) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(task.id) }
   let(:svc_service) { MiqAeMethodService::MiqAeServiceServiceAnsibleTower.find(service_ansible_tower.id) }
   let(:root_object) { Spec::Support::MiqAeMockObject.new('service' => svc_service, 'service_action' => 'Provision') }
-  let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object) }
+  let(:ae_service) { Spec::Support::MiqAeMockService.new(root_object).tap { |s| allow(s).to receive(:field_timeout).and_return(8) } }
   let(:error_msg) { "failed" }
 
   shared_examples_for "execute_errors" do


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/19558.
Depends on https://github.com/ManageIQ/manageiq-automation_engine/pull/393.

https://bugzilla.redhat.com/show_bug.cgi?id=1781353

@miq-bot add_label enhancement, changelog/yes, services, embedded ansible