### PR TITLE
Skip the clean_yaml_spec if the underlying libyaml version is 0.2.x or later

### DIFF
--- a/spec/content/automate/clean_yaml_spec.rb
+++ b/spec/content/automate/clean_yaml_spec.rb
@@ -1,4 +1,4 @@
-describe "YAML files" do
+describe "YAML files", :clean_yaml => true do
   it "should be programatically generated" do
     yaml_files = ManageIQ::Content::Engine.root.join("content/**/*.yaml")
     invalid_files = Dir.glob(yaml_files).sort.select do |f|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.include Spec::Support::AutomationHelper
+  config.filter_run_excluding(:clean_yaml) if Psych.libyaml_version[1] > 1 # 0.1.x only
 
   config.before(:suite) do
     puts "** Resetting #{ENV["AUTOMATE_DOMAINS"]} domain(s)"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.include Spec::Support::AutomationHelper
-  config.filter_run_excluding(:clean_yaml) if Psych.libyaml_version[1] > 1 # 0.1.x only
+  config.filter_run_excluding(:clean_yaml) if ENV['CI'].nil? && Psych.libyaml_version[1] > 1 # 0.1.x only
 
   config.before(:suite) do
     puts "** Resetting #{ENV["AUTOMATE_DOMAINS"]} domain(s)"


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-content/pull/677, but this is mainly focused on getting specs to pass locally.

In short, skip running `clean_yaml_spec.rb` if the libyaml version is 0.2.x or greater using rspec filters.