### PR TITLE
Fix Parameters missing `.$` in email.asl

### DIFF
--- a/content/workflows/email.asl
+++ b/content/workflows/email.asl
@@ -6,13 +6,13 @@
       "Type": "Task",
       "Resource": "builtin://email",
       "Parameters": {
-        "To": "$.to",
-        "From": "$.from",
-        "Subject": "$.subject",
-        "Cc": "$.cc",
-        "Bcc": "$.bcc",
-        "Body": "$.body",
-        "Attachment": "$.attachment"
+        "To.$": "$.to",
+        "From.$": "$.from",
+        "Subject.$": "$.subject",
+        "Cc.$": "$.cc",
+        "Bcc.$": "$.bcc",
+        "Body.$": "$.body",
+        "Attachment.$": "$.attachment"
       },
       "End": true
     }


### PR DESCRIPTION
I always forget that the parameters need a trailing `.$` otherwise they won't be interpolated.  Was trying to figure out why it was trying to email "$.to" :laughing: 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
