### PR TITLE
Add oVirt automate provisioning methods

### DIFF
--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__class__.yaml
@@ -191,3 +191,23 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: method
+      name: ovirt
+      display_name: 
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: ovirt
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_fit_cluster.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_fit_cluster.rb
@@ -1,0 +1,53 @@
+#
+# Description: This method sets the cluster based on source template
+#
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Provisioning
+          module Placement
+            class OvirtBestFitCluster
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def main
+                best_fit_cluster
+              end
+
+              private
+
+              def request
+                @handle.root["miq_provision"].tap do |req|
+                  raise "miq_provision not specified" if req.nil?
+                end
+              end
+
+              def vm
+                request.vm_template.tap do |vm|
+                  raise 'VM not specified' if vm.nil?
+                  raise "EMS not found for VM [#{vm.name}]" if vm.ext_management_system.nil?
+                end
+              end
+
+              def best_fit_cluster
+                @handle.log("info", "vm=[#{vm.name}]")
+
+                cluster = vm.ems_cluster
+                @handle.log("info", "Selected Cluster: [#{cluster.nil? ? "nil" : cluster.name}]")
+
+                # Set cluster
+                request.set_cluster(cluster) if cluster
+
+                @handle.log("info", "vm=[#{vm.name}] cluster=[#{cluster}]")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::Infrastructure::VM::Provisioning::Placement::OvirtBestFitCluster.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_fit_cluster.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_fit_cluster.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ovirt_best_fit_cluster
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_placement_with_scope.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_placement_with_scope.rb
@@ -1,0 +1,223 @@
+#
+# Description: This method is used to find the incoming templates cluster as well as hosts and storage that have the tag category
+# prov_scope = 'all' && prov_scope = <group-name>
+# Modified for ovirt
+#
+
+# Get variables
+prov = $evm.root["miq_provision"]
+vm = prov.vm_template
+raise "VM not specified" if vm.nil?
+user = prov.miq_request.requester
+raise "User not specified" if user.nil?
+ems  = vm.ext_management_system
+raise "EMS not found for VM:<#{vm.name}>" if ems.nil?
+cluster = vm.ems_cluster
+raise "Cluster not found for VM:<#{vm.name}>" if cluster.nil?
+$evm.log("info", "Selected Cluster: [#{cluster.nil? ? "nil" : cluster.name}]")
+
+tags  = {}
+#############################
+# Get Tags that are in scope
+# Default is to look for Hosts and Datastores tagged with prov_scope = All or match to Group
+#############################
+normalized_ldap_group = user.normalized_ldap_group.gsub(/\W/,'_')
+tags["prov_scope"] = ["all", normalized_ldap_group]
+
+$evm.log("info", "VM=<#{vm.name}>, Space Required=<#{vm.provisioned_storage}>, group=<#{user.normalized_ldap_group}>")
+
+#############################
+# STORAGE LIMITATIONS
+#############################
+STORAGE_MAX_VMS      = 0
+storage_max_vms      = $evm.object['storage_max_vms']
+storage_max_vms      = storage_max_vms.strip.to_i if storage_max_vms.kind_of?(String) && !storage_max_vms.strip.empty?
+storage_max_vms      = STORAGE_MAX_VMS unless storage_max_vms.kind_of?(Numeric)
+STORAGE_MAX_PCT_USED = 100
+storage_max_pct_used = $evm.object['storage_max_pct_used']
+storage_max_pct_used = storage_max_pct_used.strip.to_i if storage_max_pct_used.kind_of?(String) && !storage_max_pct_used.strip.empty?
+storage_max_pct_used = STORAGE_MAX_PCT_USED unless storage_max_pct_used.kind_of?(Numeric)
+$evm.log("info", "storage_max_vms:<#{storage_max_vms}> storage_max_pct_used:<#{storage_max_pct_used}>")
+
+#############################
+# Set host sort order here
+# options: :active_provisioning_memory, :active_provisioning_cpu, :random
+#############################
+HOST_SORT_ORDER = [:active_provisioning_memory, :random]
+
+#############################
+# Sort hosts
+#############################
+active_prov_data = prov.check_quota(:active_provisions)
+sort_data = []
+
+# Only consider hosts confined to the cluster where the template resides
+cluster.hosts.each do |h|
+  sort_data << sd = [[], h.name, h]
+  host_id = h.attributes['id'].to_i
+  HOST_SORT_ORDER.each do |type|
+    sd[0] << case type
+             # Multiply values by (-1) to cause larger values to sort first
+             when :active_provisioning_memory
+               active_prov_data[:active][:memory_by_host_id][host_id]
+             when :active_provisioning_cpu
+               active_prov_data[:active][:cpu_by_host_id][host_id]
+             when :random
+               rand(1000)
+             else 0
+             end
+  end
+end
+
+sort_data.sort! { |a, b| a[0] <=> b[0] }
+hosts = sort_data.collect { |sd| sd.pop }
+$evm.log("info", "Sorted host Order:<#{HOST_SORT_ORDER.inspect}> Results:<#{sort_data.inspect}>")
+
+#############################
+# Set storage sort order here
+# options: :active_provisioning_vms, :free_space, :free_space_percentage, :random
+#############################
+STORAGE_SORT_ORDER = [:free_space, :active_provisioning_vms, :random]
+
+host = storage = nil
+min_registered_vms = nil
+hosts.each do |h|
+  next if h.maintenance
+  next unless h.power_state == "on"
+
+  #############################
+  # Only consider hosts that have the required tags
+  #############################
+  next unless tags.all? do |key, value|
+    if value.kind_of?(Array)
+      value.any? { |v| h.tagged_with?(key, v) }
+    else
+      h.tagged_with?(key, value)
+    end
+  end
+
+  nvms = h.vms.length
+
+  #############################
+  # Only consider storages that have the tag category group=all
+  #############################
+  storages = h.writable_storages.select do |s|
+    tags.all? do |key, value|
+      if value.kind_of?(Array)
+        value.any? { |v| s.tagged_with?(key, v) }
+      else
+        s.tagged_with?(key, value)
+      end
+    end
+  end
+
+  $evm.log("info", "Evaluating storages:<#{storages.collect { |s| s.name }.join(", ")}>")
+
+  #############################
+  # Filter out storages that do not have enough free space for the VM
+  #############################
+  active_prov_data = prov.check_quota(:active_provisions)
+  storages = storages.select do |s|
+    storage_id = s.attributes['id'].to_i
+    actively_provisioned_space = active_prov_data[:active][:storage_by_id][storage_id]
+    if s.free_space > vm.provisioned_storage + actively_provisioned_space
+      true
+    else
+      $evm.log("info", "Skipping Datastore:<#{s.name}>, not enough free space for VM:<#{vm.name}>. Available:<#{s.free_space}>, Needs:<#{vm.provisioned_storage}>")
+      false
+    end
+  end
+
+  #############################
+  # Filter out storages number of VMs is greater than the max number of VMs allowed per Datastore
+  #############################
+  storages = storages.select do |s|
+    storage_id = s.attributes['id'].to_i
+    active_num_vms_for_storage = active_prov_data[:active][:vms_by_storage_id][storage_id].length
+    if (storage_max_vms == 0) || ((s.vms.size + active_num_vms_for_storage) < storage_max_vms)
+      true
+    else
+      $evm.log("info", "Skipping Datastore:<#{s.name}>, max number of VMs:<#{s.vms.size + active_num_vms_for_storage}> exceeded")
+      false
+    end
+  end
+
+  #############################
+  # Filter out storages where percent used will be greater than the max % allowed per Datastore
+  #############################
+  storages = storages.select do |s|
+    storage_id = s.attributes['id'].to_i
+    active_pct_of_storage  = ((active_prov_data[:active][:storage_by_id][storage_id]) / s.total_space.to_f) * 100
+    request_pct_of_storage = (vm.provisioned_storage / s.total_space.to_f) * 100
+
+    if (storage_max_pct_used == 100) || ((s.v_used_space_percent_of_total + active_pct_of_storage + request_pct_of_storage) < storage_max_pct_used)
+      true
+    else
+      $evm.log("info", "Skipping Datastore:<#{s.name}> percent of used space #{s.v_used_space_percent_of_total + active_pct_of_storage + request_pct_of_storage} exceeded")
+      false
+    end
+  end
+
+  if min_registered_vms.nil? || nvms < min_registered_vms
+    #############################
+    # Sort storage to determine target datastore
+    #############################
+    sort_data = []
+    storages.each_with_index do |s, idx|
+      sort_data << sd = [[], s.name, idx]
+      storage_id = s.attributes['id'].to_i
+      STORAGE_SORT_ORDER.each do |type|
+        sd[0] << case type
+                 when :free_space
+                   # Multiply values by (-1) to cause larger values to sort first
+                   (s.free_space - active_prov_data[:active][:storage_by_id][storage_id]) * -1
+                 when :free_space_percentage
+                   active_pct_of_storage  = ((active_prov_data[:active][:storage_by_id][storage_id]) / s.total_space.to_f) * 100
+                   s.v_used_space_percent_of_total + active_pct_of_storage
+                 when :active_provioning_vms
+                   active_prov_data[:active][:vms_by_storage_id][storage_id].length
+                 when :random
+                   rand(1000)
+                 else 0
+                 end
+      end
+    end
+
+    sort_data.sort! { |a, b| a[0] <=> b[0] }
+    $evm.log("info", "Sorted storage Order:<#{STORAGE_SORT_ORDER.inspect}>  Results:<#{sort_data.inspect}>")
+    selected_storage = sort_data.first
+    unless selected_storage.nil?
+      selected_idx = selected_storage.last
+      storage = storages[selected_idx]
+      host    = h
+    end
+
+    # Stop checking if we have found both host and storage
+    break if host && storage
+  end
+
+end # END - hosts.each
+
+# Set Host
+obj = $evm.object
+$evm.log("info", "Selected Host:<#{host.nil? ? "nil" : host.name}>")
+if host
+  obj["host"] = host
+  prov.set_host(host)
+end
+
+# Set Storage
+$evm.log("info", "Selected Datastore:<#{storage.nil? ? "nil" : storage.name}>")
+if storage
+  obj["storage"] = storage
+  prov.set_storage(storage)
+end
+
+# Set cluster
+$evm.log("info", "Selected Cluster:<#{cluster.nil? ? "nil" : cluster.name}>")
+if cluster
+  obj["cluster"] = cluster
+  prov.set_cluster(cluster)
+end
+
+$evm.log("info", "vm=<#{vm.name}> host=<#{host.try(:name)}> storage=<#{storage.try(:name)}> cluster=<#{cluster.try(:name)}>")

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_placement_with_scope.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/ovirt_best_placement_with_scope.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ovirt_best_placement_with_scope
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/default.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/default.yaml
@@ -10,6 +10,8 @@ object:
   fields:
   - redhat:
       value: redhat_best_fit_cluster
