### PR TITLE
Do not require prov. dialog to set :number_of_vms

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname.rb
@@ -60,7 +60,7 @@ module ManageIQ
 
               # Returns the name suffix (provision number) or nil if provisioning only one
               def suffix(condensed)
-                "$n{3}" if provision_object.get_option(:number_of_vms) > 1 || !condensed
+                "$n{3}" if (provision_object.get_option(:number_of_vms) || 1) > 1 || !condensed
               end
             end
           end

--- a/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname_spec.rb
+++ b/spec/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname_spec.rb
@@ -44,12 +44,36 @@ describe ManageIQ::Automate::Cloud::VM::Provisioning::Naming::VmName do
       expect(service.object['vmname']).to eq('abcpro$n{3}')
     end
 
-    it "provisions single vm" do
+    it "provisions single vm without name from dialog" do
       provision.update!(:options => {:number_of_vms => 1})
 
       described_class.new(service).main
 
       expect(service.object['vmname']).to eq('abc$n{3}')
+    end
+
+    it "provisions single vm with name from dialog" do
+      provision.update!(:options => {:number_of_vms => 1, :vm_name => "jay"})
+
+      described_class.new(service).main
+
+      expect(service.object['vmname']).to eq('jay')
+    end
+
+    it "provisions single vm without name from dialog when number of vms is nil" do
+      provision.update!(:options => {})
+
+      described_class.new(service).main
+
+      expect(service.object['vmname']).to eq('abc$n{3}')
+    end
+
+    it "provisions single vm with name from dialog when number of vms is nil" do
+      provision.update!(:options => {:vm_name => "jay"})
+
+      described_class.new(service).main
+
+      expect(service.object['vmname']).to eq('jay')
     end
   end
 end


### PR DESCRIPTION
For some provisioning dialogs it makes sense to assume the number of VMs
is 1. For example, when provisioning a template from an existing VM. The
VmName suffix method can safely treat a nil :number_of_vms the same as
:number_of_vms == 1, eliminating the need to set the value explicitly in
the provider dialog.

Related to:
- ManageIQ/manageiq-providers-ibm_cloud#418