### PR TITLE
Add /System/Notification/Email/send_email method.

### DIFF
--- a/content/automate/ManageIQ/System/Notification/Email.class/__methods__/send_email.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/__methods__/send_email.yaml
@@ -1,0 +1,133 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: send_email
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: builtin
+    data: ''
+  inputs:
+  - field:
+      aetype: 
+      name: to
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: 
+      name: from
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: 
+      name: subject
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: 
+      name: body
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: 
+      name: cc
+      display_name: 
+      datatype: array
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: 
+      name: bcc
+      display_name: 
+      datatype: array
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: false
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 


### PR DESCRIPTION
Domain has a [default_scope](https://github.com/ManageIQ/manageiq-automation_engine/blob/ee70c81750d70c7e25a992b638b619b09868b70b/app/models/miq_ae_domain.rb#L11) to hide `$` domain.  

Add this method to replace `send_email` method in `$` domain to pave the way for removing `$` domain in the future.