+  - ovirt:
+      value: ovirt_best_fit_cluster
   - vmware:
       value: vmware_best_fit_least_utilized
   - microsoft:

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__class__.yaml
@@ -211,3 +211,43 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: relationship
+      name: ovirt_rel1
+      display_name: ''
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: ovirt
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: ovirt_meth1
+      display_name: ''
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: ovirt
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_customizerequest.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_customizerequest.rb
@@ -1,0 +1,203 @@
+#
+# Description: This method is used to Customize the Provisioning Request
+# Customization Template mapping for RHEV, RHEV PXE, and RHEV ISO provisioning
+#
+
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Provisioning
+          module StateMachines
+            module Methods
+              class OvirtCustomizeRequest
+                def initialize(handle = $evm)
+                  @handle = handle
+                  @mapping = false
+                end
+
+                def main
+                  log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
+                  log(:info, "Template: #{template.name} Provider: #{provider.name} Vendor: #{template.vendor} Product: #{product}")
+                  # Build case statement to determine which type of processing is required
+                  case prov.type
+                  when 'ManageIQ::Providers::Ovirt::InfraManager::Provision'
+                    process_ovirt if @mapping
+                  when 'ManageIQ::Providers::Ovirt::InfraManager::ProvisionViaIso'
+                    process_ovirt_iso if @mapping
+                  when 'ManageIQ::Providers::Ovirt::InfraManager::ProvisionViaPxe'
+                    process_ovirt_pxe if @mapping
+                  else
+                    log(:info, "Provisioning Type: #{prov.type} does not match, skipping processing")
+                  end
+                end
+
+                private
+
+                def prov
+                  @prov ||= @handle.root["miq_provision"].tap do |req|
+                    raise 'miq_provision not specified' if req.nil?
+                  end
+                end
+
+                def template
+                  @template ||= prov.vm_template.tap do |req|
+                    raise 'vm_template not specified' if req.nil?
+                  end
+                end
+
+                def provider
+                  @provider ||= template.ext_management_system.tap do |ems|
+                    raise 'ext_management_system not specified' if ems.nil?
+                  end
+                end
+
+                def product
+                  @product ||= template.operating_system&.product_name&.downcase
+                end
+
+                def ws_values
+                  @ws_values ||= prov.options.fetch(:ws_values, {})
+                end
+
+                def log(level, msg, update_message = false)
+                  @handle.log(level, msg)
+                  @handle.root['miq_provision'].message = msg if @handle.root['miq_provision'] && update_message
+                end
+
+                def process_ovirt_pxe
+                  if product.include?("windows")
+                    # find the windows image that matches the template name if a PXE Image was NOT chosen in the dialog
+                    if prov.get_option(:pxe_image_id).nil?
+
+                      log(:info, "Inspecting prov.eligible_windows_images: #{prov.eligible_windows_images.inspect}")
+                      pxe_image = prov.eligible_windows_images.detect { |pi| pi.name.casecmp(template.name) == 0 }
+                      if pxe_image.nil?
+                        msg = "Failed to find matching PXE Image"
+                        log(:error, msg, true)
+                        raise msg
+                      else
+                        log(:info, "Found matching Windows PXE Image ID: #{pxe_image.id} Name: #{pxe_image.name} Description: #{pxe_image.description}")
+                      end
+                      prov.set_windows_image(pxe_image)
+                      log(:info, "Provisioning object updated {:pxe_image_id => #{prov.get_option(:pxe_image_id).inspect}}")
+                    end
+                    # Find the first customization template that matches the template name if none was chosen in the dialog
+                    if prov.get_option(:customization_template_id).nil?
+                      log(:info, "Inspecting Eligible Customization Templates: #{prov.eligible_customization_templates.inspect}")
+                      cust_temp = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name) == 0 }
+                      if cust_temp.nil?
+                        msg = "Failed to find matching PXE Image"
+                        log(:error, msg, true)
+                        raise msg
+                      end
+                      log(:info, "Found matching Windows Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+                      prov.set_customization_template(cust_temp)
+                      log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+                    end
+                  else
+                    # find the first PXE Image that matches the template name if NOT chosen in the dialog
+                    if prov.get_option(:pxe_image_id).nil?
+                      pxe_image = prov.eligible_pxe_images.detect { |pi| pi.name.casecmp(template.name) == 0 }
+                      log(:info, "Found Linux PXE Image ID: #{pxe_image.id} Name: #{pxe_image.name} Description: #{pxe_image.description}")
+                      prov.set_pxe_image(pxe_image)
+                      log(:info, "Provisioning object updated {:pxe_image_id => #{prov.get_option(:pxe_image_id).inspect}}")
+                    end
+                    # Find the first Customization Template that matches the template name if NOT chosen in the dialog
+                    if prov.get_option(:customization_template_id).nil?
+                      cust_temp = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name) == 0 }
+                      log(:info, "Found Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+                      prov.set_customization_template(cust_temp)
+                      log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+                    end
+                  end
+                end
+
+                # process_ovirt_iso - mapping customization templates (ks.cfg)
+                def process_ovirt_iso
+                  if product.include?("windows")
+                    # Linux Support only for now
+                  else
+                    # Linux - Find the first ISO Image that matches the template name if NOT chosen in the dialog
+                    if prov.get_option(:iso_image_id).nil?
+                      log(:info, "Inspecting prov.eligible_iso_images: #{prov.eligible_iso_images.inspect}")
+                      iso_image = prov.eligible_iso_images.detect { |iso| iso.name.casecmp(template.name) == 0 }
+                      if iso_image.nil?
+                        msg = "Failed to find matching ISO Image"
+                        log(:error, msg, true)
+                        raise msg
+                      else
+                        log(:info, "Found Linux ISO Image ID: #{iso_image.id} Name: #{iso_image.name}")
+                        prov.set_iso_image(iso_image)
+                        log(:info, "Provisioning object updated {:iso_image_id => #{prov.get_option(:iso_image_id).inspect}}")
+                      end
+                    else
+                      log(:info, "ISO Image selected from dialog: #{prov.get_option(:iso_image_id).inspect}")
+                    end
+
+                    # Find the first Customization Template that matches the template name if NOT chosen in the dialog
+                    if prov.get_option(:customization_template_id).nil?
+                      log(:info, "prov.eligible_customization_templates: #{prov.eligible_customization_templates.inspect}")
+
+                      cust_temp = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name) == 0 }
+                      if cust_temp.nil?
+                        msg = "Failed to find matching Customization Template"
+                        log(:error, msg, true)
+                        raise msg
+                      else
+                        log(:info, "Found Customization Template ID: #{cust_temp.id} Name: #{cust_temp.name} Description: #{cust_temp.description}")
+                        prov.set_customization_template(cust_temp)
+                        log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+                      end
+                    else
+                      log(:info, "Customization Template selected from dialog: #{prov.get_option(:customization_template_id).inspect}")
+                    end
+                  end
+                end
+
+                # process_ovirt - mapping cloud-init templates
+                def process_ovirt
+                  log(:info, "Processing process_ovirt...", true)
+                  if prov.get_option(:customization_template_id).nil?
+                    customization_template_search_by_ws_values = ws_values[:customization_template]
+                    customization_template_search_by_template_name = template.name
+                    log(:info, "prov.eligible_customization_templates: #{prov.eligible_customization_templates.inspect}")
+                    customization_template = nil
+
+                    unless customization_template_search_by_template_name.nil?
+                      # Search for customization templates enabled for Cloud-Init that match the template/image name
+                      if customization_template.blank?
+                        log(:info, "Searching for customization templates enabled for (Cloud-Init) that are named: #{customization_template_search_by_template_name}")
+                        customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(template.name) == 0 }
+                      end
+                    end
+                    unless customization_template_search_by_ws_values.nil?
+                      # Search for customization templates enabled for Cloud-Init that match ws_values[:customization_template]
+                      if customization_template.blank?
+                        log(:info, "Searching for customization templates enabled for (Cloud-Init) that are named: #{customization_template_search_by_ws_values}")
+                        customization_template = prov.eligible_customization_templates.detect { |ct| ct.name.casecmp(customization_template_search_by_ws_values) == 0 }
+                      end
+                    end
+                    if customization_template.blank?
+                      log(:warn, "Failed to find matching Customization Template", true)
+                    else
+                      log(:info, "Found Customization Template ID: #{customization_template.id} Name: #{customization_template.name} Description: #{customization_template.description}")
+                      prov.set_customization_template(customization_template) rescue nil
+                      log(:info, "Provisioning object updated {:customization_template_id => #{prov.get_option(:customization_template_id).inspect}}")
+                      log(:info, "Provisioning object updated {:customization_template_script => #{prov.get_option(:customization_template_script).inspect}}")
+                    end
+                  else
+                    log(:info, "Customization Template selected from dialog ID: #{prov.get_option(:customization_template_id).inspect} Script: #{prov.get_option(:customization_template_script).inspect}")
+                  end
+                  log(:info, "Processing process_ovirt...Complete", true)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::Infrastructure::VM::Provisioning::StateMachines::Methods::OvirtCustomizeRequest.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_customizerequest.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_customizerequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ovirt_CustomizeRequest
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_postprovision.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_postprovision.rb
@@ -1,0 +1,8 @@
+#
+# Description: This method is used to process tasks immediately after the VM has been provisioned
+#
+
+# Get provisioning object
+prov = $evm.root["miq_provision"]
+
+$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_postprovision.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_postprovision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ovirt_PostProvision
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision.rb
@@ -1,0 +1,84 @@
+#
+# Description: This default method is used to apply PreProvision customizations for RHEV provisioning
+#
+
+module ManageIQ
+  module Automate
+    module Infrastructure
+      module VM
+        module Provisioning
+          module StateMachines
+            module Methods
+              class OvirtPreprovision
+                def initialize(handle = $evm)
+                  @handle = handle
+                  @set_vlan  = false
+                  @set_notes = true
+                end
+
+                def main
+                  log(:info, "Provision:<#{prov.id}> Request:<#{prov.miq_provision_request.id}> Type:<#{prov.type}>")
+                  process_customization
+                end
+
+                private
+
+                def prov
+                  @prov ||= @handle.root["miq_provision"].tap do |req|
+                    raise 'miq_provision not specified' if req.nil?
+                  end
+                end
+
+                def template
+                  @template ||= prov.vm_template.tap do |req|
+                    raise 'vm_template not specified' if req.nil?
+                  end
+                end
+
+                def product
+                  @product ||= template.operating_system&.product_name&.downcase
+                end
+
+                def log(level, msg, update_message = false)
+                  @handle.log(level, msg)
+                  @handle.root['miq_provision'].message = msg if @handle.root['miq_provision'] && update_message
+                end
+
+                def process_customization
+                  log(:info, "Template:<#{template.name}> Vendor:<#{template.vendor}> Product:<#{product}>")
+
+                  if @set_vlan
+                    # Set default VLAN here if one was not chosen in the dialog?
+                    # The format needs to be "#{vnic_profile_name} (#{network_name})"
+                    default_vlan = "ovirtmgmt (ovirtmgmt)"
+
+                    if prov.get_option(:vlan).nil?
+                      prov.set_vlan(default_vlan)
+                      log(:info, "Provisioning object <:vlan> updated with <#{default_vlan}>")
+                    end
+                  end
+
+                  if @set_notes
+                    log(:info, "Processing set_notes...", true)
+                    vmdescription = prov.get_option(:vm_description)
+
+                    # Setup VM Annotations
+                    vm_notes =  "Owner: #{prov.get_option(:owner_first_name)} #{prov.get_option(:owner_last_name)}"
+                    vm_notes += "\nEmail: #{prov.get_option(:owner_email)}"
+                    vm_notes += "\nSource Template: #{template.name}"
+                    vm_notes += "\nCustom Description: #{vmdescription}" unless vmdescription.nil?
+                    prov.set_vm_notes(vm_notes)
+                    log(:info, "Provisioning object <:vm_notes> updated with <#{vm_notes}>")
+                    log(:info, "Processing set_notes...Complete", true)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+ManageIQ::Automate::Infrastructure::VM::Provisioning::StateMachines::Methods::OvirtPreprovision.new.main

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ovirt_PreProvision
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_template.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_template.rb
@@ -1,0 +1,8 @@
+#
+# Description: This method is used to apply PreProvision customizations.
+#
+
+# Get provisioning object
+prov = $evm.root["miq_provision"]
+
+$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_template.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_template.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ovirt_PreProvision_Clone_to_Template
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_vm.rb
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_vm.rb
@@ -1,0 +1,8 @@
+#
+# Description: This method is used to apply PreProvision customizations during the cloning to a VM:
+#
+
+# Get provisioning object
+prov = $evm.root["miq_provision"]
+
+$evm.log("info", "Provisioning ID:<#{prov.id}> Provision Request ID:<#{prov.miq_provision_request.id}> Provision Type: <#{prov.provision_type}>")

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_vm.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/ovirt_preprovision_clone_to_vm.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: ovirt_PreProvision_Clone_to_VM
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/customizerequest.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/customizerequest.yaml
@@ -12,3 +12,5 @@ object:
       value: vmware_CustomizeRequest
   - redhat_meth1:
       value: redhat_CustomizeRequest
