### PR TITLE
[WIP] Fix dialog parser for multi element arrays and tags

### DIFF
--- a/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
+++ b/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/dialog_parser.rb
@@ -18,14 +18,26 @@ end
 def process_comma_separated_object_array(sequence_id, option_key, value, hash)
   return if value.nil?
   options_value_array = []
-  value.split(",").each do |entry|
-    next if entry.blank?
-    vmdb_obj = vmdb_object_from_array_entry(entry)
-    options_value_array << if vmdb_obj.nil?
+  if value.kind_of?(Array)
+    value.each do |entry|
+      next if entry.blank?
+      vmdb_obj = vmdb_object_from_array_entry(entry)
+      options_value_array << if vmdb_obj.nil?
                              entry
                            else
                              (vmdb_obj.respond_to?(:name) ? vmdb_obj.name : "#{vmdb_obj.class.name}::#{vmdb_obj.id}")
                            end
+    end
+  else
+    value.split(",").each do |entry|
+      next if entry.blank?
+      vmdb_obj = vmdb_object_from_array_entry(entry)
+      options_value_array << if vmdb_obj.nil?
+                              'THIS IS A TEST 1'
+                            else
+                              'THIS IS A TEST 2'
+                            end
+    end
   end
   hash[sequence_id][option_key] = options_value_array
 end
@@ -70,13 +82,19 @@ def option_array_value(dialog_key, dialog_value, options_hash)
 end
 
 def tag_hash_value(dialog_key, dialog_value, tags_hash)
-  return false unless /^dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+  $evm.log('TESTING', dialog_key)
+  $evm.log('TESTING', dialog_value)
+  $evm.log('TESTING', tags_hash)
+  return false unless /^dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key || (/^dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key && dialog_value.kind_of?(Array))
   add_hash_value(sequence.to_i, option_key.to_sym, dialog_value, tags_hash)
   true
 end
 
 def tag_array_value(dialog_key, dialog_value, tags_hash)
-  return false unless /^array::dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
+  $evm.log('TESTING', dialog_key)
+  $evm.log('TESTING', dialog_value)
+  $evm.log('TESTING', tags_hash)
+  return false unless /^array::dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key ||  /^dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i =~ dialog_key
   process_comma_separated_object_array(sequence.to_i, option_key.to_sym, dialog_value, tags_hash)
   true
 end

--- a/spec/automation/unit/method_validation/dialog_parser_spec.rb
+++ b/spec/automation/unit/method_validation/dialog_parser_spec.rb
@@ -18,7 +18,7 @@ describe "DialogParser Automate Method" do
 
   def create_tags
     FactoryBot.create(:classification_department_with_tags)
-    @array_name = "Array::dialog_tag_0_department"
+    @array_name = "dialog_tag_0_department"
     @dept_ids = Classification.find_by_description('Department').children.collect do |x|
       "Classification::#{x.id}"
     end.join(',')
@@ -59,8 +59,10 @@ describe "DialogParser Automate Method" do
       create_vms
       dialog_hash = {'dialog_option_1_numero' => 'one', 'dialog_option_2_numero' => 'two',
                      'dialog_option_3_numero' => 'three', 'dialog_option_0_numero' => 'zero',
-                     'dialog_tag_0_location' => 'NYC', 'dialog_tag_1_location' => 'BOM',
-                     'dialog_tag_2_location' => 'EWR', @array_name => @dept_ids,
+                     'dialog_tag_0_location' => ['Classification::47000000000058'],
+                     'dialog_tag_1_location' => ['Classification::47000000000059'],
+                     'dialog_tag_2_location' => ['Classification::47000000000060'],
+                     @array_name => @dept_ids,
                      array_key               => array_value.join(","),
                      @vm_array_name          => @vm_id_array.join(",")}
 
@@ -71,9 +73,10 @@ describe "DialogParser Automate Method" do
                                           :dialog_str_array => array_value,
                                           :dialog_vm_array  => @vm_name_array,
                                           :vm_array         => @vm_name_array}}
-      parsed_dialog_tags_hash = {0 => {:location => "NYC"},
-                                 1 => {:location => "BOM"},
-                                 2 => {:location => "EWR"}}
+      parsed_dialog_tags_hash = {0 => {:location => "Accounting"},
+                                 1 => {:location => "Financial Services"},
+                                 2 => {:location => "Human Resources"}}
+
 
       setup_and_run_method(dialog_hash)
       pdo = load_options


### PR DESCRIPTION
Currently we use strings and the string separator `\u001F` which we eventually want to replace with arrays. The following PR explains the work needed to achieve this.

The 3 initial PRs were reverted because they worked for dropdowns, correctly returning arrays, but they broke the tag fields. Since the 3 initial PRs were all reverted, we need to first take the changes from those 3 PRs, then build the new pr changes on top of them to ensure dropdowns and tags work. Then, this PR should fix the remaining issues with this feature. Need these 3 prs:

1) Changes from https://github.com/ManageIQ/manageiq-ui-classic/pull/9220 and https://github.com/ManageIQ/manageiq-ui-classic/pull/9250

NOTE: UI-Classic has been updated with this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/9250. Once this is merged, the page will support dropdowns and tags (both single-select and multi-select). However, if the automation engine is ever updated to return arrays instead of strings separated by "\u001F", we need to update the UI-Classic code to handle the new array values.

2) Changes from https://github.com/ManageIQ/manageiq/pull/23078 and https://github.com/ManageIQ/manageiq/pull/23155
3) Changes from https://github.com/ManageIQ/manageiq-automation_engine/pull/545 and https://github.com/ManageIQ/manageiq-automation_engine/pull/555
4) In UI-Classic we should also add Cypress tests to validate that the new arrays are working correctly. We would need to validate this with a dialog that contains single select and multi select drop-downs with both string and integer ids as well as single select and multi select tag components with both string and integer ids.