### PR TITLE
Raise error for Azure if no subnets can be found for a cloud network

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Placement.class/__methods__/best_fit_azure.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Placement.class/__methods__/best_fit_azure.rb
@@ -43,11 +43,10 @@ module ManageIQ
 
               def default_cloud_subnet
                 cloud_subnet = prov.eligible_cloud_subnets.first
+                raise "No cloud subnets found for cloud network" unless cloud_subnet
 
-                if cloud_subnet
-                  prov.set_cloud_subnet(cloud_subnet)
-                  @handle.log("info", "Selected Cloud Subnet: #{cloud_subnet.name}")
-                end
+                prov.set_cloud_subnet(cloud_subnet)
+                @handle.log("info", "Selected Cloud Subnet: #{cloud_subnet.name}")
               end
 
               def default_resource_group


### PR DESCRIPTION
In rare cases a virtual network might not have an associated subnet. In Azure you cannot provision a VM with a vnet that doesn't have at least one subnet.

So, this PR modifies the `default_cloud_subnet` method to raise an error if a cloud_subnet isn't found.

Originally spotted by @lfu. More info at https://github.com/ManageIQ/manageiq-providers-azure/issues/375.