+  - ovirt_meth1:
+      value: ovirt_CustomizeRequest

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/postprovision.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/postprovision.yaml
@@ -12,3 +12,5 @@ object:
       value: vmware_PostProvision
   - redhat_meth1:
       value: redhat_PostProvision
+  - ovirt_meth1:
+      value: ovirt_PostProvision

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/preprovision.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/preprovision.yaml
@@ -12,3 +12,5 @@ object:
       value: vmware_PreProvision
   - redhat_meth1:
       value: redhat_PreProvision
+  - ovirt_meth1:
+      value: ovirt_PreProvision

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_template.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_template.yaml
@@ -12,3 +12,5 @@ object:
       value: vmware_PreProvision_Clone_to_Template
   - redhat_meth1:
       value: redhat_PreProvision_Clone_to_Template
+  - ovirt_meth1:
+      value: ovirt_PreProvision_Clone_to_Template

--- a/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_vm.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods.class/preprovision_clone_to_vm.yaml
@@ -12,3 +12,5 @@ object:
       value: vmware_PreProvision_Clone_to_VM
   - redhat_meth1:
       value: redhat_PreProvision_Clone_to_VM
+  - ovirt_meth1:
+      value: ovirt_PreProvision_Clone_to_VM

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__class__.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__class__.yaml
@@ -211,3 +211,43 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: method
+      name: ovirt_meth1
+      display_name: oVirt
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: ovirt
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: ovirt_rel1
+      display_name: oVirt
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: ovirt
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/checkpreretirement.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/checkpreretirement.yaml
@@ -10,6 +10,8 @@ object:
   fields:
   - redhat_meth1:
       value: check_pre_retirement
