### PR TITLE
Fix refresh_ems missing_credentials without using VCR authentication secret from another engine

### DIFF
--- a/spec/content/automate/ManageIQ/AutomationManagement/TerraformEnterprise/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned_spec.rb
+++ b/spec/content/automate/ManageIQ/AutomationManagement/TerraformEnterprise/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::Automate::AutomationManagement::TerraformEnterprise::Service:
   let(:workspace)   { FactoryBot.create(:configuration_script_terraform_enterprise, :manager => ems) }
   let(:task)        { FactoryBot.create(:service_template_provision_task, :destination => service, :miq_request => request) }
   let(:svc_task)    { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(task.id) }
-  let(:ems)         { FactoryBot.create(:ems_terraform_enterprise_with_vcr_authentication,) }
+  let(:ems)         { FactoryBot.create(:ems_terraform_enterprise).tap { |ems| ems.authentications << FactoryBot.create(:auth_token) } }
   let(:root_object) { Spec::Support::MiqAeMockObject.new('service_template_provision_task' => svc_task) }
   let(:ae_service)  { Spec::Support::MiqAeMockService.new(root_object) }
   let(:stack_class) { ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack }


### PR DESCRIPTION
Work around the 
```
Failures:

  1) ManageIQ::Automate::AutomationManagement::TerraformEnterprise::Service::Provisioning::StateMachines::Provision::CheckProvisioned check provision status terraform enterprise run is running retries the step
     Failure/Error: described_class.new(ae_service).main
     
     RuntimeError:
       no Provider credentials defined
```

error without using VcrSecrets from another engine.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
