### PR TITLE
Adding better logging to check_service_retire method.

### DIFF
--- a/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired.rb
+++ b/content/automate/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/check_service_retired.rb
@@ -16,6 +16,13 @@ module ManageIQ
 
               private
 
+              def log_task_info(task)
+                @handle.log('info', "Service Retire Task <#{task.id}> <#{task.description}> is not retired, setting retry.")
+                task.miq_request_tasks.each do |t|
+                  @handle.log('info', "  Service Retire Task <#{task.id}> is waiting on <#{t.request_type}> Task <#{t.id}> <#{t.description}>") if t.state != 'finished'
+                end
+              end
+
               def check_all_service_tasks
                 task = @handle.root['service_retire_task']
                 task_status = task['status']
@@ -35,7 +42,7 @@ module ManageIQ
                   reason = reason[7..-1] if reason[0..6] == 'Error: '
                   @handle.root['ae_reason'] = reason
                 when 'retry'
-                  @handle.log('info', "Service task #{task.description} is not retired, setting retry.")
+                  log_task_info(task)
                   @handle.root['ae_result']         = 'retry'
                   @handle.root['ae_retry_interval'] = '1.minute'
                 when 'ok'


### PR DESCRIPTION
Now you will see the task ids, type and descriptions of tasks waiting to be retired.

Service Retire Task:<10000000000118> <Service Retire for: vmware2-20191218-122517> is not retired, setting retry.
  Service Retire Task:<10000000000118> waiting on <vm_retire> Task:<10000000000119> <VM Retire for: Sample_Vm>

@miq-bot assign @tinaafitz