### PR TITLE
Fix rails 7 deprecation/7.1 removal by using Integer#to_fs(:human_size)

### DIFF
--- a/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.rb
+++ b/content/automate/ManageIQ/Cloud/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/validate_request.rb
@@ -145,9 +145,9 @@ unless max_memory.blank?
   desired_mem = requested_memory(prov_resource, desired_nvms)
   if desired_mem && (desired_mem.to_i > max_memory.to_i)
     $evm.log("info", "Auto-Approval Threshold(Warning): Number of vRAM requested: \
-    <#{desired_mem.to_s(:human_size)}> exceeds:<#{max_memory}>")
+    <#{desired_mem.to_fs(:human_size)}> exceeds:<#{max_memory}>")
     approval_req = true
-    reason2 = "Requested Memory #{desired_mem.to_s(:human_size)} limit is #{max_memory}"
+    reason2 = "Requested Memory #{desired_mem.to_fs(:human_size)} limit is #{max_memory}"
   end
 end
 

--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -167,7 +167,7 @@ def requested_storage(args_hash)
         $evm.log(:info, "Reconfigure Disk Removal: #{disk.inspect}")
         disk = HashWithIndifferentAccess.new(disk)
         current_size = get_disk_size(disk[:disk_name])
-        $evm.log(:info, "Reconfigure Disk Removal Disk: <#{disk[:disk_name]}> Disk Size: <#{current_size.to_s(:human_size)}>")
+        $evm.log(:info, "Reconfigure Disk Removal Disk: <#{disk[:disk_name]}> Disk Size: <#{current_size.to_fs(:human_size)}>")
         args_hash[:prov_value] -= current_size
       end
     end
@@ -175,7 +175,7 @@ def requested_storage(args_hash)
       # Disk_resize only supports increasing the size.
       $evm.log(:info, "Reconfigure Disk Resize:  #{disk.inspect}")
       current_size = get_disk_size(disk['disk_name'])
-      $evm.log(:info, "Current disk size: #{current_size.to_s(:human_size)}")
+      $evm.log(:info, "Current disk size: #{current_size.to_fs(:human_size)}")
       args_hash[:prov_value] += disk['disk_size_in_mb'].to_i.megabytes - current_size
     end
   else
@@ -184,7 +184,7 @@ def requested_storage(args_hash)
   end
 
   if @reconfigure_request
-    $evm.log(:info, "VM Reconfigure storage change: #{args_hash[:prov_value].to_s(:human_size)}")
+    $evm.log(:info, "VM Reconfigure storage change: #{args_hash[:prov_value].to_fs(:human_size)}")
     @check_quota = true if args_hash[:prov_value].to_i > 0
   end
   request_hash_value(args_hash)

--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb
@@ -22,14 +22,14 @@ module ManageIQ
 
             def used(quota_source)
               quota_used = consumption(quota_source)
-              @handle.log("info", "Quota Used: (:cpu=>#{quota_used[:cpu]}, :memory=>#{quota_used[:memory]} (#{quota_used[:memory].to_s(:human_size)}), :vms=>#{quota_used[:vms]}, storage=>#{quota_used[:storage]} (#{quota_used[:storage].to_s(:human_size)}), provisioned_storage=>#{quota_used[:provisioned_storage]} (#{quota_used[:provisioned_storage].to_s(:human_size)}))")
+              @handle.log("info", "Quota Used: (:cpu=>#{quota_used[:cpu]}, :memory=>#{quota_used[:memory]} (#{quota_used[:memory].to_fs(:human_size)}), :vms=>#{quota_used[:vms]}, storage=>#{quota_used[:storage]} (#{quota_used[:storage].to_fs(:human_size)}), provisioned_storage=>#{quota_used[:provisioned_storage]} (#{quota_used[:provisioned_storage].to_fs(:human_size)}))")
 
               quota_source_type = root_quota_source_type
               @handle.log("info", "Quota source type: #{quota_source_type}")
 
               validate_user_email if quota_source_type == 'user'
               quota_active = active_provision_counts(quota_source_type)
-              @handle.log("info", "Quota #{active_method_name(quota_source_type)}: (:cpu=>#{quota_active[:cpu]}, :memory=>#{quota_active[:memory]} (#{quota_active[:memory].to_s(:human_size)}), :vms=>#{quota_active[:vms]}, storage=>#{quota_active[:storage]} (#{quota_active[:storage].to_s(:human_size)}))")
+              @handle.log("info", "Quota #{active_method_name(quota_source_type)}: (:cpu=>#{quota_active[:cpu]}, :memory=>#{quota_active[:memory]} (#{quota_active[:memory].to_fs(:human_size)}), :vms=>#{quota_active[:vms]}, storage=>#{quota_active[:storage]} (#{quota_active[:storage].to_fs(:human_size)}))")
 
               merge_counts(quota_used, quota_active)
             end
@@ -77,7 +77,7 @@ module ManageIQ
 
             def merge_counts(quota_used, quota_active)
               @handle.root['quota_used'] = quota_used.merge(quota_active) { |_key, val1, val2| val1 + val2 }
-              @handle.log("info", "Quota Totals: (:cpu=>#{quota_used[:cpu]}, :memory=>#{quota_used[:memory]} (#{quota_used[:memory].to_s(:human_size)}), :vms=>#{quota_used[:vms]}, storage=>#{quota_used[:storage]} (#{quota_used[:storage].to_s(:human_size)}), provisioned_storage=>#{quota_used[:provisioned_storage]} (#{quota_used[:provisioned_storage].to_s(:human_size)}))")
+              @handle.log("info", "Quota Totals: (:cpu=>#{quota_used[:cpu]}, :memory=>#{quota_used[:memory]} (#{quota_used[:memory].to_fs(:human_size)}), :vms=>#{quota_used[:vms]}, storage=>#{quota_used[:storage]} (#{quota_used[:storage].to_fs(:human_size)}), provisioned_storage=>#{quota_used[:provisioned_storage]} (#{quota_used[:provisioned_storage].to_fs(:human_size)}))")
             end
           end
         end

--- a/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/validate_quota.rb
+++ b/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/validate_quota.rb
@@ -61,7 +61,7 @@ end
 
 def display_value(item, value, _precision)
   return value unless %w(memory storage).include?(item)
-  value.to_s(:human_size)
+  value.to_fs(:human_size)
 end
 
 def reason(item, used, requested, limits)


### PR DESCRIPTION
Fixes the following error on rails 7.1:

```
TypeError:
  no implicit conversion of Symbol into Integer
Shared Example Group: "used" called from ./spec/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used_spec.rb:59
  ./content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb:25:in `to_s'
  ./content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb:25:in `used'
  ./content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used.rb:18:in `main'
  ./spec/content/automate/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/used_spec.rb:41:in `block (3 levels) in <top (required)>'
```

Fixes the following deprecation warnings that should have picked this up on rails 7: 

```
DEPRECATION WARNING: Time#to_s(:db) is deprecated. Please use Time#to_fs(:db) instead. DEPRECATION WARNING: Integer#to_s(:human_size) is deprecated. Please use Integer#to_fs(:human_size) instead.
```

A similar change was fixed in here in commit:
https://github.com/ManageIQ/manageiq/commit/21bc1a9d373926282a50bd67028a0b98cb38409d Part of this PR for Rails 7: https://github.com/ManageIQ/manageiq/pull/22873

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
