### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,4 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*                                          @tinaafitz @lfu
-
-/content/ansible/                          @syncrou @mkanoor
-/content/automate/ManageIQ/Transformation/ @fdupont-redhat @gmcculloug
-/content/automate/ManageIQ/System/Event/   @lfu @gmcculloug
+* @tinaafitz @lfu


### PR DESCRIPTION
Update codeowners to reflect current coverage.

Note: I remove `Transformation` line as `fdupont-redhat` is usually the one submitting the PRs so does not make sense to auto-assign to him anymore.

@tinaafitz @lfu Please review and suggest any changes you would like to see.