### PR TITLE
Adding support for `clone_to_template` workflow to CloudManager

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__class__.yaml
@@ -251,3 +251,43 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: relationship
+      name: ibm_powervs_rel1
+      display_name: 
+      datatype: string
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: powervs
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: ibm_powervs_meth1
+      display_name: 
+      datatype: string
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: powervs
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/ibm_powervs_preprovision_clone_to_template.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/ibm_powervs_preprovision_clone_to_template.rb
@@ -1,0 +1,8 @@
+#
+# Description: This method is used to apply PreProvision customizations.
+#
+
+# Get provisioning object
+prov = $evm.root["miq_provision"]
+
+$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/ibm_powervs_preprovision_clone_to_template.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__methods__/ibm_powervs_preprovision_clone_to_template.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ibm_powervs_PreProvision_Clone_to_Template
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision.yaml
@@ -16,3 +16,5 @@ object:
       value: PreProvision
   - google_meth1:
       value: PreProvision
+  - ibm_powervs_meth1:
+      value: PreProvision

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_template.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_template.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: PreProvision_Clone_to_Template
+    inherits: 
+    description: 
+  fields:
+  - ibm_powervs_meth1:
+      value: ibm_powervs_PreProvision_Clone_to_Template

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/__class__.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/__class__.yaml
@@ -1,0 +1,213 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: Factory State Machines
+    display_name: 
+    name: VMProvision_Template
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: state
+      name: CustomizeRequest
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: "/Cloud/VM/Provisioning/StateMachines/Methods/CustomizeRequest#${/#miq_provision.source.vendor}"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Customizing Request')
+      on_exit: update_provision_status(status => 'Customized Request')
+      on_error: update_provision_status(status => 'Error Customizing Request')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: RegisterCMDB
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Registering CMDB')
+      on_exit: update_provision_status(status => 'Registered CMDB')
+      on_error: update_provision_status(status => 'Error Registering CMDB')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: Placement
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: "/Cloud/VM/Provisioning/Placement/default#${/#miq_provision.source.vendor}"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Starting Placement')
+      on_exit: update_provision_status(status => 'Placement Complete')
+      on_error: update_provision_status(status => 'Error in Placement')
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: PreProvision
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: "/Cloud/VM/Provisioning/StateMachines/Methods/PreProvision_Clone_to_Template#${/#miq_provision.source.vendor}"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Applying PreProvision Customizations')
+      on_exit: update_provision_status(status => 'Applied PreProvision Customizations')
+      on_error: update_provision_status(status => 'Error Applying PreProvision Customizations')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: Provision
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: "/Cloud/VM/Provisioning/StateMachines/Methods/Provision"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Creating Template')
+      on_exit: update_provision_status(status => 'Creating Template')
+      on_error: update_provision_status(status => 'Error Creating Template')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: CheckProvisioned
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: "/Cloud/VM/Provisioning/StateMachines/Methods/CheckProvisioned"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: update_provision_status(status => 'Creating Template')
+      on_error: update_provision_status(status => 'Error Creating Template')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: PostProvision
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Applying PostProvision Customizations')
+      on_exit: update_provision_status(status => 'Applied PostProvision Customizations')
+      on_error: update_provision_status(status => 'Error Applying PostProvision Customizations')
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: state
+      name: ActivateCMDB
+      display_name: 
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Activating CMDB')
+      on_exit: update_provision_status(status => 'Activated CMDB')
+      on_error: update_provision_status(status => 'Error Activating CMDB')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: EmailOwner
+      display_name: 
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: "/System/Notification/Email/CloudMiqProvisionTemplateComplete?event=template_provisioned"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_provision_status(status => 'Emailing Owner')
+      on_exit: update_provision_status(status => 'Emailed Owner')
+      on_error: update_provision_status(status => 'Error Emailing Owner')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: Finished
+      display_name: 
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: "/System/CommonMethods/StateMachineMethods/template_publish_finished"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: '100'
+      max_time: 

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.rb
@@ -1,0 +1,27 @@
+#
+# Description: This method updates the provision status.
+# Required inputs: status
+#
+
+prov = $evm.root['miq_provision']
+unless prov
+  $evm.log(:error, "miq_provision object not provided")
+  exit(MIQ_STOP)
+end
+status = $evm.inputs['status']
+
+# Update Status Message
+updated_message  = "[#{$evm.root['miq_server'].name}] "
+updated_message += "VM [#{prov.get_option(:vm_target_name)}] "
+updated_message += "Step [#{$evm.root['ae_state']}] "
+updated_message += "Status [#{status}] "
+updated_message += "Message [#{prov.message}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+prov.miq_request.user_message = updated_message
+prov.message = status
+
+if $evm.root['ae_result'] == "error"
+  $evm.create_notification(:level => "error", :subject => prov.miq_request, \
+                           :message => "VM Provision Error: #{updated_message}")
+  $evm.log(:error, "VM Provision Error: #{updated_message}")
+end

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: update_provision_status
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs:
+  - field:
+      aetype: 
+      name: status
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/clone_to_template.yaml
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_Template.class/clone_to_template.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Clone VM to Template
+    name: clone_to_template
+    inherits: 
+    description: 
+  fields: []

