### PR TITLE
Fix for Quota validation issue with service dialog memory values.

### DIFF
--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -347,6 +347,9 @@ def get_dialog_options_hash(dialog_options)
         $evm.log(:info, "Recalculating cloud flavor based on dialog overrides")
       end
     else
+      next unless /^dialog_(?<option_key>.*)/i =~ k
+
+      set_hash_value(0, option_key.downcase.to_sym, v, options_hash)
       set_hash_value(0, k.downcase.to_sym, v, options_hash)
     end
   end
@@ -356,6 +359,8 @@ end
 
 def set_hash_value(sequence_id, option_key, value, options_hash)
   return if value.blank?
+
+  value = value.to_i.megabytes if option_key.to_s.downcase.include?('vm_memory')
   $evm.log(:info, "Adding seq_id: #{sequence_id} key: #{option_key.inspect} value: #{value.inspect} to options_hash")
   options_hash[sequence_id][option_key] = value
 end

--- a/spec/automation/unit/method_validation/requested_spec.rb
+++ b/spec/automation/unit/method_validation/requested_spec.rb
@@ -103,12 +103,12 @@ describe "Quota Validation" do
     it_behaves_like "requested"
   end
 
-  context "vmware service item with dialog override vm_memory = 2147483648" do
+  context "vmware service item with dialog override vm_memory = 2048" do
     let(:result_counts_hash) do
       {:storage => 512.megabytes, :cpu => 4, :vms => 1, :memory => 2.gigabytes}
     end
     let(:result_dialog) do
-      {"dialog_option_0_vm_memory" => "2147483648"}
+      {"dialog_option_0_vm_memory" => "2048"}
     end
     it_behaves_like "requested"
   end


### PR DESCRIPTION
Modified requested method for the following 2 issues:
1. vm_memory value in service dialog was NOT being used for Quota requested.
2. option_0_vm_memory value in service dialog was being used without the megabytes so 8192 would only be 8KB not 8GIG.

With this fix, if you use option_0_vm_memory or vm_memory in a service dialog and request 8192, it will be 8 GIG requested in Quota.

fixes:https://bugzilla.redhat.com/show_bug.cgi?id=1775211
@miq-bot add_label bug
@miq-bot assign @tinaafitz