### PR TITLE
Support the retirement of VM which is provisioned by OVF service template

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -36,7 +36,7 @@ module ManageIQ
 
                   case @handle.inputs['removal_type'].try(:downcase)
                   when "remove_from_disk"
-                    remove_from_disk if @vm.miq_provision || @vm.tagged_with?(category, tag)
+                    remove_from_disk if @vm.miq_provision || @vm.service || @vm.tagged_with?(category, tag)
                   when "unregister"
                     unregister
                   else

--- a/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider_spec.rb
+++ b/spec/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider_spec.rb
@@ -63,6 +63,13 @@ describe ManageIQ::Automate::Infrastructure::VM::Retirement::StateMachines::Meth
     let(:ems) { FactoryBot.create(:ems_vmware, :zone => zone) }
     let(:vm) { FactoryBot.create(:vm_vmware, :ems_id => ems.id) }
 
+    it "removes a vm provisioned by OVF template" do
+      ae_service.inputs['removal_type'] = 'remove_from_disk'
+      vm.add_to_service(FactoryBot.create(:service_ovf))
+      expect { described_class.new(ae_service).main }.to_not raise_error
+      expect(ae_service.get_state_var('vm_removed_from_provider')).to be_truthy
+    end
+
     it_behaves_like 'ae_method'
   end
 


### PR DESCRIPTION
Vm provisioned by service template has an association to service. 

https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/16312