### PR TITLE
Use specific role versions

### DIFF
--- a/content/ansible/roles/requirements.yml
+++ b/content/ansible/roles/requirements.yml
@@ -1,3 +1,5 @@
 roles:
 - name: manageiq.manageiq_vmdb
+  version: v1.0.0
 - name: manageiq.manageiq_automate
+  version: v1.0.0


### PR DESCRIPTION
@jrafanie Please review

Alternatively, we can use something like:

```yaml
roles:
- name: manageiq.manageiq_vmdb
  src: https://github.com/ManageIQ/ansible-manageiq-vmdb
  version: v1.0
- name: manageiq.manageiq_automate
  src: https://github.com/ManageIQ/ansible-manageiq-automate
  version: v1.0
```

This would allow this repo to stay more flexible and not have to bump the version every time.  Thoughts?