### PR TITLE
Add compute.instance.resize.confirm.end to OpenStack event types

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/compute.instance.resize.confirm.end.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/OpenStack.class/compute.instance.resize.confirm.end.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: compute.instance.resize.confirm.end
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"


### PR DESCRIPTION
The compute.instance.resize.confirm.end is triggered when already prepared
Instance resize gets confirmed, it is needed to trigger refresh.

OpenStack targeted refresh code should not need any change since it looks on
compute.instance.* event types.