### PR TITLE
Moving RedHat domain content for 8 existing methods to ManageIQ.

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/amazon_customizerequest.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/amazon_customizerequest.rb
@@ -2,7 +2,99 @@
 # Description: This method is used to Customize the Amazon Provisioning Request
 #
 
+# process_customization - mapping instance_types, key pairs, security groups and cloud-init templates
+def process_customization(mapping, prov, template, product, provider )
+  log(:info, "Processing Amazon customizations...", true)
+  case mapping
+  when 0
+    # No mapping
+  when 1
+    ws_values = prov.options.fetch(:ws_values, {})
+
+    if prov.get_option(:instance_type).nil? && ws_values.has_key?(:instance_type)
+      provider.flavors.each do |flavor|
+        if flavor.name.downcase == ws_values[:instance_type].downcase
+          prov.set_option(:instance_type, [flavor.id, "#{flavor.name}':'#{flavor.description}"])
+          log(:info, "Provisioning object updated {:instance_type => #{prov.get_option(:instance_type).inspect}}")
+        end
+      end
+    end
+
+    if prov.get_option(:guest_access_key_pair).nil? && ws_values.has_key?(:guest_access_key_pair)
+      provider.key_pairs.each do |keypair|
+        if keypair.name == ws_values[:guest_access_key_pair]
+          prov.set_option(:guest_access_key_pair, [keypair.id,keypair.name])
+          log(:info, "Provisioning object updated {:guest_access_key_pair => #{prov.get_option(:guest_access_key_pair).inspect}}")
+        end
+      end
+    end
+
+    if prov.get_option(:security_groups).blank? && ws_values.has_key?(:security_groups)
+      provider.security_groups.each do |securitygroup|
+        if securitygroup.name == ws_values[:security_groups]
+          prov.set_option(:security_groups, [securitygroup.id])
+          log(:info, "Provisioning object updated {:security_groups => #{prov.get_option(:security_groups).inspect}}")
+        end
+      end
+    end
+
+    if prov.get_option(:customization_template_id).nil?
+      customization_template_search_by_function       = "#{prov.type}_#{prov.get_tags[:function]}" rescue nil
+      customization_template_search_by_template_name  = template.name
+      customization_template_search_by_ws_values      = ws_values[:customization_template] rescue nil
+      log(:info, "prov.eligible_customization_templates: #{prov.eligible_customization_templates.inspect}")
+      customization_template = nil
+
+      unless customization_template_search_by_function.nil?
+        # Search for customization templates enabled for Cloud-Init that equal MiqProvisionAmazon_prov.get_tags[:function]
+        if customization_template.blank?
+          log(:info, "Searching for customization templates (Cloud-Init) enabled that are named: #{customization_template_search_by_function}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_function)==0 }
+        end
+      end
+      unless customization_template_search_by_template_name.nil?
+        # Search for customization templates enabled for Cloud-Init that match the template/image name
+        if customization_template.blank?
+          log(:info, "Searching for customization templates (Cloud-Init) enabled that are named: #{customization_template_search_by_template_name}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_template_name)==0 }
+        end
+      end
+      unless customization_template_search_by_ws_values.nil?
+        # Search for customization templates enabled for Cloud-Init that match ws_values[:customization_template]
+        if customization_template.blank?
+          log(:info, "Searching for customization templates (Cloud-Init) enabled that are named: #{customization_template_search_by_ws_values}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_ws_values)==0 }
+        end
+      end
+      if customization_template.blank?
+        log(:warn, "Failed to find matching Customization Template", true)
+      else
+        log(:info, "Found Customization Template ID: #{customization_template.id} Name: #{customization_template.name} Description: #{customization_template.description}")
+        prov.set_customization_template(customization_template) rescue nil
+        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+        log(:info, "Provisioning object updated {:customization_template_script => #{prov.get_option(:customization_template_script).inspect}}")
+      end
+    else
+      log(:info, "Customization Template selected from dialog ID: #{prov.get_option(:customization_template_id).inspect}} Script: #{prov.get_option(:customization_template_script).inspect}")
+    end
+  end # case mapping
+  log(:info, "Processing Amazon customizations...Complete", true)
+end
+
+def log(level, msg, update_message=false)
+  $evm.log(level, "#{msg}")
+  $evm.root['miq_provision'].message = "#{msg}" if $evm.root['miq_provision'] && update_message
+end
+
 # Get provisioning object
 prov = $evm.root["miq_provision"]
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.type}>")
+log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
+
+template = prov.vm_template
+provider = template.ext_management_system
+product  = template.operating_system['product_name'].downcase rescue nil
+log(:info, "Template: #{template.name} Provider: #{provider.name} Vendor: #{template.vendor} Product: #{product}")
+
+mapping = 0
+process_customization(mapping, prov, template, product, provider)

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/openstack_customizerequest.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/openstack_customizerequest.rb
@@ -2,7 +2,99 @@
 # Description: This method is used to Customize the Openstack Provisioning Request
 #
 
+# process_customization - mapping instance_types, key pairs, security groups and cloud-init templates
+def process_customization(mapping, prov, template, product, provider )
+  log(:info, "Processing Openstack customizations...", true)
+  case mapping
+  when 0
+    # No mapping
+  when 1
+    ws_values = prov.options.fetch(:ws_values, {})
+
+    if prov.get_option(:instance_type).nil? && ws_values.has_key?(:instance_type)
+      provider.flavors.each do |flavor|
+        if flavor.name.downcase == ws_values[:instance_type].downcase
+          prov.set_option(:instance_type, [flavor.id, "#{flavor.name}':'#{flavor.description}"])
+          log(:info, "Provisioning object updated {:instance_type => #{prov.get_option(:instance_type).inspect}}")
+        end
+      end
+    end
+
+    if prov.get_option(:guest_access_key_pair).nil? && ws_values.has_key?(:guest_access_key_pair)
+      provider.key_pairs.each do |keypair|
+        if keypair.name == ws_values[:guest_access_key_pair]
+          prov.set_option(:guest_access_key_pair, [keypair.id,keypair.name])
+          log(:info, "Provisioning object updated {:guest_access_key_pair => #{prov.get_option(:guest_access_key_pair).inspect}}")
+        end
+      end
+    end
+
+    if prov.get_option(:security_groups).blank? && ws_values.has_key?(:security_groups)
+      provider.security_groups.each do |securitygroup|
+        if securitygroup.name == ws_values[:security_groups]
+          prov.set_option(:security_groups, [securitygroup.id])
+          log(:info, "Provisioning object updated {:security_groups => #{prov.get_option(:security_groups).inspect}}")
+        end
+      end
+    end
+
+    if prov.get_option(:customization_template_id).nil?
+      customization_template_search_by_function       = "#{prov.type}_#{prov.get_tags[:function]}" rescue nil
+      customization_template_search_by_template_name  = template.name
+      customization_template_search_by_ws_values      = ws_values[:customization_template] rescue nil
+      log(:info, "prov.eligible_customization_templates: #{prov.eligible_customization_templates.inspect}")
+      customization_template = nil
+
+      unless customization_template_search_by_function.nil?
+        # Search for customization templates enabled for Cloud-Init that equal MiqProvisionOpenstack_prov.get_tags[:function]
+        if customization_template.blank?
+          log(:info, "Searching for customization templates (Cloud-Init) enabled that are named: #{customization_template_search_by_function}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_function)==0 }
+        end
+      end
+      unless customization_template_search_by_template_name.nil?
+        # Search for customization templates enabled for Cloud-Init that match the template/image name
+        if customization_template.blank?
+          log(:info, "Searching for customization templates (Cloud-Init) enabled that are named: #{customization_template_search_by_template_name}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_template_name)==0 }
+        end
+      end
+      unless customization_template_search_by_ws_values.nil?
+        # Search for customization templates enabled for Cloud-Init that match ws_values[:customization_template]
+        if customization_template.blank?
+          log(:info, "Searching for customization templates (Cloud-Init) enabled that are named: #{customization_template_search_by_ws_values}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_ws_values)==0 }
+        end
+      end
+      if customization_template.blank?
+        log(:warn, "Failed to find matching Customization Template", true)
+      else
+        log(:info, "Found Customization Template ID: #{customization_template.id} Name: #{customization_template.name} Description: #{customization_template.description}")
+        prov.set_customization_template(customization_template) rescue nil
+        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+        log(:info, "Provisioning object updated {:customization_template_script => #{prov.get_option(:customization_template_script).inspect}}")
+      end
+    else
+      log(:info, "Customization Template selected from dialog ID: #{prov.get_option(:customization_template_id).inspect}} Script: #{prov.get_option(:customization_template_script).inspect}")
+    end
+  end # case mapping
+  log(:info, "Processing Openstack customizations...Complete", true)
+end
+
+def log(level, msg, update_message=false)
+  $evm.log(level, "#{msg}")
+  $evm.root['miq_provision'].message = "#{msg}" if $evm.root['miq_provision'] && update_message
+end
+
 # Get provisioning object
 prov = $evm.root["miq_provision"]
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")
+log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
+
+template = prov.vm_template
+provider = template.ext_management_system
+product  = template.operating_system['product_name'].downcase rescue nil
+log(:info, "Template: #{template.name} Provider: #{provider.name} Vendor: #{template.vendor} Product: #{product}")
+
+mapping = 0
+process_customization(mapping, prov, template, product, provider)

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/redhat_customizerequest.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/redhat_customizerequest.rb
@@ -1,8 +1,228 @@
 #
-# Description: This method is used to Customize the RHEV, RHEV PXE, and RHEV ISO Provisioning Request
+# Description: This method is used to Customize the Provisioning Request
+# Customization Template mapping for RHEV, RHEV PXE, and RHEV ISO provisioning
 #
+
+def log(level, msg, update_message=false)
+  $evm.log(level, "#{msg}")
+  $evm.root['miq_provision'].message = "#{msg}" if $evm.root['miq_provision'] && update_message
+end
+
+def set_customspec(prov, spec)
+  prov.set_customization_spec(spec, true) rescue nil
+  log(:info, "Provisioning object updated {:sysprep_custom_spec => #{prov.get_option(:sysprep_custom_spec).inspect rescue nil}}")
+  log(:info, "Provisioning object updated {:sysprep_spec_override => #{prov.get_option(:sysprep_spec_override)}}")
+end
+
+def process_redhat_pxe(mapping, prov, template, product, provider)
+  case mapping
+
+  when 0
+    # No mapping
+
+  when 1
+    if product.include?("windows")
+      # find the windows image that matches the template name if a PXE Image was NOT chosen in the dialog
+      if prov.get_option(:pxe_image_id).nil?
+
+        log(:info, "Inspecting prov.eligible_windows_images: #{prov.eligible_windows_images.inspect}")
+        pxe_image = prov.eligible_windows_images.detect { |pi| pi.name.casecmp(template.name)==0 }
+        if pxe_image.nil?
+          log(:error, "Failed to find matching PXE Image", true)
+          raise
+        else
+          log(:info, "Found matching Windows PXE Image ID: #{pxe_image.id} Name: #{pxe_image.name} Description: #{pxe_image.description}")
+        end
+        prov.set_windows_image(pxe_image)
+        log(:info, "Provisioning object updated {:pxe_image_id => #{prov.get_option(:pxe_image_id).inspect}}")
+      end
+      # Find the first customization template that matches the template name if none was chosen in the dialog
+      if prov.get_option(:customization_template_id).nil?
+        log(:info, "Inspecting Eligible Customization Templates: #{prov.eligible_customization_templates.inspect}")
+        cust_temp = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name)==0 }
+        if cust_temp.nil?
+          log(:error, "Failed to find matching PXE Image", true)
+          raise
+        end
+        log(:info, "Found matching Windows Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+        prov.set_customization_template(cust_temp)
+        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+      end
+    else
+      # find the first PXE Image that matches the template name if NOT chosen in the dialog
+      if prov.get_option(:pxe_image_id).nil?
+        pxe_image = prov.eligible_pxe_images.detect { |pi| pi.name.casecmp(template.name)==0 }
+        log(:info, "Found Linux PXE Image ID: #{pxe_image.id} Name: #{pxe_image.name} Description: #{pxe_image.description}")
+        prov.set_pxe_image(pxe_image)
+        log(:info, "Provisioning object updated {:pxe_image_id => #{prov.get_option(:pxe_image_id).inspect}}")
+      end
+      # Find the first Customization Template that matches the template name if NOT chosen in the dialog
+      if prov.get_option(:customization_template_id).nil?
+        cust_temp = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name)==0 }
+        log(:info, "Found Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+        prov.set_customization_template(cust_temp)
+        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+      end
+    end
+  when 3
+    #
+    # Enter your own RHEV custom mapping here
+  else
+    # Skip mapping
+  end # end case
+end # end process_redhat
+
+# process_redhat_iso - mapping customization templates (ks.cfg)
+def process_redhat_iso(mapping, prov, template, product, provider)
+  case mapping
+
+  when 0
+    # No mapping
+  when 1
+    if product.include?("windows")
+      # Linux Support only for now
+    else
+      # Linux - Find the first ISO Image that matches the template name if NOT chosen in the dialog
+      if prov.get_option(:iso_image_id).nil?
+        log(:info, "Inspecting prov.eligible_iso_images: #{prov.eligible_iso_images.inspect rescue nil}")
+        iso_image = prov.eligible_iso_images.detect { |iso| iso.name.casecmp(template.name)==0 }
+        if iso_image.nil?
+          log(:error, "Failed to find matching ISO Image", true)
+          raise
+        else
+          log(:info, "Found Linux ISO Image ID: #{iso_image.id} Name: #{iso_image.name} Description: #{iso_image.description}")
+          prov.set_iso_image(iso_image)
+          log(:info, "Provisioning object updated {:iso_image_id => #{prov.get_option(:iso_image_id).inspect}}")
+        end
+      else
+        log(:info, "ISO Image selected from dialog: #{prov.get_option(:iso_image_id).inspect}")
+      end
+
+      # Find the first Customization Template that matches the template name if NOT chosen in the dialog
+      if prov.get_option(:customization_template_id).nil?
+        log(:info, "prov.eligible_customization_templates: #{prov.eligible_customization_templates.inspect}")
+
+        cust_temp = $evm.vmdb('customization_template').all.detect { |ct| ct.name.casecmp(template.name)==0 }
+        if cust_temp.nil?
+          log(:error, "Failed to find matching Customization Template", true)
+          raise
+        else
+          log(:info, "Found Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+          prov.set_customization_template(cust_temp)
+          log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+        end
+      else
+        log(:info, "Customization Template selected from dialog: #{prov.get_option(:customization_template_id).inspect}")
+      end
+    end
+  when 2
+    #
+    # Enter your own RHEV ISO custom mapping here
+  else
+    # Skip mapping
+  end
+end
+
+# process_redhat - mapping cloud-init templates
+def process_redhat(mapping, prov, template, product, provider)
+  log(:info, "Processing process_redhat...", true)
+  case mapping
+  when 0
+    # No mapping
+  when 1
+    if prov.get_option(:customization_template_id).nil?
+      customization_template_search_by_ws_values = ws_values[:customization_template] rescue nil
+      customization_template_search_by_template_name = template.name
+      log(:info, "prov.eligible_customization_templates: #{prov.eligible_customization_templates.inspect}")
+      customization_template = nil
+
+      unless customization_template_search_by_template_name.nil?
+        # Search for customization templates enabled for Cloud-Init that match the template/image name
+        if customization_template.blank?
+          log(:info, "Searching for customization templates enabled for (Cloud-Init) that are named: #{customization_template_search_by_template_name}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name)==0 }
+        end
+      end
+      unless customization_template_search_by_ws_values.nil?
+        # Search for customization templates enabled for Cloud-Init that match ws_values[:customization_template]
+        if customization_template.blank?
+          log(:info, "Searching for customization templates enabled for (Cloud-Init) that are named: #{customization_template_search_by_ws_values}")
+          customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_ws_values)==0 }
+        end
+      end
+      if customization_template.blank?
+        log(:warn, "Failed to find matching Customization Template", true)
+      else
+        log(:info, "Found Customization Template ID: #{customization_template.id} Name: #{customization_template.name} Description: #{customization_template.description}")
+        prov.set_customization_template(customization_template) rescue nil
+        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+        log(:info, "Provisioning object updated {:customization_template_script => #{prov.get_option(:customization_template_script).inspect}}")
+      end
+    else
+      log(:info, "Customization Template selected form dialog ID: #{prov.get_option(:customization_template_id).inspect}} Script: #{prov.get_option(:customization_template_script).inspect}")
+    end
+  when 2
+    # Enter your own RHEV custom mapping here
+  else
+    # Skip mapping
+  end
+  log(:info, "Processing process_redhat...Complete", true)
+end
 
 # Get provisioning object
 prov = $evm.root["miq_provision"]
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")
+log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
+
+template = prov.vm_template
+provider = template.ext_management_system
+product  = template.operating_system['product_name'].downcase rescue nil
+log(:info, "Template: #{template.name} Provider: #{provider.name} Vendor: #{template.vendor} Product: #{product}")
+
+# Build case statement to determine which type of processing is required
+case prov.type
+
+when 'ManageIQ::Providers::Redhat::InfraManager::Provision'
+  ##########################################################
+  # Red Hat Mapping for template Provisioning
+  #
+  # Possible values:
+  #   0 - (DEFAULT No Mapping) This option skips the mapping of customization templates/cloud-init
+  #
+  ##########################################################
+  mapping = 0
+  process_redhat(mapping, prov, template, product, provider)
+
+when 'ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso'
+  ##########################################################
+  # Red Hat Customization Template Mapping for ISO Provisioning
+  #
+  # Possible values:
+  #   0 - (DEFAULT No Mapping) This option skips the mapping of iso images and customization templates
+  #
+  #   1 - CFME will look for a iso image and a customization template with
+  #   the exact name as the template name if none were chosen from the provisioning dialog
+  #
+  #   2 - Include your own custom mapping logic here
+  ##########################################################
+  mapping = 0
+  process_redhat_iso(mapping, prov, template, product, provider)
+
+when 'ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe'
+  ##########################################################
+  # Red Hat Customization Template Mapping for PXE Provisioning
+  #
+  # Possible values:
+  #   0 - (DEFAULT No Mapping) This option skips the mapping of pxe images and customization templates
+  #
+  #   1 - CFME will look for a pxe image and a customization template with
+  #   the exact name as the template name if none were chosen from the provisioning dialog
+  #
+  #   2 - Include your own custom mapping logic here
+  ##########################################################
+  mapping = 0
+  process_redhat_pxe(mapping, prov, template, product, provider)
+
+else
+  log(:info, "Provisioning Type: #{prov.type} does not match, skipping processing")
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/redhat_preprovision.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/redhat_preprovision.rb
@@ -1,8 +1,60 @@
 #
-# Description: This method is used to apply PreProvision customizations for RHEV provisioning
+# Description: This default method is used to apply PreProvision customizations for RHEV provisioning
 #
+
+def log(level, msg, update_message = false)
+  $evm.log(level, "#{msg}")
+  $evm.root['miq_provision'].message = "#{msg}" if $evm.root['miq_provision'] && update_message
+end
+
+def process_customization(prov)
+  # Choose the sections to process
+  set_vlan  = false
+  set_notes = true
+
+  # Get information from the template platform
+  template = prov.vm_template
+  product  = template.operating_system['product_name'].downcase
+  log(:info, "Template:<#{template.name}> Vendor:<#{template.vendor}> Product:<#{product}>")
+
+  if set_vlan
+    # Set default VLAN here if one was not chosen in the dialog?
+    # The format needs to be "#{vnic_profile_name} (#{network_name})"
+    default_vlan = "ovirtmgmt (ovirtmgmt)"
+
+    if prov.get_option(:vlan).nil?
+      prov.set_vlan(default_vlan)
+      log(:info, "Provisioning object <:vlan> updated with <#{default_vlan}>")
+    end
+  end
+
+  if set_notes
+    log(:info, "Processing set_notes...", true)
+    ###################################
+    # Set the VM Description and VM Annotations  as follows:
+    # The example would allow user input in provisioning dialog "vm_description"
+    # to be added to the VM notes
+    ###################################
+    # Stamp VM with custom description
+    unless prov.get_option(:vm_description).nil?
+      vmdescription = prov.get_option(:vm_description)
+      prov.set_option(:vm_description, vmdescription)
+      log(:info, "Provisioning object <:vmdescription> updated with <#{vmdescription}>")
+    end
+
+    # Setup VM Annotations
+    vm_notes =  "Owner: #{prov.get_option(:owner_first_name)} #{prov.get_option(:owner_last_name)}"
+    vm_notes += "\nEmail: #{prov.get_option(:owner_email)}"
+    vm_notes += "\nSource Template: #{template.name}"
+    vm_notes += "\nCustom Description: #{vmdescription}" unless vmdescription.nil?
+    prov.set_vm_notes(vm_notes)
+    log(:info, "Provisioning object <:vm_notes> updated with <#{vm_notes}>")
+    log(:info, "Processing set_notes...Complete", true)
+  end
+end
 
 # Get provisioning object
 prov = $evm.root['miq_provision']
+log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")
+process_customization(prov)

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_customizerequest.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_customizerequest.rb
@@ -1,8 +1,177 @@
 #
-# Description: This method is used to Customize the VMware and VMware PXE Provisioning Request
+# Description: This method is used to Customize the Provisioning Request
+# Customization mapping for VMware and VMWare PXE provisioning
 #
+
+def log(level, msg, update_message = false)
+  $evm.log(level, "#{msg}")
+  $evm.root['miq_provision'].message = "#{@method} - #{msg}" if $evm.root['miq_provision'] && update_message
+end
+
+def set_customspec(prov, spec)
+  prov.set_customization_spec(spec, true) rescue nil
+  log(:info, "Provisioning object updated {:sysprep_custom_spec => #{prov.get_option(:sysprep_custom_spec).inspect rescue nil}}")
+  log(:info, "Provisioning object updated {:sysprep_spec_override => #{prov.get_option(:sysprep_spec_override)}}")
+end
+
+# process_vmware
+def process_vmware(mapping, prov, template, product, provider)
+# if prov.get_option(:sysprep_custom_spec) || product.include?("other") || prov.provision_type.include?("clone_to_template")
+  if product.include?("other") || prov.provision_type.include?("clone_to_template")
+    mapping = 0
+  end
+
+  case mapping
+
+  when 0
+  # Skip mapping
+
+  when 1
+  # Automatic customization specification mapping if template is RHEL,Suse or Windows
+    if product.include?("red hat") || product.include?("suse") || product.include?("windows")
+      spec = prov.vm_template.name # to match the template name
+      set_customspec(prov, spec)
+
+      # Set linux hostname stuff here
+      prov.set_option(:linux_host_name, prov.get_option(:vm_target_name))
+      log(:info, "Provisioning object updated {:linux_host_name => #{prov.get_option(:linux_host_name)}}")
+      prov.set_option(:vm_target_hostname, prov.get_option(:vm_target_name))
+      log(:info, "Provisioning object updated {:hostname => #{prov.get_option(:vm_target_hostname)}}")
+    end
+
+  when 2
+    # Use this option to use a combination of product name and bitness to select your customization specification
+    spec = nil # unknown type
+
+    if product.include?("2003")
+      spec = "W2K3R2-Entx64"  # Windows Server 2003
+    elsif product.include?("2008")
+      spec = "vmware_windows" # Windows Server 2008
+    elsif product.include?("windows 7")
+      spec = "vmware_windows" # Windows7
+    elsif product.include?("suse")
+      spec = "vmware_suse" # Suse
+    elsif product.include?("red hat")
+      spec = "vmware_rhel" # RHEL
+    end
+    log(:info, "VMware Customization Specification: #{spec}")
+
+    # Set values in provisioning object
+    set_customspec(prov, spec) unless spec.nil?
+  when 3
+    #
+    # Enter your own VMware custom mapping here
+  else
+  # Skip mapping
+  end # end case
+end # end process_vmware
+
+# process_vmware_pxe
+def process_vmware_pxe(mapping, prov, template, product, provider)
+  case mapping
+
+  when 0
+  # No mapping
+
+  when 1
+    if product.include?("windows")
+      # find the windows image that matches the template name if a PXE Image was NOT chosen in the dialog
+      if prov.get_option(:pxe_image_id).nil?
+
+        log(:info, "Inspecting Eligible Windows Images: #{prov.eligible_windows_images.inspect rescue nil}")
+        pxe_image = prov.eligible_windows_images.detect { |pi| pi.name.casecmp(template.name) == 0 }
+        if pxe_image.nil?
+          log(:error, "Failed to find matching PXE Image", true)
+          raise
+        else
+          log(:info, "Found matching Windows PXE Image ID: #{pxe_image.id} Name: #{pxe_image.name} Description: #{pxe_image.description}")
+        end
+        prov.set_windows_image(pxe_image)
+        log(:info, "Provisioning object updated {:pxe_image_id => #{prov.get_option(:pxe_image_id).inspect}}")
+      end
+      # Find the first customization template that matches the template name if none was chosen in the dialog
+      if prov.get_option(:customization_template_id).nil?
+        log(:info, "Inspecting Eligible Customization Templates: #{prov.eligible_customization_templates.inspect rescue nil}")
+        cust_temp = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name) == 0 }
+        if cust_temp.nil?
+          log(:error, "Failed to find matching PXE Image", true)
+          raise
+        end
+        log(:info, "Found mathcing Windows Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+        prov.set_customization_template(cust_temp)
+        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+      end
+    else
+      # find the first PXE Image that matches the template name if NOT chosen in the dialog
+      if prov.get_option(:pxe_image_id).nil?
+        pxe_image = prov.eligible_pxe_images.detect { |pi| pi.name.casecmp(template.name) == 0 }
+        log(:info, "Found Linux PXE Image ID: #{pxe_image.id}  Name: #{pxe_image.name} Description: #{pxe_image.description}")
+        prov.set_pxe_image(pxe_image)
+        log(:info, "Provisioning object updated {:pxe_image_id => #{prov.get_option(:pxe_image_id).inspect}}")
+      end
+      # Find the first Customization Template that matches the template name if NOT chosen in the dialog
+      if prov.get_option(:customization_template_id).nil?
+        cust_temp = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name) == 0 }
+        log(:info, "Found Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+        prov.set_customization_template(cust_temp)
+        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+      end
+    end
+  when 3
+  #
+  # Enter your own VMware PXE custom mapping here
+  else
+  # Skip mapping
+  end # end case
+end # end process_vmware_pxe
 
 # Get provisioning object
 prov = $evm.root["miq_provision"]
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")
+log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
+
+template = prov.vm_template
+provider = template.ext_management_system
+product  = template.operating_system['product_name'].downcase rescue nil
+log(:info, "Template: #{template.name} Provider: #{provider.name} Vendor: #{template.vendor} Product: #{product}")
+
+# Build case statement to determine which type of processing is required
+case prov.type
+
+when 'ManageIQ::Providers::Vmware::InfraManager::Provision'
+##########################################################
+# VMware Customization Specification Mapping
+#
+# Possible values:
+#   0 - (Default No Mapping) This option is automatically chosen if it finds a customization
+#   specification mapping chosen from the dialog
+#
+#   1 - CFME will look for a customization specification with
+#   the exact name as the template name
+#
+#   2 - Use this option to use a combination of product name and bitness to
+#   select your customization specification
+#
+#   3 - Include your own custom mapping logic here
+##########################################################
+  mapping = 0
+  process_vmware(mapping, prov, template, product, provider)
+
+when 'ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe'
+##########################################################
+# VMware PXE Customization Specification Mapping
+#
+# Possible values:
+#   0 - (DEFAULT No Mapping) This option skips the mapping of pxe images and customization templates
+#
+#   1 - CFME will look for a pxe image and a customization template with
+#   the exact name as the template name if none were chosen from the provisioning dialog
+#
+#   2 - Include your own custom mapping logic here
+##########################################################
+  mapping = 0
+  process_vmware_pxe(mapping, prov, template, product, provider)
+
+else
+  log(:info, "Provisioning Type: #{prov.type} does not match, skipping processing")
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_preprovision.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_preprovision.rb
@@ -1,8 +1,106 @@
 #
-# Description: This method is used to apply PreProvision customizations for VMware
+# Description: This default method is used to apply PreProvision customizations for VMware
 #
+
+def log(level, msg, update_message = false)
+  $evm.log(level, "#{msg}")
+  $evm.root['miq_provision'].message = "#{msg}" if $evm.root['miq_provision'] && update_message
+end
+
+def process_customization(prov)
+  # Choose the sections to process
+  set_vlan          = false
+  set_folder        = true
+  set_resource_pool = false
+  set_notes         = true
+
+  # Get information from the template platform
+  template = prov.vm_template
+  ems = template.ext_management_system
+  product  = template.operating_system['product_name'].downcase
+  bitness = template.operating_system['bitness']
+  log(:info, "Template:<#{template.name}> Provider:<#{ems.name}> Vendor:<#{template.vendor}> Product:<#{product}> Bitness:<#{bitness}>")
+
+  tags = prov.get_tags
+  log(:info, "Provision Tags:<#{tags.inspect}>")
+
+  if set_vlan
+    log(:info, "Processing set_vlan...", true)
+    ###################################
+    # Was a VLAN selected in dialog?
+    # If not you can set one here.
+    ###################################
+    if prov.get_option(:vlan).nil?
+      default_vlan = "VM Network"
+      #default_dvs = "portgroup1"
+
+      prov.set_vlan(default_vlan)
+      #prov.set_dvs(default_dvs)
+      log(:info, "Provisioning object <:vlan> updated with <#{prov.get_option(:vlan)}>")
+    end
+    log(:info, "Processing set_vlan...Complete", true)
+  end
+
+  if set_folder
+    log(:info, "Processing set_folder...", true)
+    ###################################
+    # Drop the VM in the targeted folder if no folder was chosen in the dialog.
+    # The vCenter folder must exist for the VM to be placed correctly,
+    # Otherwise the VM will be placed at the Data Center level.
+    ###################################
+    if prov.get_option(:placement_folder_name).nil?
+      datacenter = template.v_owning_datacenter
+
+      # prov.get_folder_paths.each { |key, path| log(:info, "Eligible folders:<#{key.inspect}> - <#{path.inspect}>") }
+      prov.set_folder(datacenter)
+      log(:info, "Provisioning object <:placement_folder_name> updated with <#{prov.options[:placement_folder_name].inspect}>")
+    else
+      log(:info, "Placing VM in folder: <#{prov.options[:placement_folder_name].inspect}>")
+    end
+    log(:info, "Processing set_folder...Complete", true)
+  end
+
+  if set_resource_pool
+    log(:info, "Processing set_resource_pool...", true)
+    if prov.get_option(:placement_rp_name).nil?
+      ############################################
+      # Find and set the Resource Pool for a VM:
+      ############################################
+      default_resource_pool = 'MyResPool'
+      respool = prov.eligible_resource_pools.detect { |c| c.name.casecmp(default_resource_pool) == 0 }
+      log(:info, "Provisioning object <:placement_rp_name> updated with <#{respool.name.inspect}>")
+      prov.set_resource_pool(respool)
+    end
+    log(:info, "Processing set_resource_pool...Complete", true)
+  end
+
+  if set_notes
+    log(:info, "Processing set_notes...", true)
+    ###################################
+    # Set the VM Description and VM Annotations  as follows:
+    # The example would allow user input in provisioning dialog "vm_description"
+    # to be added to the VM notes
+    ###################################
+    # Stamp VM with custom description
+    unless prov.get_option(:vm_description).nil?
+      vmdescription = prov.get_option(:vm_description)
+      prov.set_option(:vm_description, vmdescription)
+      log(:info, "Provisioning object <:vmdescription> updated with <#{vmdescription}>")
+    end
+
+    # Setup VM Annotations
+    vm_notes =  "Owner: #{prov.get_option(:owner_first_name)} #{prov.get_option(:owner_last_name)}"
+    vm_notes += "\nEmail: #{prov.get_option(:owner_email)}"
+    vm_notes += "\nSource: #{template.name}"
+    vm_notes += "\nDescription: #{vmdescription}" unless vmdescription.nil?
+    prov.set_vm_notes(vm_notes)
+    log(:info, "Provisioning object <:vm_notes> updated with <#{vm_notes}>")
+  end
+  log(:info, "Processing set_notes...Complete", true)
+end
 
 # Get provisioning object
 prov = $evm.root['miq_provision']
+log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")
+process_customization(prov)

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_preprovision_clone_to_template.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_preprovision_clone_to_template.rb
@@ -1,7 +1,88 @@
 #
-# Description: This method is used to apply PreProvision customizations.
+# Description: This default method is used to apply PreProvision customizations as follows:
+# 1. VM Description/Annotations
+# 2. Target VC Folder
+# 3. Tag Inheritance
+
+set_folder     = true
+set_notes      = true
+set_tags       = true
 
 # Get provisioning object
 prov = $evm.root["miq_provision"]
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")
+# Get Provision Type
+prov_type = prov.provision_type
+$evm.log("info", "Provision Type: <#{prov_type}>")
+
+# Get template
+template = prov.vm_template
+
+# Get OS Type from the template platform
+product  = template.operating_system['product_name'] rescue ''
+$evm.log("info", "Source Product: <#{product}>")
+
+if set_notes
+  ###################################
+  # Set the VM Description and VM Annotations  as follows:
+  # The example would allow user input in provisioning dialog "vm_description"
+  # to be added to the VM notes
+  ###################################
+  # Stamp VM with custom description
+  unless prov.get_option(:vm_description).nil?
+    vmdescription = prov.get_option(:vm_description)
+    prov.set_option(:vm_description, vmdescription)
+    $evm.log("info", "Provisioning object <:vmdescription> updated with <#{vmdescription}>")
+  end
+
+  # Setup VM Annotations
+  vm_notes =  "Owner: #{prov.get_option(:owner_first_name)} #{prov.get_option(:owner_last_name)}"
+  vm_notes += "\nEmail: #{prov.get_option(:owner_email)}"
+  vm_notes += "\nSource Template: #{prov.vm_template.name}"
+  vm_notes += "\nCustom Description: #{vmdescription}" unless vmdescription.nil?
+  prov.set_vm_notes(vm_notes)
+  $evm.log("info", "Provisioning object <:vm_notes> updated with <#{vm_notes}>")
+end
+
+if set_folder
+  ###################################
+  # Drop the VM in the targeted folder if no folder was chosen in the dialog
+  # The VC folder must exist for the VM to be placed correctly,
+  # Otherwise the VM will be placed at the Data Center level.
+  ###################################
+  datacenter = template.v_owning_datacenter
+
+  if prov.get_option(:placement_folder_name).nil?
+    prov.set_folder(datacenter)
+    $evm.log("info", "Provisioning object <:placement_folder_name> updated with <#{prov.options[:placement_folder_name].inspect}>")
+  else
+    $evm.log("info", "Placing VM in folder: <#{prov.get_option(:placement_folder_name)}>")
+  end
+end
+
+if set_tags
+  ###################################
+  #
+  # Inherit parent VM's tags and apply
+  # them to the published template
+  #
+  ###################################
+
+  # List of tag categories to carry over
+  tag_categories_to_migrate = %w(environment department location function)
+
+  # Assign variables
+  prov_tags = prov.get_tags
+  $evm.log("info", "Inspecting Provisioning Tags: <#{prov_tags.inspect}>")
+  template_tags = template.tags
+  $evm.log("info", "Inspecting Template Tags: <#{template_tags.inspect}>")
+
+  # Loop through each source tag for matching categories
+  template_tags.each do |cat_tagname|
+    category, tag_value = cat_tagname.split('/')
+    $evm.log("info", "Processing Tag Category: <#{category}> Value: <#{tag_value}>")
+    next unless tag_categories_to_migrate.include?(category)
+    prov.add_tag(category, tag_value)
+    $evm.log("info", "Updating Provisioning Tags with Category: <#{category}> Value: <#{tag_value}>")
+  end
+end

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_preprovision_clone_to_vm.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/vmware_preprovision_clone_to_vm.rb
@@ -1,7 +1,108 @@
 #
-# Description: This method is used to apply PreProvision customizations during the cloning to a VM:
+# Description: This default method is used to apply PreProvision customizations during the cloning to a VM:
+# 1. Customization Spec
+# 2. VLAN
+# 3. VM Description/Annotations
+# 4. Resource Pool
+# 5. Tag Inheritance
+
+set_vlan       = false
+set_notes      = true
+set_tags       = true
+set_customspec = false
 
 # Get provisioning object
 prov = $evm.root["miq_provision"]
 
-$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")
+# Get Provision Type
+prov_type = prov.provision_type
+$evm.log("info", "Provision Type: <#{prov_type}>")
+
+# Get template
+template = prov.vm_template
+
+# Get OS Type from the template platform
+product  = template.operating_system['product_name'] rescue ''
+$evm.log("info", "Source Product: <#{product}>")
+
+
+if set_customspec
+  ###################################
+  # Set the customization spec here
+  # If one selected in dialog it will be used,
+  # else it will map the customization spec based on the
+  # the entry below
+  ###################################
+  customization_spec = "my-custom-spec"
+
+  # Skip automatic customization spec mapping if template is 'Other'
+  unless product.include?("Other")
+    if prov.get_option(:sysprep_custom_spec).nil?
+      prov.set_customization_spec(customization_spec)
+      $evm.log("info", "Provisioning object updated - <:sysprep_custom_spec> = <#{customization_spec}>")
+    end
+  else
+    $evm.log("info", "Skipping automatic customization spec mapping")
+  end
+end
+
+if set_vlan
+  ###################################
+  # Was a VLAN selected in dialog?
+  # If not you can set one here.
+  ###################################
+  default_vlan = "vlan1"
+
+  if prov.get_option(:vlan).nil?
+    prov.set_vlan(default_vlan)
+  end
+end
+
+if set_notes
+  ###################################
+  # Set the VM Description and VM Annotations  as follows:
+  # The example would allow user input in provisioning dialog "vm_description"
+  # to be added to the VM notes
+  ###################################
+  # Stamp VM with custom description
+  unless prov.get_option(:vm_description).nil?
+    vmdescription = prov.get_option(:vm_description)
+    prov.set_option(:vm_description, vmdescription)
+    $evm.log("info", "Provisioning object <:vmdescription> updated with <#{vmdescription}>")
+  end
+
+  # Setup VM Annotations
+  vm_notes =  "Owner: #{prov.get_option(:owner_first_name)} #{prov.get_option(:owner_last_name)}"
+  vm_notes += "\nEmail: #{prov.get_option(:owner_email)}"
+  vm_notes += "\nSource VM: #{prov.vm_template.name}"
+  vm_notes += "\nCustom Description: #{vmdescription}" unless vmdescription.nil?
+  prov.set_vm_notes(vm_notes)
+  $evm.log("info", "Provisioning object <:vm_notes> updated with <#{vm_notes}>")
+end
+
+if set_tags
+  ###################################
+  #
+  # Inherit parent VM's tags and apply
+  # them to the cloned VM
+  #
+  ###################################
+
+  # List of tag categories to carry over
+  tag_categories_to_migrate = %w(environment department location function)
+
+  # Assign variables
+  prov_tags = prov.get_tags
+  $evm.log("info", "Provisioning Tags: <#{prov_tags.inspect}>")
+  template_tags = template.tags
+  $evm.log("info", "Template Tags: <#{template_tags.inspect}>")
+
+  # Loop through each source tag for matching categories
+  template_tags.each do |cat_tagname|
+    category, tag_value = cat_tagname.split('/')
+    $evm.log("info", "Processing Tag Category: <#{category}> Value: <#{tag_value}>")
+    next unless tag_categories_to_migrate.include?(category)
+    prov.add_tag(category, tag_value)
+    $evm.log("info", "Updating Provisioning Tags with Category: <#{category}> Value: <#{tag_value}>")
+  end
+end


### PR DESCRIPTION
Moving/Replacing 8 RedHat Automate methods to the ManageIQ domain:
  2 for Cloud/Vm/Provisioning/StateMachine/Methods
  6 for Infrastructure/Vm/Provisioning/StateMachine/Methods

These are methods that are currently in the ManageIQ domain.




![image](https://user-images.githubusercontent.com/11841651/71683096-900aee80-2d5f-11ea-9045-096abdea1052.png)



@miq-bot assign @tinaafitz