### PR TITLE
Multiple notifications bug fix

### DIFF
--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -24,10 +24,15 @@ module ManageIQ
                 updated_message = update_status_message(prov, @handle.inputs['status'])
 
                 if @handle.root['ae_result'] == "error"
-                  @handle.create_notification(:level   => "error",
-                                              :subject => prov.miq_request,
-                                              :message => "Service Provision Error: #{updated_message}")
-                  @handle.log(:error, "Service Provision Error: #{updated_message}")
+                  check = "Service Provision Error: #{check_message(prov)}"
+                  message = "Service Provision Error: #{updated_message}"
+                  notified = @handle.vmdb('notification').where('options LIKE ?',"%#{check}%")
+                  if notified.count < 1
+                    @handle.create_notification(:level   => "error",
+                                                :subject => prov.miq_request,
+                                                :message => message)
+                    @handle.log(:error, message)
+                  end
                 end
               end
 

--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -39,8 +39,7 @@ module ManageIQ
               private
 
               def check_message(prov)
-                updated_message  = "Server [#{@handle.root['miq_server'].name}] "
-                updated_message += "Service [#{prov.destination.name}]"
+                "Server [#{@handle.root['miq_server'].name}] Service [#{prov.destination.name}]"
               end
 
               def update_status_message(prov, status)

--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -38,6 +38,11 @@ module ManageIQ
 
               private
 
+              def check_message(prov)
+                updated_message  = "Server [#{@handle.root['miq_server'].name}] "
+                updated_message += "Service [#{prov.destination.name}]"
+              end
+
               def update_status_message(prov, status)
                 updated_message  = "Server [#{@handle.root['miq_server'].name}] "
                 updated_message += "Service [#{prov.destination.name}] "

--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -26,7 +26,7 @@ module ManageIQ
                 if @handle.root['ae_result'] == "error"
                   check = "Service Provision Error: #{check_message(prov)}"
                   message = "Service Provision Error: #{updated_message}"
-                  notified = @handle.vmdb('notification').where('options LIKE ?',"%#{check}%")
+                  notified = @handle.vmdb('notification').where('options LIKE ?', "%#{check}%")
                   if notified.count < 1
                     @handle.create_notification(:level   => "error",
                                                 :subject => prov.miq_request,

--- a/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
@@ -30,7 +30,8 @@ module ManageIQ
               case @handle.root['vmdb_object_type']
               when 'service_template_provision_task'
                 final_message += "Service [#{task.destination.name}] Provisioned Successfully"
-                @handle.create_notification(:type => :automate_service_provisioned, :subject => task.destination) if task.miq_request_task.nil?
+                notified = @handle.vmdb('notification').where('options LIKE ?',"%#{final_message}%")
+                @handle.create_notification(:type => :automate_service_provisioned, :subject => task.destination) if task.miq_request_task.nil?  && notified.count < 1
               when 'miq_provision'
                 if task.get_option(:request_type) == :clone_to_template
                   final_message += "Template [#{task.get_option(:vm_target_name)}] Published Successfully"

--- a/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
@@ -30,8 +30,8 @@ module ManageIQ
               case @handle.root['vmdb_object_type']
               when 'service_template_provision_task'
                 final_message += "Service [#{task.destination.name}] Provisioned Successfully"
-                notified = @handle.vmdb('notification').where('options LIKE ?',"%#{final_message}%")
-                @handle.create_notification(:type => :automate_service_provisioned, :subject => task.destination) if task.miq_request_task.nil?  && notified.count < 1
+                notified = @handle.vmdb('notification').where('options LIKE ?', "%#{final_message}%")
+                @handle.create_notification(:type => :automate_service_provisioned, :subject => task.destination) if task.miq_request_task.nil? && notified.count < 1
               when 'miq_provision'
                 if task.get_option(:request_type) == :clone_to_template
                   final_message += "Template [#{task.get_option(:vm_target_name)}] Published Successfully"


### PR DESCRIPTION
Getting Multiple Notifications in my Services Catalog.
1. Multiple notifications after the service provision
<img width="741" alt="Screenshot 2022-10-19 at 12 36 05 AM" src="https://user-images.githubusercontent.com/16753936/197173210-63285121-9f06-4989-86ea-6d1128f7618c.png">
2. Two error messages are showing when an error happens between the provision.
<img width="741" alt="Screenshot 2022-10-19 at 12 36 05 AM" src="https://user-images.githubusercontent.com/16753936/197173399-1922bf99-4c59-42d2-bfd9-6c698abf740d.png">

Fix
-----
Added a duplication check before creating notifications.
