### PR TITLE
Reorganize out of the box workflows

### DIFF
--- a/content/workflows/email.asl
+++ b/content/workflows/email.asl
@@ -1,10 +1,10 @@
 {
-  "Comment": "Send an email.",
+  "Comment": "Send an email",
   "StartAt": "SendEmail",
   "States": {
     "SendEmail": {
       "Type": "Task",
-      "Resource": "builtin://email",
+      "Resource": "manageiq://email",
       "Parameters": {
         "To.$": "$.to",
         "From.$": "$.from",

--- a/content/workflows/provision.asl
+++ b/content/workflows/provision.asl
@@ -1,5 +1,5 @@
 {
-  "Comment": "Basic VM Provisioning",
+  "Comment": "Basic Provisioning",
   "StartAt": "PreProvision",
   "States": {
     "PreProvision": {
@@ -8,7 +8,7 @@
     },
     "Provision": {
       "Type": "Task",
-      "Resource": "builtin://provision_execute",
+      "Resource": "manageiq://provision_execute",
       "Next": "PostProvision"
     },
     "PostProvision": {


### PR DESCRIPTION
- move provision-vm-builtin/provision-vm-builtin.asl to just provision.asl since we don't need the redundant nesting and this can be used for more than vm provisioning.
- Rename 'builtin' scheme to 'manageiq'

Co-dependent on 
- [ ] https://github.com/ManageIQ/manageiq-providers-workflows/pull/96


@agrare Please review cc @kbrock