### PR TITLE
Add refresh hook for AWS_API_CALL_ModifyVolume

### DIFF
--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifyvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifyvolume.yaml
@@ -3,10 +3,10 @@ object_type: instance
 version: 1.0
 object:
   attributes:
-    display_name:
+    display_name: 
     name: AWS_API_CALL_ModifyVolume
-    inherits:
-    description:
+    inherits: 
+    description: 
   fields:
   - rel4:
       value: "/System/event_handlers/refresh"

--- a/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifyvolume.yaml
+++ b/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class/aws_api_call_modifyvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: AWS_API_CALL_ModifyVolume
+    inherits:
+    description:
+  fields:
+  - rel4:
+      value: "/System/event_handlers/refresh"


### PR DESCRIPTION
We have handlers for creating, attaching, detaching and deleting volumes, but none currently for modifying a volume.

Attempts to address https://github.com/ManageIQ/manageiq-providers-amazon/issues/637