### PR TITLE
[available_credentials_spec.rb] Use provider factory

### DIFF
--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/Methods.class/__methods__/available_credentials_spec.rb
@@ -1,7 +1,7 @@
 require_domain_file
 
 describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::AvailableCredentials do
-  let(:ansible_manager) { FactoryBot.create(:embedded_automation_manager_ansible) }
+  let(:ansible_manager) { FactoryBot.create(:provider_embedded_ansible).automation_manager }
   let(:playbook) do
     FactoryBot.create(:embedded_playbook, :manager => ansible_manager)
   end
@@ -90,7 +90,6 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::Ava
     end
 
     context "no service template" do
-      let(:ansible_manager) { FactoryBot.create(:embedded_automation_manager_ansible) }
       let(:root_object) do
         Spec::Support::MiqAeMockObject.new
       end


### PR DESCRIPTION
Instead of using the `:embedded_automation_manager_ansible` factory directly, use the `:provider_embedded_ansible` one and reference the `.automation_manager` from the provider.

See this commit for information about the `ensure_manager` code that exists on the provider for `EmbeddedAnsible`:

ManageIQ/manageiq@31a2f329b8809b76c1ef8fce572edde9917973de


Links
-----

Caused by: https://github.com/ManageIQ/manageiq/pull/20787