### PR TITLE
Fix cancellation process

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover.rb
@@ -14,8 +14,8 @@ module ManageIQ
               @handle.root['ae_result'] = 'retry'
               @handle.root['ae_retry_server_affinity'] = true
               @handle.root['ae_retry_interval'] = 15.seconds
-            else
-              raise 'Migration failed' if @task.get_option(:progress)[:status] == "error"
+            elsif @task.get_option(:progress)[:status] == "error"
+              raise 'Migration failed'
             end
           end
         end

--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover.rb
@@ -14,6 +14,8 @@ module ManageIQ
               @handle.root['ae_result'] = 'retry'
               @handle.root['ae_retry_server_affinity'] = true
               @handle.root['ae_retry_interval'] = 15.seconds
+            else
+              raise 'Migration failed' if @task.get_option(:progress)[:status] == "error"
             end
           end
         end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
@@ -52,7 +52,7 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
     it "stops retrying when preflight check passed and handover is done" do
       allow(svc_model_task).to receive(:state).and_return('migrate')
       svc_model_task.set_option(:workflow_runner, 'automate')
-      svc_model_task.set_option(:progress, {:status => 'ok'})
+      svc_model_task.set_option(:progress, :status => 'ok')
       described_class.new(ae_service).main
       expect(ae_service.root['ae_result']).to be_nil
       expect(ae_service.root['ae_retry_server_affinity']).to be_nil

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
@@ -62,7 +62,7 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
     it "raises if task failed" do
       allow(svc_model_task).to receive(:state).and_return('migrate')
       svc_model_task.set_option(:workflow_runner, 'automate')
-      svc_model_task.set_option(:progress, {:status => 'error'})
+      svc_model_task.set_option(:progress, :status => 'error')
       expect { described_class.new(ae_service).main }.to raise_error('Migration failed')
     end
   end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
@@ -60,7 +60,7 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
 
     it "raises if task failed" do
       allow(svc_model_task).to receive(:state).and_return('finished')
-      svc_model_task.set_option(:progress => {:status => 'error'})
+      svc_model_task.set_option(:progress, :status => 'error')
       expect { described_class.new(ae_service).main }.to raise_error('Migration failed')
     end
   end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
@@ -57,5 +57,11 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
       expect(ae_service.root['ae_retry_server_affinity']).to be_nil
       expect(ae_service.root['ae_retry_interval']).to be_nil
     end
+
+    it "raises if task failed" do
+      allow(svc_model_task).to receive(:state).and_return('finished')
+      svc_model.set_option(:progress => { :status => 'error' })
+      expect { described_class.new(ae_service).main }.to raise_error('Migration failed')
+    end
   end
 end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
@@ -52,6 +52,7 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
     it "stops retrying when preflight check passed and handover is done" do
       allow(svc_model_task).to receive(:state).and_return('migrate')
       svc_model_task.set_option(:workflow_runner, 'automate')
+      svc_model_task.set_option(:progress, {:status => 'ok'})
       described_class.new(ae_service).main
       expect(ae_service.root['ae_result']).to be_nil
       expect(ae_service.root['ae_retry_server_affinity']).to be_nil
@@ -59,8 +60,9 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
     end
 
     it "raises if task failed" do
-      allow(svc_model_task).to receive(:state).and_return('finished')
-      svc_model_task.set_option(:progress, :status => 'error')
+      allow(svc_model_task).to receive(:state).and_return('migrate')
+      svc_model_task.set_option(:workflow_runner, 'automate')
+      svc_model_task.set_option(:progress, {:status => 'error'})
       expect { described_class.new(ae_service).main }.to raise_error('Migration failed')
     end
   end

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
@@ -60,7 +60,7 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
 
     it "raises if task failed" do
       allow(svc_model_task).to receive(:state).and_return('finished')
-      svc_model.set_option(:progress => { :status => 'error' })
+      svc_model_task.set_option(:progress => {:status => 'error'})
       expect { described_class.new(ae_service).main }.to raise_error('Migration failed')
     end
   end


### PR DESCRIPTION
In the current process, InfraConversionJob hands over to automate to finish the task. However, it doesn't propagate errors in the task status. This PR checks for the job (artificial) status and raises if it is equal to `error`. This way, the task fails, as well as its parent request.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789433