### PR TITLE
Fix unhandled task failure during preflight check

### DIFF
--- a/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover.rb
+++ b/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover.rb
@@ -10,7 +10,7 @@ module ManageIQ
 
           def main
             @handle.log(:info, "WaitForHandover: task.state: #{@task.state} - task.options.workflow_runner: #{@task.get_option(:workflow_runner)}")
-            if @task.state != 'migrate' || @task.get_option(:workflow_runner) != 'automate'
+            if %w[active migrate].exclude?(@task.state) || @task.get_option(:workflow_runner) != 'automate'
               @handle.root['ae_result'] = 'retry'
               @handle.root['ae_retry_server_affinity'] = true
               @handle.root['ae_retry_interval'] = 15.seconds

--- a/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
+++ b/spec/content/automate/ManageIQ/Transformation/Common.class/__methods__/waitforhandover_spec.rb
@@ -41,6 +41,13 @@ describe ManageIQ::Automate::Transformation::Common::WaitForHandover do
       expect(ae_service.root['ae_retry_interval']).to eq(15.seconds)
     end
 
+    it "raises when preflight check failed" do
+      allow(svc_model_task).to receive(:state).and_return('active')
+      svc_model_task.set_option(:workflow_runner, 'automate')
+      svc_model_task.set_option(:progress, :status => 'error')
+      expect { described_class.new(ae_service).main }.to raise_error('Migration failed')
+    end
+
     it "retries when preflight check passed and handover is not done" do
       allow(svc_model_task).to receive(:state).and_return('migrate')
       described_class.new(ae_service).main


### PR DESCRIPTION
When a `ServiceTemplateTransformationPlanTask` fails its preflight check, it's not yet in the `migrate`, but still in the `active` state. So, even if `options[:workflow_runner]` is equal to `automate`, `WaitForHandover` method will exit in retry.

This pull request adds the `active` state to the condition to not retry, in order to allow a failed task to exit.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1819998