+  - ovirt_meth1:
+      value: check_pre_retirement
   - vmware_meth1:
       value: check_pre_retirement
   - microsoft_meth1:

--- a/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/preretirement.yaml
+++ b/content/automate/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/preretirement.yaml
@@ -10,6 +10,8 @@ object:
   fields:
   - redhat_meth1:
       value: pre_retirement
+  - ovirt_meth1:
+      value: pre_retirement
   - vmware_meth1:
       value: pre_retirement
   - microsoft_meth1:

--- a/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job_spec.rb
@@ -211,7 +211,7 @@ describe ManageIQ::Automate::AutomationManagement::AnsibleTower::Operations::Sta
     let(:workflow_jt_class) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationWorkflow }
     let(:workflow_job) { FactoryBot.create(:ansible_tower_workflow_job) }
     let(:svc_workflow_job) { workflow_job_class.find(workflow_job.id) }
-    let(:workflow_template) { FactoryBot.create(:configuration_workflow, :manager_id => manager.id) }
+    let(:workflow_template) { FactoryBot.create(:ansible_configuration_workflow, :manager_id => manager.id) }
     let(:svc_workflow_template) { workflow_jt_class.find(workflow_template.id) }
 
     before do


### PR DESCRIPTION
- needed as a result of ovirt/rhv split

Related:
- https://github.com/ManageIQ/manageiq-providers-ovirt/pull/611
- https://github.com/ManageIQ/manageiq-automation_engine/pull/504

@miq-bot assign @agrare 
@miq-bot add_label bug