### PR TITLE
Add OpenStack SecurityGroupRule Events

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/security_group_rule.create.end.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/security_group_rule.create.end.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: security_group_rule.create.end
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/security_group_rule.delete.end.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/security_group_rule.delete.end.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: security_group_rule.delete.end
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/security_group_rule.update.end.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/security_group_rule.update.end.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: security_group_rule.update.end
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"


### PR DESCRIPTION
Security Group Rules from OpenStack are modelled as Firewall Rules in MIQ.
It is needed catch related events to trigger refresh.

Adding related types of events to automate.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1776365