### PR TITLE
Replace Automation Manager strings with Automation Provider

### DIFF
--- a/content/automate/ManageIQ/AutomationManagement/AutomationManager/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.rb
+++ b/content/automate/ManageIQ/AutomationManagement/AutomationManager/Provisioning/StateMachines/Provision.class/__methods__/update_provision_status.rb
@@ -37,7 +37,7 @@ module ManageIQ
                   @handle.create_notification(
                     :level   => "error",
                     :subject => task.miq_request,
-                    :message => "Automation Manager Provision Error: #{msg}"
+                    :message => "Automation Provider Provision Error: #{msg}"
                   )
                 end
 

--- a/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/automation_manager_provision_finished.yaml
+++ b/content/automate/ManageIQ/System/CommonMethods/StateMachineMethods.class/automation_manager_provision_finished.yaml
@@ -9,5 +9,5 @@ object:
     description:
   fields:
   - execute:
-      value: task_finished(object => 'miq_provision', message => 'Automation Manager
+      value: task_finished(object => 'miq_provision', message => 'Automation Provider
         Provisioning Finished Successfully' )


### PR DESCRIPTION
Replace Automation Manager strings with Automation Provider

Relevant PRs:
- https://github.com/ManageIQ/manageiq/pull/23915
- https://github.com/ManageIQ/manageiq-documentation/pull/1905
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10162
- https://github.com/ManageIQ/manageiq-ui-service/pull/2110
- https://github.com/ManageIQ/manageiq-providers-awx/pull/65
- https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/344
- https://github.com/ManageIQ/manageiq-api-client/pull/165