--- a/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
@@ -32,10 +32,15 @@ module ManageIQ
                 final_message += "Service [#{task.destination.name}] Provisioned Successfully"
                 @handle.create_notification(:type => :automate_service_provisioned, :subject => task.destination) if task.miq_request_task.nil?
               when 'miq_provision'
-                final_message += "VM [#{task.get_option(:vm_target_name)}] "
-                final_message += "IP [#{task.vm.ipaddresses.first}] " if task.vm&.ipaddresses.present?
-                final_message += "Provisioned Successfully"
-                @handle.create_notification(:type => :automate_vm_provisioned, :subject => task.vm)
+                if task.get_option(:request_type) == :clone_to_template
+                  final_message += "Template [#{task.get_option(:vm_target_name)}] Published Successfully"
+                  @handle.create_notification(:type => :automate_template_published, :subject => task.vm)
+                else
+                  final_message += "VM [#{task.get_option(:vm_target_name)}] "
+                  final_message += "IP [#{task.vm.ipaddresses.first}] " if task.vm&.ipaddresses.present?
+                  final_message += "Provisioned Successfully"
+                  @handle.create_notification(:type => :automate_vm_provisioned, :subject => task.vm)
+                end
               else
                 final_message += @handle.inputs['message']
               end

--- a/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/template_publish_finished.yaml
+++ b/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/template_publish_finished.yaml
@@ -1,0 +1,13 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: template_publish_finished
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: task_finished(object => 'template_publish_task', message => 'Template
+        Published Successfully' )

--- a/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisiontemplatecomplete.yaml
+++ b/content/automate/ManageIQ/System/Notification/Email.class/cloudmiqprovisiontemplatecomplete.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CloudMiqProvisionTemplateComplete
+    inherits: 
+    description: 
+  fields:
+  - to:
+      value: "${/#miq_provision.miq_request.get_option(:owner_email)} || ${/#miq_provision.miq_request.requester.email}
+        || ${/Configuration/Email/Default#default_recipient}"
+  - subject:
+      value: 'Request ID ${/#miq_provision.miq_request.id} - Your Publish to Template
+        Request has Completed - Template Name : ${/#miq_provision.vm}'
+  - customize:
+      value: miq_provision_template_customize_body

--- a/spec/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished_spec.rb
+++ b/spec/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished_spec.rb
@@ -91,6 +91,7 @@ describe ManageIQ::Automate::System::CommonMethods::StateMachineMethods::TaskFin
 
     it "task_finished" do
       expect(ae_service).to receive(:create_notification)
+      allow(svc_miq_provision_task).to receive(:get_option).with(:request_type).and_return('clone_to_vm')
       allow(svc_miq_provision_task).to receive(:get_option).with(:vm_target_name).and_return('fred')
       allow(svc_miq_provision_task).to receive(:finished).once
       expect(Notification.count).to eq(0)


### PR DESCRIPTION
This is to enable `clone_to_template` workflow in `CloudManager` context, mimicking what's already implemented on `InfraManager` side. Defines the generic structure for the workflow and `ibm_powervs` UI pages triggered via: https://github.com/ManageIQ/manageiq-ui-classic/pull/8248

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>