### PR TITLE
Save automate timeout in to a service options hash.

### DIFF
--- a/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/reconfigure.rb
+++ b/content/automate/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/Methods.class/__methods__/reconfigure.rb
@@ -6,7 +6,7 @@ $evm.log("info", "Starting Orchestration Reconfiguration")
 
 task = $evm.root["service_reconfigure_task"]
 service = task.source
-service.set_automate_timeout(@handle.field_timeout, 'reconfigure')
+service.set_automate_timeout($evm.field_timeout, 'reconfigure')
 
 begin
   service.update_orchestration_stack


### PR DESCRIPTION
Followup of https://github.com/ManageIQ/manageiq-content/pull/618

https://bugzilla.redhat.com/show_bug.cgi?id=1781353

@miq_bot add_label enhancement, changelog/no, ivanchuk/yes