### PR TITLE
Bump savon to 2.17.2 for CVE-2026-53510

### DIFF
--- a/manageiq-content.gemspec
+++ b/manageiq-content.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "savon", "~>2.11.1" # Because users expect it to be there for custom code
+  spec.add_runtime_dependency "savon", "~>2.17", ">=2.17.2" # Because users expect it to be there for custom code
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
@jrafanie @agrare Please review.

Unfortunately, we have to do a large minor jump for this, however, I think it's ok ([savon releases](https://github.com/savonrb/savon/releases)). That being said some of the transitive deps took huge major jumps, including wasabi, so I'm cross-repo-testing to ensure those bumps don't break anything.

@miq-bot cross-repo-test /all

