### PR TITLE
Use automate timeout when execution_ttl is not set for an orchestration service

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -17,6 +17,7 @@ module ManageIQ
 
                 task = @handle.root["service_template_provision_task"]
                 service = task.destination
+                service.set_automate_timeout(@handle.field_timeout, 'provision')
 
                 begin
                   stack = service.deploy_orchestration_stack

--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/reconfigure.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/reconfigure.rb
@@ -6,6 +6,7 @@ $evm.log("info", "Starting Orchestration Reconfiguration")
 
 task = $evm.root["service_reconfigure_task"]
 service = task.source
+service.set_automate_timeout(@handle.field_timeout, 'reconfigure')
 
 begin
   service.update_orchestration_stack

--- a/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision_spec.rb
@@ -34,6 +34,7 @@ describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::
       current_object = Spec::Support::MiqAeMockObject.new
       current_object.parent = root_object
       service.object = current_object
+      allow(service).to receive(:field_timeout).and_return(8)
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq/pull/19558

https://bugzilla.redhat.com/show_bug.cgi?id=1781353

@miq_bot assign @tinaafitz
@miq_bot add_label enhancement, changelog/yes, orchestration