### PR TITLE
Refactor start_retirement method for Cloud Orchestration Retirement.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -2,27 +2,60 @@
 # Description: This method sets the retirement_state to retiring
 #
 
-$evm.log("info", "Listing Root Object Attributes:")
-$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
-$evm.log("info", "===========================================")
+module ManageIQ
+  module Automate
+    module Cloud
+      module Orchestration
+        module Retirement
+          module StateMachines
+            module Methods
+              class StartRetirement
+                def initialize(handle = $evm)
+                  @handle = handle
+                end
 
-stack = $evm.root['orchestration_stack']
-if stack.nil?
-  $evm.log('error', "OrchestrationStack Object not found")
-  exit MIQ_ABORT
+                def main
+                  log_info
+                  start_retirement(stack)
+                end
+
+                private
+
+                def stack
+                  @handle.root["orchestration_stack"].tap do |stack|
+                    raise 'OrchestrationStack Object not found' if stack.nil?
+                  end
+                end
+
+                def stack_validation(stack)
+                  if stack.retired?
+                    raise 'Stack is already retired. Aborting current State Machine.'
+                  end
+                  if stack.retiring?
+                    raise 'Stack is in the process of being retired. Aborting current State Machine.'
+                  end
+                end
+
+                def log_info
+                  @handle.log("info", "Listing Root Object Attributes:")
+                  @handle.root.attributes.sort.each { |k, v| @handle.log("info", "\t#{k}: #{v}") }
+                  @handle.log("info", "===========================================")
+                end
+
+                def start_retirement(stack)
+                  stack_validation(stack)
+                  @handle.log('info', "Stack before start_retirement: #{stack.inspect} ")
+                  @handle.create_notification(:type => :vm_retiring, :subject => stack)
+
+                  stack.start_retirement
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end
 
-if stack.retired?
-  $evm.log('error', "Stack is already retired. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
-if stack.retiring?
-  $evm.log('error', "Stack is in the process of being retired. Aborting current State Machine.")
-  exit MIQ_ABORT
-end
-
-$evm.log('info', "Stack before start_retirement: #{stack.inspect} ")
-$evm.create_notification(:type => :vm_retiring, :subject => stack)
-
-stack.start_retirement
+ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::StartRetirement.new.main

--- a/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_retirement_spec.rb
@@ -13,25 +13,6 @@ describe "Orchestration retirement state machine Methods Validation" do
 
   let(:stack_in_provider) { true }
 
-  describe "#start_retirement" do
-    let(:method_name) { "StartRetirement" }
-
-    it "starts a retirement request" do
-      ws
-      expect(OrchestrationStack.where(:id => stack.id).first.retirement_state).to eq('retiring')
-    end
-
-    it "aborts if stack is already retired" do
-      stack.update(:retired => true)
-      expect { ws }.to raise_error(MiqAeException::AbortInstantiation, 'Method exited with rc=MIQ_ABORT')
-    end
-
-    it "aborts if stack is retiring" do
-      stack.update(:retirement_state => 'retiring')
-      expect { ws }.to raise_error(MiqAeException::AbortInstantiation, 'Method exited with rc=MIQ_ABORT')
-    end
-  end
-
   describe "#remove_from_provider" do
     let(:method_name) { "RemoveFromProvider" }
 

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement_spec.rb
@@ -1,0 +1,47 @@
+require_domain_file
+
+describe ManageIQ::Automate::Cloud::Orchestration::Retirement::StateMachines::Methods::StartRetirement do
+  let(:stack)                 { FactoryBot.create(:orchestration_stack_amazon) }
+  let(:service_orchestration) { FactoryBot.create(:service_orchestration) }
+  let(:svc_model_service)     { MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  let(:svc_model_stack)       { MiqAeMethodService::MiqAeServiceOrchestrationStack.find(stack.id) }
+
+  let(:root_hash) do
+    { 'service_template' => MiqAeMethodService::MiqAeServiceService.find(service_orchestration.id) }
+  end
+
+  let(:root_object) do
+    obj = Spec::Support::MiqAeMockObject.new(root_hash)
+    obj["orchestration_stack"] = svc_model_stack
+    obj
+  end
+
+  let(:ae_service) do
+    Spec::Support::MiqAeMockService.new(root_object).tap do |service|
+      current_object = Spec::Support::MiqAeMockObject.new
+      current_object.parent = root_object
+      service.object = current_object
+    end
+  end
+
+  it "without stack" do
+    ae_service.root['orchestration_stack'] = nil
+    expect { described_class.new(ae_service).main }.to raise_error('OrchestrationStack Object not found')
+  end
+
+  it "with retired stack" do
+    svc_model_stack.finish_retirement
+    expect { described_class.new(ae_service).main }.to raise_error('Stack is already retired. Aborting current State Machine.')
+  end
+
+  it "with retiring stack" do
+    svc_model_stack.start_retirement
+    expect { described_class.new(ae_service).main }.to raise_error('Stack is in the process of being retired. Aborting current State Machine.')
+  end
+
+  it "starts retirement" do
+    expect(ae_service).to receive(:create_notification).with(:type => :vm_retiring, :subject => svc_model_stack)
+    expect(svc_model_stack).to receive(:start_retirement)
+    expect { described_class.new(ae_service).main }.to_not raise_error
+  end
+end


### PR DESCRIPTION
This PR is based on the issue below.
ManageIQ/manageiq#12038

@miq-bot add_label refactoring
@miq-bot assign @tinaafitz